### PR TITLE
Fix weird scrolling when opening status detail

### DIFF
--- a/Packages/Status/Sources/Status/Detail/StatusDetailView.swift
+++ b/Packages/Status/Sources/Status/Detail/StatusDetailView.swift
@@ -89,9 +89,6 @@ public struct StatusDetailView: View {
             _ = routerPath.path.popLast()
           }
         }
-        DispatchQueue.main.async {
-          proxy.scrollTo(viewModel.statusId, anchor: .center)
-        }
       }
       .onChange(of: watcher.latestEvent?.id) { _ in
         guard let lastEvent = watcher.latestEvent else { return }


### PR DESCRIPTION
When tapping on a post that is beyond a certain height (including pictures, link previews etc.), the view would be scrolled a little bit down, hiding the profile picture and name. This PR fixes this – opening the detail view now looks smoother.

Here's a recording of the current behavior:

https://user-images.githubusercontent.com/38211057/213803328-53e09642-9872-4090-8f4a-b45e6e778ad5.mp4

