### PR TITLE
Allow tapping avatar to go details page

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -22,7 +22,11 @@ public struct StatusRowView: View {
       if !viewModel.isCompact,
          theme.avatarPosition == .leading,
          let status: AnyStatus = viewModel.status.reblog ?? viewModel.status {
+        Button {
+          routeurPath.navigate(to: .accountDetailWithAccount(account: status.account))
+        } label: {
           AvatarView(url: status.account.avatar, size: .status)
+        }
       }
       VStack(alignment: .leading) {
         if !viewModel.isCompact {


### PR DESCRIPTION
When the avatar position is set to `leading`, we lose the ability to go to a user's details when tapping the avatar. This PR brings this functionality back.