### PR TITLE
Less typing padding constants

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -124,7 +124,7 @@ struct AccountDetailHeaderView: View {
           routeurPath.handle(url: url)
         })
     }
-    .padding(.horizontal, DS.Constants.layoutPadding)
+    .padding(.horizontal, .layoutPadding)
     .offset(y: -40)
   }
   

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -50,7 +50,7 @@ public struct AccountDetailView: View {
               }
             }
             .pickerStyle(.segmented)
-            .padding(.horizontal, DS.Constants.layoutPadding)
+            .padding(.horizontal, .layoutPadding)
             .offset(y: -20)
           }
           .id("status")
@@ -180,7 +180,7 @@ public struct AccountDetailView: View {
             }
           }
         }
-        .padding(.leading, DS.Constants.layoutPadding)
+        .padding(.leading, .layoutPadding)
       }
     }
   }
@@ -191,7 +191,7 @@ public struct AccountDetailView: View {
       VStack(alignment: .leading, spacing: 2) {
         Text("Also followed by")
           .font(.headline)
-          .padding(.leading, DS.Constants.layoutPadding)
+          .padding(.leading, .layoutPadding)
         ScrollView(.horizontal, showsIndicators: false) {
           LazyHStack(spacing: 0) {
             ForEach(viewModel.familliarFollowers) { account in
@@ -202,7 +202,7 @@ public struct AccountDetailView: View {
                 .padding(.leading, -4)
             }
           }
-          .padding(.leading, DS.Constants.layoutPadding + 4)
+          .padding(.leading, .layoutPadding + 4)
         }
       }
       .padding(.top, 2)
@@ -244,7 +244,7 @@ public struct AccountDetailView: View {
           Spacer()
           Image(systemName: "chevron.right")
         }
-        .padding(.horizontal, DS.Constants.layoutPadding)
+        .padding(.horizontal, .layoutPadding)
         .padding(.vertical, 8)
       }
     }
@@ -260,7 +260,7 @@ public struct AccountDetailView: View {
             Image(systemName: "chevron.right")
           }
           .padding(.vertical, 8)
-          .padding(.horizontal, DS.Constants.layoutPadding)
+          .padding(.horizontal, .layoutPadding)
           .font(.headline)
           .foregroundColor(.white)
         }
