### PR TITLE
Design system improvements

### DIFF
--- a/IceCubesApp/App/IceCubesApp.swift
+++ b/IceCubesApp/App/IceCubesApp.swift
@@ -31,13 +31,11 @@ struct IceCubesApp: App {
   var body: some Scene {
     WindowGroup {
       appView
-      .tint(theme.tintColor)
+      .applyTheme(theme)
       .onAppear {
         setNewClientsInEnv(client: appAccountsManager.currentClient)
-        setBarsColor(color: theme.primaryBackgroundColor)
         setupRevenueCat()
       }
-      .preferredColorScheme(theme.selectedScheme == ColorScheme.dark ? .dark : .light)
       .environmentObject(appAccountsManager)
       .environmentObject(appAccountsManager.currentClient)
       .environmentObject(quickLook)
@@ -48,17 +46,14 @@ struct IceCubesApp: App {
       .environmentObject(watcher)
       .quickLookPreview($quickLook.url, in: quickLook.urls)
     }
-    .onChange(of: scenePhase, perform: { scenePhase in
+    .onChange(of: scenePhase) { scenePhase in
       handleScenePhase(scenePhase: scenePhase)
-    })
+    }
     .onChange(of: appAccountsManager.currentClient) { newClient in
       setNewClientsInEnv(client: newClient)
       if newClient.isAuth {
         watcher.watch(streams: [.user, .direct])
       }
-    }
-    .onChange(of: theme.primaryBackgroundColor) { newValue in
-      setBarsColor(color: newValue)
     }
   }
   
@@ -137,11 +132,6 @@ struct IceCubesApp: App {
     default:
       break
     }
-  }
-  
-  private func setBarsColor(color: Color) {
-    UINavigationBar.appearance().isTranslucent = true
-    UINavigationBar.appearance().barTintColor = UIColor(color)
   }
   
   private func setupRevenueCat() {

--- a/Packages/DesignSystem/Sources/DesignSystem/ThemeApplier.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/ThemeApplier.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public extension View {
+    func applyTheme(_ theme: Theme) -> some View {
+        modifier(ThemeApplier(theme: theme))
+    }
+}
+
+struct ThemeApplier: ViewModifier {
+    @ObservedObject var theme: Theme
+    
+    func body(content: Content) -> some View {
+        content
+            .tint(theme.tintColor)
+            .preferredColorScheme(theme.selectedScheme == ColorScheme.dark ? .dark : .light)
+            .onAppear {
+                setWindowTint(theme.tintColor)
+                setWindowUserInterfaceStyle(theme.selectedScheme)
+                setBarsColor(theme.primaryBackgroundColor)
+            }
+            .onChange(of: theme.tintColor) { newValue in
+                setWindowTint(newValue)
+            }
+            .onChange(of: theme.selectedScheme) { newValue in
+                setWindowUserInterfaceStyle(newValue)
+            }
+            .onChange(of: theme.primaryBackgroundColor) { newValue in
+                setBarsColor(newValue)
+            }
+    }
+    
+    private func setWindowUserInterfaceStyle(_ colorScheme: ColorScheme) {
+        allWindows()
+            .forEach {
+                switch colorScheme {
+                case .dark:
+                    $0.overrideUserInterfaceStyle = .dark
+                case .light:
+                    $0.overrideUserInterfaceStyle = .light
+                }
+            }
+    }
+    
+    private func setWindowTint(_ color: Color) {
+        allWindows()
+            .forEach {
+                $0.tintColor = UIColor(color)
+            }
+    }
+    
+    private func setBarsColor(_ color: Color) {
+        #if canImport(UIKit)
+        UINavigationBar.appearance().isTranslucent = true
+        UINavigationBar.appearance().barTintColor = UIColor(color)
+        #endif
+    }
+    
+    private func allWindows() -> [UIWindow] {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+    }
+}

--- a/Packages/DesignSystem/Sources/DesignSystem/ThemeApplier.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/ThemeApplier.swift
@@ -16,6 +16,7 @@ struct ThemeApplier: ViewModifier {
         content
             .tint(theme.tintColor)
             .preferredColorScheme(theme.selectedScheme == ColorScheme.dark ? .dark : .light)
+            #if canImport(UIKit)
             .onAppear {
                 setWindowTint(theme.tintColor)
                 setWindowUserInterfaceStyle(theme.selectedScheme)
@@ -30,8 +31,10 @@ struct ThemeApplier: ViewModifier {
             .onChange(of: theme.primaryBackgroundColor) { newValue in
                 setBarsColor(newValue)
             }
+            #endif
     }
     
+    #if canImport(UIKit)
     private func setWindowUserInterfaceStyle(_ colorScheme: ColorScheme) {
         allWindows()
             .forEach {
@@ -52,10 +55,8 @@ struct ThemeApplier: ViewModifier {
     }
     
     private func setBarsColor(_ color: Color) {
-        #if canImport(UIKit)
         UINavigationBar.appearance().isTranslucent = true
         UINavigationBar.appearance().barTintColor = UIColor(color)
-        #endif
     }
     
     private func allWindows() -> [UIWindow] {
@@ -63,4 +64,5 @@ struct ThemeApplier: ViewModifier {
             .compactMap { $0 as? UIWindowScene }
             .flatMap { $0.windows }
     }
+    #endif
 }


### PR DESCRIPTION
- Move applying `Theme` to `applyTheme` View-Extension
- Apply `Theme` to all connected `UIWindowScenes` and their windows

Currently the connected windows ignore the selected theme, which means Alerts, ShareSheets, etc. do not apply the theme and selected tint color.

Therefore this views could be in light-mode even though a dark theme was selected and vice versa.

Before

| Alert | ShareSheet |
:-:|:-:|
| ![Simulator Screen Shot - iPhone 13 - 2023-01-08 at 13 21 14](https://user-images.githubusercontent.com/6899256/211195827-7002b0bc-2aa2-437b-81cb-93c4215cdc3a.png) | ![Simulator Screen Shot - iPhone 13 - 2023-01-08 at 13 21 34](https://user-images.githubusercontent.com/6899256/211195840-15fc0fe0-86f3-4671-8400-798bc754e94e.png) |

After

| Alert | ShareSheet |
:-:|:-:|
| ![Simulator Screen Shot - iPhone 13 - 2023-01-08 at 13 24 42](https://user-images.githubusercontent.com/6899256/211195918-f1c0eda4-6e6c-4d27-a83d-b4ecf61c802c.png) | ![Simulator Screen Shot - iPhone 13 - 2023-01-08 at 13 24 57](https://user-images.githubusercontent.com/6899256/211195909-a6b87c87-8a20-4eeb-97cb-6847cdcf803e.png) |
