### PR TITLE
Moved app version to the section footer

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -110,7 +110,7 @@ struct SettingsTabs: View {
   }
 
   private var appSection: some View {
-    Section("settings.section.app") {
+    Section {
       if !ProcessInfo.processInfo.isiOSAppOnMac {
         NavigationLink(destination: IconSelectorView()) {
           Label {
@@ -135,16 +135,18 @@ struct SettingsTabs: View {
         Label("settings.app.support", systemImage: "wand.and.stars")
       }
       
-      if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-        Label("App Version: \(appVersion)", systemImage: "app.badge.checkmark")
-      }
-      
       if let reviewURL = URL(string: "https://apps.apple.com/app/id\(AppInfo.appStoreAppId)?action=write-review") {
         Link(destination: reviewURL) {
           Label("Rate Ice Cubes", systemImage: "link")
         }
         .tint(theme.labelColor)
       }
+    } header: {
+        Text("settings.section.app")
+    } footer: {
+        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+            Text("App Version: \(appVersion)").frame(maxWidth: .infinity, alignment: .center)
+        }
     }
     .listRowBackground(theme.primaryBackgroundColor)
   }


### PR DESCRIPTION
Since the app version row doesn't have any action assigned I think it can also be moved to the section footer.

See Screenshot:
<img width="378" alt="Screenshot 2023-01-21 at 08 24 13" src="https://user-images.githubusercontent.com/132167/213848890-8669ae3c-7d4e-4465-9565-6ff739e54edf.png">

