### PR TITLE
Poll results UI update

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/DesignSystem.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/DesignSystem.swift
@@ -6,4 +6,5 @@ public extension CGFloat {
   static let statusColumnsSpacing: CGFloat = 8
   static let maxColumnWidth: CGFloat = 650
   static let sidebarWidth: CGFloat = 80
+  static let pollBarHeight: CGFloat = 30
 }

--- a/Packages/Status/Sources/Status/Poll/StatusPollView.swift
+++ b/Packages/Status/Sources/Status/Poll/StatusPollView.swift
@@ -106,10 +106,11 @@ public struct StatusPollView: View {
                   let width = widthForOption(option: option, proxy: proxy)
                   Rectangle()
                     .foregroundColor(theme.tintColor)
-                    .frame(height: Constants.barHeight)
                     .frame(height: .pollBarHeight)
                     .frame(width: width)
-                  Spacer()
+                  if width != proxy.size.width {
+                    Spacer()
+                  }
                 }
               }
             }

--- a/Packages/Status/Sources/Status/Poll/StatusPollView.swift
+++ b/Packages/Status/Sources/Status/Poll/StatusPollView.swift
@@ -49,7 +49,7 @@ public struct StatusPollView: View {
           makeBarView(for: option)
           if !viewModel.votes.isEmpty || viewModel.poll.expired || status.account.id == currentAccount.account?.id {
             Spacer()
-            Text("\(percentForOption(option: option)) %")
+            Text("\(percentForOption(option: option))%")
               .font(.scaledSubheadline)
               .frame(width: 40)
           }

--- a/Packages/Status/Sources/Status/Poll/StatusPollView.swift
+++ b/Packages/Status/Sources/Status/Poll/StatusPollView.swift
@@ -5,10 +5,6 @@ import Network
 import SwiftUI
 
 public struct StatusPollView: View {
-  enum Constants {
-    static let barHeight: CGFloat = 30
-  }
-
   @EnvironmentObject private var theme: Theme
   @EnvironmentObject private var client: Client
   @EnvironmentObject private var currentInstance: CurrentInstance
@@ -111,13 +107,14 @@ public struct StatusPollView: View {
                   Rectangle()
                     .foregroundColor(theme.tintColor)
                     .frame(height: Constants.barHeight)
+                    .frame(height: .pollBarHeight)
                     .frame(width: width)
                   Spacer()
                 }
               }
             }
             .foregroundColor(theme.tintColor.opacity(0.40))
-            .frame(height: Constants.barHeight)
+            .frame(height: .pollBarHeight)
             .clipShape(RoundedRectangle(cornerRadius: 8))
 
           HStack {
@@ -133,7 +130,7 @@ public struct StatusPollView: View {
           .padding(.leading, 12)
         }
       }
-      .frame(height: Constants.barHeight)
+      .frame(height: .pollBarHeight)
     }
   }
 }


### PR DESCRIPTION
The entire bar is not filled when a poll result is 100%. This PR fixes this.

| Before | After |
| ------ | ----- |
| <img height="50%" src="https://user-images.githubusercontent.com/169561/213873333-f3fb9e81-a068-4bd2-abaf-3760d9b6fee1.png"> | <img height="50%" src="https://user-images.githubusercontent.com/169561/213873355-c98296bd-f7ec-4149-a750-8f3aa934f464.png"> |
| <img height="50%" src="https://user-images.githubusercontent.com/169561/213873343-a0b6deab-da12-4038-8949-be1a3dd7af9c.png"> | <img height="50%" src="https://user-images.githubusercontent.com/169561/213873370-a8eb99fb-3116-45bb-823c-d540eafaa752.png"> | 
