### PR TITLE
Made filtered key optional

### DIFF
--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -38,7 +38,7 @@ public protocol AnyStatus {
   var visibility: Visibility { get }
   var poll: Poll? { get }
   var spoilerText: String { get }
-  var filtered: [Filtered] { get }
+  var filtered: [Filtered]? { get }
 }
 
 
@@ -69,7 +69,7 @@ public struct Status: AnyStatus, Codable, Identifiable {
   public let visibility: Visibility
   public let poll: Poll?
   public let spoilerText: String
-  public let filtered: [Filtered]
+  public let filtered: [Filtered]?
   
   public static func placeholder() -> Status {
     .init(id: UUID().uuidString,
@@ -128,5 +128,5 @@ public struct ReblogStatus: AnyStatus, Codable, Identifiable {
   public let visibility: Visibility
   public let poll: Poll?
   public let spoilerText: String
-  public let filtered: [Filtered]
+  public let filtered: [Filtered]?
 }

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -19,7 +19,7 @@ public class StatusRowViewModel: ObservableObject {
   @Published var isFiltered: Bool = false
   
   var filter: Filtered? {
-    status.reblog?.filtered.first ?? status.filtered.first
+    status.reblog?.filtered?.first ?? status.filtered?.first
   }
   
   var client: Client?


### PR DESCRIPTION
When filtered key is missing from the response data. 

App can't load the timeline data. So made it optional. 