### PR TITLE
Fix crash on message tab-iPad only

### DIFF
--- a/IceCubesApp/App/Tabs/MessagesTab.swift
+++ b/IceCubesApp/App/Tabs/MessagesTab.swift
@@ -25,8 +25,8 @@ struct MessagesTab: View {
           }
         }
         .id(currentAccount.account?.id)
+        .environmentObject(routeurPath)
     }
-    .environmentObject(routeurPath)
     .onChange(of: $popToRootTab.wrappedValue) { popToRootTab in
       if popToRootTab == .messages {
         routeurPath.path = []


### PR DESCRIPTION
When running only on the iPad, switching to the Messages tab caused a crash with this error:

<img width="1017" alt="CleanShot 2023-01-06 at 09 44 17@2x" src="https://user-images.githubusercontent.com/169561/211046787-5dd6c1b3-7307-41b0-9ce2-872deaf83a22.png">

This PR fixes this. Tested on iPhone and iPad.