### PR TITLE
Less chatty api calling

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/AddAccountsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AddAccountsView.swift
@@ -6,6 +6,7 @@ import DesignSystem
 import NukeUI
 import Shimmer
 import AppAccount
+import Combine
 
 struct AddAccountView: View {
   @Environment(\.dismiss) private var dismiss
@@ -23,6 +24,8 @@ struct AddAccountView: View {
   @State private var signInClient: Client?
   @State private var instances: [InstanceSocial] = []
   @State private var instanceFetchError: String?
+
+  private let instanceNamePublisher = PassthroughSubject<String, Never>()
   
   @FocusState private var isInstanceURLFieldFocused: Bool
   
@@ -68,6 +71,9 @@ struct AddAccountView: View {
         isSigninIn = false
       }
       .onChange(of: instanceName) { newValue in
+        instanceNamePublisher.send(newValue)
+      }
+      .onReceive(instanceNamePublisher.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)) { newValue in
         let client = Client(server: newValue)
         Task {
           do {

--- a/IceCubesApp/App/Tabs/Timeline/AddRemoteTimelineVIew.swift
+++ b/IceCubesApp/App/Tabs/Timeline/AddRemoteTimelineVIew.swift
@@ -5,6 +5,7 @@ import Env
 import DesignSystem
 import NukeUI
 import Shimmer
+import Combine
 
 struct AddRemoteTimelineView: View {
   @Environment(\.dismiss) private var dismiss
@@ -15,6 +16,8 @@ struct AddRemoteTimelineView: View {
   @State private var instanceName: String = ""
   @State private var instance: Instance?
   @State private var instances: [InstanceSocial] = []
+
+  private let instanceNamePublisher = PassthroughSubject<String, Never>()
   
   @FocusState private var isInstanceURLFieldFocused: Bool
     
@@ -55,12 +58,17 @@ struct AddRemoteTimelineView: View {
           Button("Cancel", action: { dismiss() })
         }
       }
-      .onChange(of: instanceName, perform: { newValue in
+      .onChange(of: instanceName) { newValue in
+        if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          instanceNamePublisher.send(newValue)
+        }
+      }
+      .onReceive(instanceNamePublisher.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)) { newValue in
         Task {
           let client = Client(server: newValue)
           instance = try? await client.get(endpoint: Instances.instance)
         }
-      })
+      }
       .onAppear {
         isInstanceURLFieldFocused = true
         let client = InstanceSocialClient()

--- a/IceCubesApp/App/Tabs/Timeline/AddRemoteTimelineVIew.swift
+++ b/IceCubesApp/App/Tabs/Timeline/AddRemoteTimelineVIew.swift
@@ -59,9 +59,7 @@ struct AddRemoteTimelineView: View {
         }
       }
       .onChange(of: instanceName) { newValue in
-        if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-          instanceNamePublisher.send(newValue)
-        }
+        instanceNamePublisher.send(newValue)
       }
       .onReceive(instanceNamePublisher.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)) { newValue in
         Task {

--- a/Packages/Explore/Sources/Explore/ExploreView.swift
+++ b/Packages/Explore/Sources/Explore/ExploreView.swift
@@ -26,10 +26,7 @@ public struct ExploreView: View {
         }
       } else if !viewModel.isLoaded {
         loadingView
-      } else if viewModel.trendingLinks.isEmpty &&
-                  viewModel.trendingTags.isEmpty &&
-                  viewModel.trendingStatuses.isEmpty &&
-                  viewModel.suggestedAccounts.isEmpty {
+      } else if viewModel.allSectionsEmpty {
         EmptyView(iconName: "magnifyingglass",
                   title: "Search your instance",
                   message: "From this screen you can search anything on \(client.server)")

--- a/Packages/Explore/Sources/Explore/ExploreViewModel.swift
+++ b/Packages/Explore/Sources/Explore/ExploreViewModel.swift
@@ -38,6 +38,10 @@ class ExploreViewModel: ObservableObject {
       }
     }
   }
+
+  var allSectionsEmpty: Bool {
+    trendingLinks.isEmpty && trendingTags.isEmpty && trendingStatuses.isEmpty && suggestedAccounts.isEmpty
+  }
   
   @Published var tokens: [Token] = []
   @Published var suggestedToken: [Token] = []

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -98,8 +98,12 @@ public struct StatusRowView: View {
       HStack(spacing: 2) {
         Image(systemName:"arrow.left.arrow.right.circle.fill")
         AvatarView(url: viewModel.status.account.avatar, size: .boost)
-        EmojiTextApp(viewModel.status.account.safeDisplayName.asMarkdown, emojis: viewModel.status.account.emojis)
-        Text("boosted")
+        if viewModel.status.account.username != account.account?.username {
+          EmojiTextApp(viewModel.status.account.safeDisplayName.asMarkdown, emojis: viewModel.status.account.emojis)
+          Text("boosted")
+        } else {
+          Text("You boosted")
+        }
       }
       .font(.footnote)
       .foregroundColor(.gray)


### PR DESCRIPTION
The code changes how often the API is called for adding new remote instances and server account addition.

Instead of calling the API for every keypress, the app will now wait 500ms between keystrokes to kick off an API call to `https://{instance name to search for}/api/v1/instance`.