### PR TITLE
Navigate to status details when tapped on empty space

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -69,6 +69,13 @@ public struct StatusRowView: View {
       .contextMenu {
         StatusRowContextMenu(viewModel: viewModel)
       }
+      .background {
+        Color.clear
+          .contentShape(Rectangle())
+          .onTapGesture {
+            viewModel.navigateToDetail(routeurPath: routeurPath)
+          }
+      }
     }
   }
   


### PR DESCRIPTION
This PR performs navigation to status details when tapping on empty space under the avatar when its position is configured to "Leading".

**Before:**

https://user-images.githubusercontent.com/1384684/212136896-324bcf69-6d17-44ea-822b-1d24091777f2.mp4

**After:**

https://user-images.githubusercontent.com/1384684/212137069-df34aba6-374e-40d8-be59-8752373b5fb1.mp4
