### PR TITLE
Skip unsupported notifications

### DIFF
--- a/Packages/Notifications/Sources/Notifications/NotificationsListView.swift
+++ b/Packages/Notifications/Sources/Notifications/NotificationsListView.swift
@@ -80,9 +80,11 @@ public struct NotificationsListView: View {
                   message: "Notifications? What notifications? Your notification inbox is looking so empty. Keep on being awesome! 📱😎")
       } else {
         ForEach(notifications) { notification in
-          NotificationRowView(notification: notification)
-          Divider()
-            .padding(.vertical, .dividerPadding)
+            if notification.supportedType != nil {
+                NotificationRowView(notification: notification)
+                Divider()
+                    .padding(.vertical, .dividerPadding)
+            }
         }
       }
       


### PR DESCRIPTION
As an instance admin one can receive `admin.sign_up` and `admin.report` notifications ([mastodon code](https://github.com/tootsuite/mastodon/blob/55bef1e34fc3b07ed7f762d565a161e74e128016/app/javascript/mastodon/actions/notifications.js#L135-L136)).

<img width="838" alt="image" src="https://user-images.githubusercontent.com/11699655/211074536-75d496bf-16fe-4988-871f-791a4e629efd.png">

Since IceCubesApp does  not support them, we see a bunch of dividers in the app. This MR skips them entirely.


| Before | After |
| ------ | ----- |
|  ![SCR-20230106-qtq](https://user-images.githubusercontent.com/11699655/211074769-b069ccca-af9d-4c79-af01-58631f1100de.jpeg) |![SCR-20230106-qt8](https://user-images.githubusercontent.com/11699655/211074764-c3dc1a29-e774-4ae9-a0c5-81d38c60ba20.jpeg)| 
