### PR TITLE
Fix Link Handling

### DIFF
--- a/Packages/Env/Sources/Env/CurrentAccount.swift
+++ b/Packages/Env/Sources/Env/CurrentAccount.swift
@@ -22,12 +22,21 @@ public class CurrentAccount: ObservableObject {
   
   private func fetchUserData() async {
     await withTaskGroup(of: Void.self) { group in
+      group.addTask { await self.fetchConnections() }
       group.addTask { await self.fetchCurrentAccount() }
       group.addTask { await self.fetchLists() }
       group.addTask { await self.fetchFollowedTags() }
     }
   }
   
+  public func fetchConnections() async {
+    guard let client = client else { return }
+    do {
+      let connections: [String] = try await client.get(endpoint: Instances.peers)
+      client.addConnections(connections)
+    } catch { }
+  }
+    
   public func fetchCurrentAccount() async {
     guard let client = client, client.isAuth else {
       account = nil
@@ -61,7 +70,6 @@ public class CurrentAccount: ObservableObject {
       lists.append(list)
     } catch { }
   }
-  
   
   public func deleteList(list: Models.List) async {
     guard let client else { return }

--- a/Packages/Env/Sources/Env/Routeur.swift
+++ b/Packages/Env/Sources/Env/Routeur.swift
@@ -66,6 +66,8 @@ public class RouterPath: ObservableObject {
       navigate(to: .accountDetail(id: mention.id))
       return .handled
     } else if let client = client,
+              client.isAuth,
+              client.hasConnection(with: url),
               let id = Int(url.lastPathComponent) {
       if url.absoluteString.contains(client.server) {
         navigate(to: .statusDetail(id: String(id)))

--- a/Packages/Network/Sources/Network/Client.swift
+++ b/Packages/Network/Sources/Network/Client.swift
@@ -20,6 +20,7 @@ public class Client: ObservableObject, Equatable {
   
   public var server: String
   public let version: Version
+  public private(set) var connections: Set<String>
   private let urlSession: URLSession
   private let decoder = JSONDecoder()
   
@@ -38,8 +39,20 @@ public class Client: ObservableObject, Equatable {
     self.urlSession = URLSession.shared
     self.decoder.keyDecodingStrategy = .convertFromSnakeCase
     self.oauthToken = oauthToken
+    self.connections = Set([server])
   }
   
+  public func addConnections(_ connections: [String]) {
+    connections.forEach {
+      self.connections.insert($0)
+    }
+  }
+    
+  public func hasConnection(with url: URL) -> Bool {
+    guard let host = url.host(percentEncoded: false) else { return false }
+    return connections.contains(host)
+  }
+    
   private func makeURL(scheme: String = "https", endpoint: Endpoint, forceVersion: Version? = nil) -> URL {
     var components = URLComponents()
     components.scheme = scheme

--- a/Packages/Network/Sources/Network/Endpoint/Instances.swift
+++ b/Packages/Network/Sources/Network/Endpoint/Instances.swift
@@ -2,11 +2,14 @@ import Foundation
 
 public enum Instances: Endpoint {
   case instance
+  case peers
   
   public func path() -> String {
     switch self {
     case .instance:
       return "instance"
+    case .peers:
+      return "instance/peers"
     }
   }
   

--- a/Packages/Status/Sources/Status/Detail/StatusDetailVIew.swift
+++ b/Packages/Status/Sources/Status/Detail/StatusDetailVIew.swift
@@ -11,6 +11,7 @@ public struct StatusDetailView: View {
   @EnvironmentObject private var watcher: StreamWatcher
   @EnvironmentObject private var client: Client
   @EnvironmentObject private var routeurPath: RouterPath
+  @Environment(\.openURL) private var openURL
   @StateObject private var viewModel: StatusDetailViewModel
   @State private var isLoaded: Bool = false
     
@@ -81,7 +82,12 @@ public struct StatusDetailView: View {
         viewModel.client = client
         let result = await viewModel.fetch()
         if !result {
-          _ = routeurPath.path.popLast()
+          if let url = viewModel.remoteStatusURL {
+            openURL(url)
+          }
+          DispatchQueue.main.async {
+            _ = routeurPath.path.popLast()
+          }
         }
         DispatchQueue.main.async {
           proxy.scrollTo(viewModel.statusId, anchor: .center)

--- a/Packages/Status/Sources/Status/Detail/StatusDetailViewModel.swift
+++ b/Packages/Status/Sources/Status/Detail/StatusDetailViewModel.swift
@@ -51,7 +51,6 @@ class StatusDetailViewModel: ObservableObject {
       await fetchStatusDetail()
       return true
     } else {
-      await UIApplication.shared.open(remoteStatusURL)
       return false
     }
   }


### PR DESCRIPTION
Resolving links to a status results in a lot of false positives, breaking opening said links with `SFSafariViewController`

Twitter links for example where wrongly identified as Mastodon Status Links since it only checked if the URL ends with an `id`

> Example of a link that generates a false positive: https://twitter.com/Dimillian/status/1608909053836808192

Therefore we should check if the URL is a known connection on the current Mastodon Instance and only then treat the URL as a Status URL.

Not really sure where to add this but currently it is added to `Client` and fetched when the `Client` is switched and user data is fetched.

Seems more like `Instance` information but currently the `Client` is available in the `Routeur` but maybe we move it to `Instance` and make it available within `Routeur`?

