### PR TITLE
Disable post button when there's no content

### DIFF
--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -84,6 +84,7 @@ public struct StatusEditorView: View {
               Text("Post")
             }
           }
+          .disabled(!viewModel.canPost)
         }
         ToolbarItem(placement: .navigationBarLeading) {
           Button {

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -44,6 +44,9 @@ public class StatusEditorViewModel: ObservableObject {
   @Published var mediasImages: [ImageContainer] = []
   @Published var replyToStatus: Status?
   @Published var embededStatus: Status?
+  var canPost: Bool {
+    statusText.length > 0 || !selectedMedias.isEmpty
+  }
   
   @Published var visibility: Models.Visibility = .pub
   


### PR DESCRIPTION
Disables the "Post" button on the editor when the content is empty and there's no media attached