### PR TITLE
Fix loading local time line

### DIFF
--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -8,6 +8,15 @@ public struct Application: Codable, Identifiable {
   public let website: URL?
 }
 
+extension Application {
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+
+    name = try values.decodeIfPresent(String.self, forKey: .name) ?? ""
+    website = try? values.decodeIfPresent(URL.self, forKey: .website)
+  }
+}
+
 public enum Visibility: String, Codable, CaseIterable {
   case pub = "public"
   case unlisted


### PR DESCRIPTION
It appears that the API can return
- a valid URL
- NULL
- and **BLANK**

The last case above was causing the json decoder to throw when trying to create a valid URL.

| Before | After |
| ------ | ----- |
| <img width="271" alt="CleanShot 2023-01-06 at 12 15 39@2x" src="https://user-images.githubusercontent.com/169561/211073568-10a88317-e0df-4677-8ecb-604f33cb6ff3.png"> | <img width="271" alt="CleanShot 2023-01-06 at 12 14 19@2x" src="https://user-images.githubusercontent.com/169561/211073590-0d7eb4c4-1359-456e-a987-3652c26c325c.png"> |

