### PR TITLE
Make vapidKey in InstanceApp model optional

### DIFF
--- a/Packages/Models/Sources/Models/InstanceApp.swift
+++ b/Packages/Models/Sources/Models/InstanceApp.swift
@@ -7,5 +7,5 @@ public struct InstanceApp: Codable, Identifiable {
   public let redirectUri: String
   public let clientId: String
   public let clientSecret: String
-  public let vapidKey: String
+  public let vapidKey: String?
 }


### PR DESCRIPTION
This allows Ice Cubes to log into GoToSocial instances.
Related to #16, but not a full fix since the issue is also about Pleroma support.