### PR TITLE
Fix spelling of "GitHub"

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -123,7 +123,7 @@ struct SettingsTabs: View {
       }
       
       Link(destination: URL(string: "https://github.com/Dimillian/IceCubesApp")!) {
-        Label("Source (Github link)", systemImage: "link")
+        Label("Source (GitHub link)", systemImage: "link")
       }
       .tint(theme.labelColor)
       


### PR DESCRIPTION
Apologies for such a small and pedantic fix 😅 It just really sticks out to me when I see the name misspelled somewhere.

Really liking the app so far btw!