### PR TITLE
Add button to re-hide sensitive media once expanded

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
@@ -150,15 +150,7 @@ public struct StatusMediaPreviewView: View {
             }
           }
           if sensitive {
-            Button {
-              withAnimation {
-                isHidingMedia = true
-              }
-            } label: {
-              Image(systemName:"eye.slash")
-            }
-              .position(x:30, y:30)
-              .buttonStyle(.bordered)
+            cornerSensitiveButton
           }
           if let alt = attachement.description, !alt.isEmpty, !isNotifications {
             Button {
@@ -225,15 +217,7 @@ public struct StatusMediaPreviewView: View {
               .frame(width: isNotifications ? imageMaxHeight : proxy.frame(in: .local).width)
               .frame(height: imageMaxHeight)
               if sensitive {
-                Button {
-                  withAnimation {
-                    isHidingMedia = true
-                  }
-                } label: {
-                  Image(systemName:"eye.slash")
-                }
-                  .position(x:30, y:30)
-                  .buttonStyle(.bordered)
+                cornerSensitiveButton
               }
               if let alt = attachement.description, !alt.isEmpty, !isNotifications {
                 Button {
@@ -301,5 +285,17 @@ public struct StatusMediaPreviewView: View {
           .buttonStyle(.borderedProminent)
         }
       }
+  }
+  
+  private var cornerSensitiveButton: some View {
+    Button {
+      withAnimation {
+        isHidingMedia = true
+      }
+    } label: {
+      Image(systemName:"eye.slash")
+    }
+    .position(x: 30, y: 30)
+    .buttonStyle(.borderedProminent)
   }
 }

--- a/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
@@ -157,7 +157,8 @@ public struct StatusMediaPreviewView: View {
             } label: {
               Image(systemName:"eye.slash")
             }
-              .position(x:20, y:20)
+              .position(x:30, y:30)
+              .buttonStyle(.bordered)
           }
           if let alt = attachement.description, !alt.isEmpty, !isNotifications {
             Button {
@@ -231,7 +232,8 @@ public struct StatusMediaPreviewView: View {
                 } label: {
                   Image(systemName:"eye.slash")
                 }
-                  .position(x:20, y:20)
+                  .position(x:30, y:30)
+                  .buttonStyle(.bordered)
               }
               if let alt = attachement.description, !alt.isEmpty, !isNotifications {
                 Button {

--- a/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
@@ -149,6 +149,16 @@ public struct StatusMediaPreviewView: View {
                 .shimmering()
             }
           }
+          if sensitive {
+            Button {
+              withAnimation {
+                isHidingMedia = true
+              }
+            } label: {
+              Image(systemName:"eye.slash")
+            }
+              .position(x:20, y:20)
+          }
           if let alt = attachement.description, !alt.isEmpty, !isNotifications {
             Button {
               altTextDisplayed = alt
@@ -213,6 +223,16 @@ public struct StatusMediaPreviewView: View {
               }
               .frame(width: isNotifications ? imageMaxHeight : proxy.frame(in: .local).width)
               .frame(height: imageMaxHeight)
+              if sensitive {
+                Button {
+                  withAnimation {
+                    isHidingMedia = true
+                  }
+                } label: {
+                  Image(systemName:"eye.slash")
+                }
+                  .position(x:20, y:20)
+              }
               if let alt = attachement.description, !alt.isEmpty, !isNotifications {
                 Button {
                   altTextDisplayed = alt


### PR DESCRIPTION
I just added a very simple button in the top left corner to re-hide the media. I tried the default button style and on some images like this one it was pretty hard to actually see the button, so I changed the button style to `.bordered`. It should only appear if the image is marked as sensitive and the user unhides it. Here is a screenshot:

<img width="307" alt="Screenshot 2023-01-10 at 11 30 57 PM" src="https://user-images.githubusercontent.com/91493312/211718392-29a9dacc-2188-41db-b2ed-2063ed06eaef.png">
