### PR TITLE
Fix list visibility in light theme

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -262,7 +262,7 @@ public struct AccountDetailView: View {
           .padding(.vertical, 8)
           .padding(.horizontal, DS.Constants.layoutPadding)
           .font(.headline)
-          .foregroundColor(.white)
+          .foregroundColor(theme.labelColor)
         }
         .contextMenu {
           Button("Delete list", role: .destructive) {


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width="542" alt="IceCubes-Before-AccountView-Lists" src="https://user-images.githubusercontent.com/169561/210285189-3c504181-0700-4554-a3dc-b02fbb7eb24e.png"> | <img width="542" alt="IceCubes-After-AccountView-Lists" src="https://user-images.githubusercontent.com/169561/210285193-1f129a48-82f6-493e-bd64-f0b35b5fb63f.png"> |

Theme being used:
<img width="406" alt="CleanShot 2023-01-02 at 17 41 05@2x" src="https://user-images.githubusercontent.com/169561/210285208-d3bd6511-2b74-421f-982a-6961a468ee33.png">
