### PR TITLE
Add some padding when new posts button is shown

### DIFF
--- a/Packages/Timeline/Sources/Timeline/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineView.swift
@@ -48,7 +48,7 @@ public struct TimelineView: View {
               StatusesListView(fetcher: viewModel)
             }
           }
-          .padding(.top, .layoutPadding)
+          .padding(.top, .layoutPadding + (!viewModel.pendingStatuses.isEmpty ? 28 : 0))
         }
         .background(theme.primaryBackgroundColor)
         if viewModel.pendingStatusesEnabled {


### PR DESCRIPTION
Currently, the "x new posts" button hides the name of the first displayed status' user.
This PR fixes that by adding little padding at the top of the scrollview when this button is shown.