@@ -275,7 +275,7 @@ public struct AccountDetailView: View {
       Button("Create a new list") {
         isCreateListAlertPresented = true
       }
-      .padding(.horizontal, DS.Constants.layoutPadding)
+      .padding(.horizontal, .layoutPadding)
     }
     .alert("Create a new list", isPresented: $isCreateListAlertPresented) {
       TextField("List name", text: $createListTitle)

--- a/Packages/DesignSystem/Sources/DesignSystem/DesignSystem.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/DesignSystem.swift
@@ -1,9 +1,7 @@
 import Foundation
 
-public struct DS {
-  public enum Constants {
-    public static let layoutPadding: CGFloat = 20
-    public static let dividerPadding: CGFloat = 4
-    public static let statusColumnsSpacing: CGFloat = 8
-  }
+extension CGFloat {
+  public static let layoutPadding: CGFloat = 20
+  public static let dividerPadding: CGFloat = 4
+  public static let statusColumnsSpacing: CGFloat = 8
 }

--- a/Packages/Notifications/Sources/Notifications/NotificationsListView.swift
+++ b/Packages/Notifications/Sources/Notifications/NotificationsListView.swift
@@ -32,8 +32,8 @@ public struct NotificationsListView: View {
             .font(.title3)
         }
       }
-      .padding(.horizontal, DS.Constants.layoutPadding)
-      .padding(.top, DS.Constants.layoutPadding)
+      .padding(.horizontal, .layoutPadding)
+      .padding(.top, .layoutPadding)
     }
     .background(theme.primaryBackgroundColor)
     .task {
@@ -61,14 +61,14 @@ public struct NotificationsListView: View {
           .redacted(reason: .placeholder)
           .shimmering()
         Divider()
-          .padding(.vertical, DS.Constants.dividerPadding)
+          .padding(.vertical, .dividerPadding)
       }
       
     case let .display(notifications, nextPageState):
       ForEach(notifications) { notification in
         NotificationRowView(notification: notification)
         Divider()
-          .padding(.vertical, DS.Constants.dividerPadding)
+          .padding(.vertical, .dividerPadding)
       }
       
       switch nextPageState {

--- a/Packages/Status/Sources/Status/Detail/StatusDetailVIew.swift
+++ b/Packages/Status/Sources/Status/Detail/StatusDetailVIew.swift
@@ -34,7 +34,7 @@ public struct StatusDetailView: View {
               ForEach(context.ancestors) { ancestor in
                 StatusRowView(viewModel: .init(status: ancestor, isCompact: false))
                 Divider()
-                  .padding(.vertical, DS.Constants.dividerPadding)
+                  .padding(.vertical, .dividerPadding)
               }
             }
             StatusRowView(viewModel: .init(status: status,
@@ -42,12 +42,12 @@ public struct StatusDetailView: View {
                                            isFocused: true))
               .id(status.id)
             Divider()
-              .padding(.bottom, DS.Constants.dividerPadding * 2)
+              .padding(.bottom, .dividerPadding * 2)
             if !context.descendants.isEmpty {
               ForEach(context.descendants) { descendant in
                 StatusRowView(viewModel: .init(status: descendant, isCompact: false))
                 Divider()
-                  .padding(.vertical, DS.Constants.dividerPadding)
+                  .padding(.vertical, .dividerPadding)
               }
             }
             
@@ -55,8 +55,8 @@ public struct StatusDetailView: View {
             Text(error.localizedDescription)
           }
         }
-        .padding(.horizontal, DS.Constants.layoutPadding)
-        .padding(.top, DS.Constants.layoutPadding)
+        .padding(.horizontal, .layoutPadding)
+        .padding(.top, .layoutPadding)
       }
       .scrollContentBackground(.hidden)
       .background(theme.primaryBackgroundColor)

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -47,7 +47,7 @@ struct StatusEditorAccessoryView: View {
         characterCountView
       }
       .frame(height: 20)
-      .padding(.horizontal, DS.Constants.layoutPadding)
+      .padding(.horizontal, .layoutPadding)
       .padding(.vertical, 12)
       .background(.ultraThinMaterial)
     }

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAutoCompleteView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAutoCompleteView.swift
@@ -16,7 +16,7 @@ struct StatusEditorAutoCompleteView: View {
             suggestionsTagView
           }
         }
-        .padding(.horizontal, DS.Constants.layoutPadding)
+        .padding(.horizontal, .layoutPadding)
       }
       .frame(height: 40)
       .background(.ultraThinMaterial)

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
@@ -28,7 +28,7 @@ struct StatusEditorMediaView: View {
           }
         }
       }
-      .padding(.horizontal, DS.Constants.layoutPadding)
+      .padding(.horizontal, .layoutPadding)
     }
   }
   

