### PR TITLE
Implement language selection for new posts

### DIFF
--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -50,6 +50,7 @@ public protocol AnyStatus {
   var spoilerText: String { get }
   var filtered: [Filtered]? { get }
   var sensitive: Bool { get }
+  var language: String? { get }
 }
 
 
@@ -83,6 +84,7 @@ public struct Status: AnyStatus, Codable, Identifiable {
   public let spoilerText: String
   public let filtered: [Filtered]?
   public let sensitive: Bool
+  public let language: String?
   
   public static func placeholder() -> Status {
     .init(id: UUID().uuidString,
@@ -109,7 +111,8 @@ public struct Status: AnyStatus, Codable, Identifiable {
           poll: nil,
           spoilerText: "",
           filtered: [],
-          sensitive: false)
+          sensitive: false,
+          language: nil)
   }
   
   public static func placeholders() -> [Status] {
@@ -146,4 +149,5 @@ public struct ReblogStatus: AnyStatus, Codable, Identifiable {
   public let spoilerText: String
   public let filtered: [Filtered]?
   public let sensitive: Bool
+  public let language: String?
 }

--- a/Packages/Network/Sources/Network/Endpoint/Statuses.swift
+++ b/Packages/Network/Sources/Network/Endpoint/Statuses.swift
@@ -80,7 +80,8 @@ public struct StatusData: Encodable {
   public let spoilerText: String?
   public let mediaIds: [String]?
   public let poll: PollData?
-  
+  public let language: String?
+
   public struct PollData: Encodable {
     public let options: [String]
     public let multiple: Bool
@@ -98,12 +99,14 @@ public struct StatusData: Encodable {
               inReplyToId: String? = nil,
               spoilerText: String? = nil,
               mediaIds: [String]? = nil,
-              poll: PollData? = nil) {
+              poll: PollData? = nil,
+              language: String? = nil) {
     self.status = status
     self.visibility = visibility
     self.inReplyToId = inReplyToId
     self.spoilerText = spoilerText
     self.mediaIds = mediaIds
     self.poll = poll
+    self.language = language
   }
 }

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -5,15 +5,16 @@ import Models
 import Env
 
 struct StatusEditorAccessoryView: View {
-  @Environment(\.dismiss) private var dismiss
-  
   @EnvironmentObject private var preferences: UserPreferences
   @EnvironmentObject private var theme: Theme
   @EnvironmentObject private var currentInstance: CurrentInstance
   
   @FocusState<Bool>.Binding var isSpoilerTextFocused: Bool
   @ObservedObject var viewModel: StatusEditorViewModel
+  
   @State private var isDrafsSheetDisplayed: Bool = false
+  @State private var isLanguageSheetDisplayed: Bool = false
+  @State private var languageSearch: String = ""
   
   var body: some View {
     VStack(spacing: 0) {
@@ -25,18 +26,6 @@ struct StatusEditorAccessoryView: View {
         }
         .disabled(viewModel.showPoll)
         
-        Button {
-          viewModel.insertStatusText(text: " @")
-        } label: {
-          Image(systemName: "at")
-        }
-        
-        Button {
-          viewModel.insertStatusText(text: " #")
-        } label: {
-          Image(systemName: "number")
-        }
-
         Button {
           withAnimation {
             viewModel.showPoll.toggle()
@@ -63,13 +52,8 @@ struct StatusEditorAccessoryView: View {
           }
         }
 
-        Menu {
-          Picker("status.editor.language-selection", selection: $viewModel.selectedLanguage) {
-            ForEach(self.availableLanguages, id: \.0) { (isoCode, nativeName, name) in
-              languageTextView(isoCode: isoCode, nativeName: nativeName, name: name)
-                .tag(Optional(isoCode))
-            }
-          }
+        Button {
+          isLanguageSheetDisplayed.toggle()
         } label: {
           if let language = viewModel.selectedLanguage {
             Text(language.uppercased())
@@ -77,8 +61,7 @@ struct StatusEditorAccessoryView: View {
             Image(systemName: "globe")
           }
         }
-        .menuOrder(.fixed)
-    
+        
         Spacer()
         
         characterCountView
@@ -91,6 +74,9 @@ struct StatusEditorAccessoryView: View {
     .sheet(isPresented: $isDrafsSheetDisplayed) {
       draftsSheetView
     }
+    .sheet(isPresented: $isLanguageSheetDisplayed, content: {
+      languageSheetView
+    })
     .onAppear {
       viewModel.setInitialLanguageSelection(preference: preferences.serverPreferences?.postLanguage)
     }
@@ -102,6 +88,39 @@ struct StatusEditorAccessoryView: View {
       Text("\(nativeName) (\(name))")
     } else {
       Text(isoCode.uppercased())
+    }
+  }
+  
+  private var languageSheetView: some View {
+    NavigationStack {
+      List {
+        ForEach(availableLanguages, id: \.0) { (isoCode, nativeName, name) in
+          HStack {
+            languageTextView(isoCode: isoCode, nativeName: nativeName, name: name)
+              .tag(isoCode)
+            Spacer()
+            if isoCode == viewModel.selectedLanguage {
+              Image(systemName: "checkmark")
+            }
+          }
+          .listRowBackground(theme.primaryBackgroundColor)
+          .contentShape(Rectangle())
+          .onTapGesture {
+            viewModel.selectedLanguage = isoCode
+            isLanguageSheetDisplayed = false
+          }
+        }
+      }
+      .searchable(text: $languageSearch)
+      .toolbar {
+        ToolbarItem(placement: .navigationBarLeading) {
+          Button("Cancel", action: { isLanguageSheetDisplayed = false })
+        }
+      }
+      .navigationTitle("Select Languages")
+      .navigationBarTitleDisplayMode(.inline)
+      .scrollContentBackground(.hidden)
+      .background(theme.secondaryBackgroundColor)
     }
   }
   
@@ -125,7 +144,7 @@ struct StatusEditorAccessoryView: View {
       }
       .toolbar {
         ToolbarItem(placement: .navigationBarLeading) {
-          Button("Cancel", action: { dismiss() })
+          Button("Cancel", action: { isDrafsSheetDisplayed = false })
         }
       }
       .scrollContentBackground(.hidden)
@@ -153,6 +172,12 @@ struct StatusEditorAccessoryView: View {
           nativeLocale.localizedString(forLanguageCode: lang.identifier),
           Locale.current.localizedString(forLanguageCode: lang.identifier)
         )
+      }
+      .filter { (identifier, nativeLocale, locale) in
+        guard !languageSearch.isEmpty else {
+          return true
+        }
+        return nativeLocale?.lowercased().hasPrefix(languageSearch.lowercased()) == true
       }
   }
 }

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -97,7 +97,14 @@ public class StatusEditorViewModel: ObservableObject {
   }
   
   func setInitialLanguageSelection(preference: String?) {
-    selectedLanguage = preference ?? currentAccount?.source?.language
+    switch mode {
+    case .replyTo(let status), .edit(let status):
+      selectedLanguage = status.language
+    default:
+      break
+    }
+    
+    selectedLanguage = selectedLanguage ?? preference ?? currentAccount?.source?.language
   }
 
   private func getPollOptionsForAPI() -> [String]? {

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -63,6 +63,7 @@ public class StatusEditorViewModel: ObservableObject {
   
   @Published var mentionsSuggestions: [Account] = []
   @Published var tagsSuggestions: [Tag] = []
+  @Published var selectedLanguage: String?
   private var currentSuggestionRange: NSRange?
   
   private var embededStatusURL: URL? {
@@ -94,6 +95,10 @@ public class StatusEditorViewModel: ObservableObject {
     statusText = .init(string: text)
     selectedRange = .init(location: text.utf16.count, length: 0)
   }
+  
+  func setInitialLanguageSelection(preference: String?) {
+    selectedLanguage = preference ?? currentAccount?.source?.language
+  }
 
   private func getPollOptionsForAPI() -> [String]? {
     let options = pollOptions.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
@@ -116,7 +121,8 @@ public class StatusEditorViewModel: ObservableObject {
                             inReplyToId: mode.replyToStatus?.id,
                             spoilerText: spoilerOn ? spoilerText : nil,
                             mediaIds: mediasImages.compactMap{ $0.mediaAttachement?.id },
-                            poll: pollData)
+                            poll: pollData,
+                            language: selectedLanguage)
       switch mode {
       case .new, .replyTo, .quote, .mention, .shareExtension:
         postStatus = try await client.post(endpoint: Statuses.postStatus(json: data))


### PR DESCRIPTION
This PR adds the ability to select a new post's language. It takes into account the preference set by the user (sent by the server). Replies take the language of the parent post by default.

Preview (the simulator is set to English as first and German as second language):
![image](https://user-images.githubusercontent.com/38211057/212774337-4a66e934-5aa5-4efd-92b6-f49d68bfb61b.png)

Closes #76 