### PR TITLE
Add option to re-hide spoiler content after expanding

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -114,6 +114,16 @@ public struct StatusRowView: View {
         Text(status.spoilerText)
           .font(.body)
       }
+      if viewModel.displaySpoiler == false && !viewModel.status.spoilerText.isEmpty {
+        Button {
+          withAnimation {
+            viewModel.displaySpoiler = true
+          }
+        } label: {
+          Text("Show less")
+        }
+          .buttonStyle(.bordered)
+      }
       if viewModel.displaySpoiler {
         Button {
           withAnimation {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -113,27 +113,16 @@ public struct StatusRowView: View {
       if !viewModel.status.spoilerText.isEmpty {
         Text(status.spoilerText)
           .font(.body)
-      }
-      if viewModel.displaySpoiler == false && !viewModel.status.spoilerText.isEmpty {
         Button {
           withAnimation {
-            viewModel.displaySpoiler = true
+            viewModel.displaySpoiler.toggle()
           }
         } label: {
-          Text("Show less")
-        }
-          .buttonStyle(.bordered)
-      }
-      if viewModel.displaySpoiler {
-        Button {
-          withAnimation {
-            viewModel.displaySpoiler = false
-          }
-        } label: {
-          Text("Show more")
+            Text(viewModel.displaySpoiler ? "Show more" : "Show less")
         }
         .buttonStyle(.bordered)
-      } else {
+      }
+      if !viewModel.displaySpoiler {
         Text(status.content.asSafeAttributedString)
           .font(.body)
           .environment(\.openURL, OpenURLAction { url in


### PR DESCRIPTION
Uses the same logic as the "Show more" button, but in reverse. This allows a user to hide the content that they expanded.

I am not sure if there is a better way to implement the conditional logic, but that was the simplest method I could come up with!