### PR TITLE
Fix typo in German localization

### DIFF
--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -127,7 +127,7 @@
 "account.action.unblock" = "Block aufheben";
 "account.action.mute" = "Stummschalten";
 "account.action.unmute" = "Stummschaltung aufheben";
-"account.boosted-by" = "Geboosted von";
+"account.boosted-by" = "Geboostet von";
 "account.detail.about" = "Über";
 "account.detail.familiar-followers" = "Auch gefolgt von";
 "account.detail.n-fields %lld" = "%lld Felder";
@@ -219,7 +219,7 @@
 "notifications.label.follow-request" = "möchte dir folgen";
 "notifications.label.mention" = "hat dich erwähnt";
 "notifications.label.poll" = "Umfrage beendet";
-"notifications.label.reblog" = "hat geboosted";
+"notifications.label.reblog" = "hat geboostet";
 "notifications.label.status" = "hat einen Beitrag gepostet";
 "notifications.label.update" = "hat einen Beitrag geändert";
 "notifications.menu-title.favorite" = "Favorit";
@@ -303,9 +303,9 @@
 "status.poll.frequency" = "Auswahlmöglichkeiten";
 "status.poll.option-n %lld" = "Option %lld";
 "status.post-from-%@" = "Post von %@";
-"status.row.was-boosted" = "hat geboosted";
+"status.row.was-boosted" = "hat geboostet";
 "status.row.was-reply" = "Antwort auf";
-"status.row.you-boosted" = "Du hast geboosted";
+"status.row.you-boosted" = "Du hast geboostet";
 "status.show-less" = "Weniger anzeigen";
 "status.show-more" = "Mehr anzeigen";
 "status.summary.at-time" = " um ";


### PR DESCRIPTION
`geboosted` → `geboostet`

These germanized English words always end in -t, never in -d. `Geboostet` isn't in the [Duden](https://www.duden.de/) yet, but it works exactly the same as e.g. [`gebootet`](https://de.wiktionary.org/wiki/Flexion:booten).