### PR TITLE
AppAccountView: support emoji in account name + slight design change

### DIFF
--- a/IceCubesApp/App/AppAccounts/AppAccountView.swift
+++ b/IceCubesApp/App/AppAccounts/AppAccountView.swift
@@ -18,12 +18,10 @@ struct AppAccountView: View {
         }
       }
       VStack(alignment: .leading) {
-        Text(viewModel.appAccount.server)
-          .font(.headline)
         if let account = viewModel.account {
-          Text(account.displayName)
-          Text(account.username)
-            .font(.footnote)
+          account.displayNameWithEmojis
+          Text("\(account.username)@\(viewModel.appAccount.server)")
+            .font(.subheadline)
             .foregroundColor(.gray)
         }
       }


### PR DESCRIPTION
Since `account.displayNameWithEmojis` took more height on the line, it looked funky, so I simplified the 3 lines into 2, by showing the full account address.

| Before | After |
| ------ | ----- |
| ![SCR-20221230-v9h](https://user-images.githubusercontent.com/11699655/210113381-372744e1-b03f-463b-9253-d7e2fdeae87c.png)  | ![](https://user-images.githubusercontent.com/11699655/210113375-07549b5e-ffc1-466e-8ffe-026869742972.png) |