### PR TITLE
AccountDetailView: support display name with emoji in navbar title

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -92,7 +92,14 @@ public struct AccountDetailView: View {
       }
     }
     .edgesIgnoringSafeArea(.top)
-    .navigationTitle(Text(scrollOffset < -200 ? viewModel.title : ""))
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+        ToolbarItem(placement: .principal) {
+            if scrollOffset < -200 {
+                currentAccount.account?.displayNameWithEmojis
+            }
+        }
+    }
   }
   
   @ViewBuilder

--- a/Packages/Account/Sources/Account/AccountDetailViewModel.swift
+++ b/Packages/Account/Sources/Account/AccountDetailViewModel.swift
@@ -46,7 +46,6 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
   }
   @Published var statusesState: StatusesState = .loading
   
-  @Published var title: String = ""
   @Published var relationship: Relationshionship?
   @Published var favourites: [Status] = []
   private var favouritesNextPage: LinkHandler?
@@ -89,7 +88,6 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
       self.featuredTags = try await featuredTags
       self.featuredTags.sort { $0.statusesCountInt > $1.statusesCountInt }
       self.fields = loadedAccount.fields
-      self.title = loadedAccount.displayName
       if isCurrentUser {
         self.followedTags = try await followedTags
       } else {


### PR DESCRIPTION
I kept the same offset before displaying the name.

I removed the `title` property from `AccountDetailViewModel` because it's not used anymore. Since the `displayNameWithEmojis` method returns a view, I'm not sure if we should still go through the ViewModel somehow or if using `currentAccount.account?.displayNameWithEmojis` is OK?

| Before | After |
| ------ | ----- |
| ![SCR-20221230-v7n](https://user-images.githubusercontent.com/11699655/210113039-7a5a7bc1-9967-497c-bb7e-772138c01e78.png)  | ![SCR-20221230-v6f](https://user-images.githubusercontent.com/11699655/210113056-8429b9d8-df0a-42bf-91c4-f282cbd19d1a.png)|