### PR TITLE
Fix bug where App Icon in settings displays wrong image for some values.

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/IconSelectorView.swift
+++ b/IceCubesApp/App/Tabs/Settings/IconSelectorView.swift
@@ -11,7 +11,7 @@ struct IconSelectorView: View {
       if string == Icon.primary.appIconName {
         self = .primary
       } else {
-        self = .init(rawValue: Int(String(string.last!))!)!
+        self = .init(rawValue: Int(String(string.replacing("AppIconAlternate", with: "")))!)!
       }
     }
 


### PR DESCRIPTION
It looks like when converting from Icon name to Icon enum if the number is two digits only the last digit is pulled giving the wrong image. This changes how it converts the String `AppIconAlternate[XXX]` into an Icon enum. 