### PR TITLE
Timeline VoiceOver Improvements

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -200,11 +200,11 @@ public struct StatusRowView: View {
         makeStatusContentView(status: status)
           .contentShape(Rectangle())
           .onTapGesture {
-            viewModel.navigateToDetail(routerPath: routerPath)
-          }
-      }
-    }
-    .accessibilityElement(children: viewModel.isFocused ? .contain : .combine)
+			  viewModel.navigateToDetail(routerPath: routerPath)
+		  }
+	  }
+	}
+	.accessibilityElement(children: viewModel.isFocused ? .contain : .combine)
 	.accessibilityAction {
 		viewModel.navigateToDetail(routerPath: routerPath)
 	}
@@ -243,7 +243,7 @@ public struct StatusRowView: View {
         }
 
         makeMediasView(status: status)
-			  .accessibilityHidden(!viewModel.isFocused)
+		  .accessibilityHidden(!viewModel.isFocused)
         makeCardView(status: status)
       }
     }


### PR DESCRIPTION
### Timeline

- Added accessibility custom actions for available status options
- Accessibility actions also include the ability to open any @ mentions in the status
- Grouped status content so that VoiceOver users only need to swipe once between statuses (before/after video attached)
- I left the status detail page alone, so that images can be accessed (plus that screen is a bigger LOE)
- Here and there the code formatting doesn't look right...but looks fine in Xcode. Not sure what's going on there. Let me know if I need to fix that.

https://user-images.githubusercontent.com/19654210/213884202-5f8fe1c6-adda-45f0-ba26-ec99b4b33e5c.MP4

https://user-images.githubusercontent.com/19654210/213884200-19aaa385-3861-4d50-8fbf-c0fa71983d02.MP4