### PR TITLE
Make instance suggestion tap targets full-width

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/AddAccountsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AddAccountsView.swift
@@ -89,20 +89,22 @@ struct AddAccountView: View {
           .listRowBackground(theme.primaryBackgroundColor)
       } else {
         ForEach(instanceName.isEmpty ? instances : instances.filter{ $0.name.contains(instanceName.lowercased()) }) { instance in
-          VStack(alignment: .leading, spacing: 4) {
-            Text(instance.name)
-              .font(.headline)
-            Text(instance.info?.shortDescription ?? "")
-              .font(.body)
-              .foregroundColor(.gray)
-            Text("\(instance.users) users  ⸱  \(instance.statuses) posts")
-              .font(.footnote)
-              .foregroundColor(.gray)
+          Button {
+            self.instanceName = instance.name
+          } label: {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(instance.name)
+                .font(.headline)
+                .foregroundColor(.primary)
+              Text(instance.info?.shortDescription ?? "")
+                .font(.body)
+                .foregroundColor(.gray)
+              Text("\(instance.users) users  ⸱  \(instance.statuses) posts")
+                .font(.footnote)
+                .foregroundColor(.gray)
+            }
           }
           .listRowBackground(theme.primaryBackgroundColor)
-          .onTapGesture {
-            self.instanceName = instance.name
-          }
         }
       }
     }


### PR DESCRIPTION
Currently, because of the behavior of `.onTapGesture { ... }`, you must tap within the frame of the instance suggestion label in order to make a selection. This simple change allows you to tap anywhere within the cell to achieve the same result.

### Implementation Details
This was a simple fix, I just made the following broadstrokes change...
```
// Before
ForEach(...) { instance in
    label
    .onTapGesture { action }
}

// After
ForEach(...) { instance in
    Button {
        action
    } label: {
        label
    }
}
```

### Before
https://user-images.githubusercontent.com/5414589/210125205-7ee6b49f-64a4-4045-a890-8fd9b20c19fc.mov

### After
https://user-images.githubusercontent.com/5414589/210125044-07537370-e232-4347-adb9-7b62f6d4076c.mov