--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -29,13 +29,13 @@ public struct StatusEditorView: View {
           spoilerTextView
           VStack(spacing: 12) {
             accountHeaderView
-              .padding(.horizontal, DS.Constants.layoutPadding)
+              .padding(.horizontal, .layoutPadding)
             TextView($viewModel.statusText, $viewModel.selectedRange)
               .placeholder("What's on your mind")
-              .padding(.horizontal, DS.Constants.layoutPadding)
+              .padding(.horizontal, .layoutPadding)
             if let status = viewModel.embededStatus {
               StatusEmbededView(status: status)
-                .padding(.horizontal, DS.Constants.layoutPadding)
+                .padding(.horizontal, .layoutPadding)
             }
             StatusEditorMediaView(viewModel: viewModel)
             Spacer()
@@ -95,7 +95,7 @@ public struct StatusEditorView: View {
       VStack {
         TextField("Spoiler Text", text: $viewModel.spoilerText)
           .focused($isSpoilerTextFocused)
-          .padding(.horizontal, DS.Constants.layoutPadding)
+          .padding(.horizontal, .layoutPadding)
       }
       .frame(height: 35)
       .background(theme.tintColor.opacity(0.20))

--- a/Packages/Status/Sources/Status/List/StatusesListView.swift
+++ b/Packages/Status/Sources/Status/List/StatusesListView.swift
@@ -19,7 +19,7 @@ public struct StatusesListView<Fetcher>: View where Fetcher: StatusesFetcher {
             .redacted(reason: .placeholder)
             .shimmering()
           Divider()
-            .padding(.vertical, DS.Constants.dividerPadding)
+            .padding(.vertical, .dividerPadding)
         }
       case let .error(error):
         Text(error.localizedDescription)
@@ -27,7 +27,7 @@ public struct StatusesListView<Fetcher>: View where Fetcher: StatusesFetcher {
         ForEach(statuses, id: \.viewId) { status in
           StatusRowView(viewModel: .init(status: status, isCompact: false))
           Divider()
-            .padding(.vertical, DS.Constants.dividerPadding)
+            .padding(.vertical, .dividerPadding)
         }
         
         switch nextPageState {
@@ -45,7 +45,7 @@ public struct StatusesListView<Fetcher>: View where Fetcher: StatusesFetcher {
         }
       }
     }
-    .padding(.horizontal, DS.Constants.layoutPadding)
+    .padding(.horizontal, .layoutPadding)
   }
   
   private var loadingRow: some View {

--- a/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
@@ -96,8 +96,8 @@ public struct StatusMediaPreviewView: View {
     switch attachement.supportedType {
     case .image:
       if let size = size(for: attachement) {
-        let avatarColumnWidth = theme.avatarPosition == .leading ? AvatarView.Size.status.size.width + DS.Constants.statusColumnsSpacing : 0
-        let availableWidth = UIScreen.main.bounds.width - (DS.Constants.layoutPadding * 2) - avatarColumnWidth
+        let avatarColumnWidth = theme.avatarPosition == .leading ? AvatarView.Size.status.size.width + .statusColumnsSpacing : 0
+        let availableWidth = UIScreen.main.bounds.width - (.layoutPadding * 2) - avatarColumnWidth
         let newSize = imageSize(from: size,
                                 newWidth: availableWidth)
         LazyImage(url: attachement.url) { state in

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -18,7 +18,7 @@ public struct StatusRowView: View {
   }
   
   public var body: some View {
-    HStack(alignment: .top, spacing: DS.Constants.statusColumnsSpacing) {
+    HStack(alignment: .top, spacing: .statusColumnsSpacing) {
       if !viewModel.isCompact,
          theme.avatarPosition == .leading,
          let status: AnyStatus = viewModel.status.reblog ?? viewModel.status {

--- a/Packages/Timeline/Sources/Timeline/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineView.swift
@@ -43,7 +43,7 @@ public struct TimelineView: View {
               .padding(.bottom, 16)
             StatusesListView(fetcher: viewModel)
           }
-          .padding(.top, DS.Constants.layoutPadding)
+          .padding(.top, .layoutPadding)
         }
         .background(theme.primaryBackgroundColor)
         if viewModel.pendingStatusesEnabled {
@@ -148,7 +148,7 @@ public struct TimelineView: View {
           Text(tag.following ? "Following": "Follow")
         }.buttonStyle(.bordered)
       }
-      .padding(.horizontal, DS.Constants.layoutPadding)
+      .padding(.horizontal, .layoutPadding)
       .padding(.vertical, 8)
       .background(theme.secondaryBackgroundColor)
     }


### PR DESCRIPTION
Having to type `DS.Constants` when auto-complete fails to work in Xcode is too much! 😉 So, let's help our hands out by having to type less.

In this PR, I propose to move the constants from the `enum` and put them as a part of a `CGFloat`.

**Before:**  `.padding(.horizontal, DS.Constants.layoutPadding)`
**After:** `.padding(.horizontal, .layoutPadding)`

