### PR TITLE
Fix bookmark/unbookmark text in context menu

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -37,7 +37,7 @@ struct StatusRowContextMenu: View {
           await viewModel.bookmark()
         }
       } } label: {
-        Label(viewModel.isReblogged ? "status.action.unbookmark" : "status.action.bookmark",
+        Label(viewModel.isBookmarked ? "status.action.unbookmark" : "status.action.bookmark",
               systemImage: "bookmark")
       }
       Button {


### PR DESCRIPTION
When you tapped on the three dots context menu of a bookmarked post, the label would still say "Bookmark" and not "Unbookmark".