### PR TITLE
Setting to hide boost content

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
@@ -51,6 +51,7 @@ struct DisplaySettingsView: View {
           }
         }
         Toggle("settings.display.translate-button", isOn: $userPreferences.showTranslateButton)
+        Toggle("settings.display.show-boost-content", isOn: $userPreferences.showBoostContent)
       }
       .listRowBackground(theme.primaryBackgroundColor)
 

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "settings.display.restore" = "Standard wiederherstellen";
 "settings.display.section.display" = "Anzeigen";
 "settings.display.section.theme" = "Thema";
+"settings.display.show-boost-content" = "Show boost content";
 "settings.display.status.action-buttons" = "Status Aktions-Buttons";
 "settings.display.status.media-style" = "Status Medien";
 "settings.display.translate-button" = "Show translate button";
@@ -308,6 +309,7 @@
 "status.row.was-boosted" = "hat geboostet";
 "status.row.was-reply" = "Antwort auf";
 "status.row.you-boosted" = "Du hast geboostet";
+"status.show-boost-content" = "Show boost content";
 "status.show-less" = "Weniger anzeigen";
 "status.show-more" = "Mehr anzeigen";
 "status.summary.at-time" = " um ";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "settings.display.restore" = "Restore defaults";
 "settings.display.section.display" = "Display";
 "settings.display.section.theme" = "Theme";
+"settings.display.show-boost-content" = "Show boost content";
 "settings.display.status.action-buttons" = "Status action buttons";
 "settings.display.status.media-style" = "Status media style";
 "settings.display.translate-button" = "Show translate button";
@@ -308,6 +309,7 @@
 "status.row.was-boosted" = "boosted";
 "status.row.was-reply" = "Replied to";
 "status.row.you-boosted" = "You boosted";
+"status.show-boost-content" = "Show boost content";
 "status.show-less" = "Show less";
 "status.show-more" = "Show more";
 "status.summary.at-time" = " at ";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "settings.display.restore" = "Restaurar ajustes predeterminados";
 "settings.display.section.display" = "Apariencia";
 "settings.display.section.theme" = "Tema";
+"settings.display.show-boost-content" = "Show boost content";
 "settings.display.status.action-buttons" = "Botones de acción";
 "settings.display.status.media-style" = "Estilo del contenido multimedia";
 "settings.display.translate-button" = "Show translate button";
@@ -308,6 +309,7 @@
 "status.row.was-boosted" = "boosteó";
 "status.row.was-reply" = "Respuesta a";
 "status.row.you-boosted" = "Boosteaste";
+"status.show-boost-content" = "Show boost content";
 "status.show-less" = "Mostrar menos";
 "status.show-more" = "Mostrar más";
 "status.summary.at-time" = " a las ";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "settings.display.restore" = "Ripristina i valori predefiniti";
 "settings.display.section.display" = "Visualizzazione";
 "settings.display.section.theme" = "Tema";
+"settings.display.show-boost-content" = "Show boost content";
 "settings.display.status.action-buttons" = "Bottoni di azione";
 "settings.display.status.media-style" = "Stile dei media";
 "settings.display.translate-button" = "Show translate button";
@@ -308,6 +309,7 @@
 "status.row.was-boosted" = "Condiviso";
 "status.row.was-reply" = "Risposta per";
 "status.row.you-boosted" = "Tu hai condiviso";
+"status.show-boost-content" = "Show boost content";
 "status.show-less" = "Mostra meno";
 "status.show-more" = "Mostra di più";
 "status.summary.at-time" = " alle ";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "settings.display.restore" = "Standaardinstellingen herstellen";
 "settings.display.section.display" = "Weergave";
 "settings.display.section.theme" = "Thema";
+"settings.display.show-boost-content" = "Show boost content";
 "settings.display.status.action-buttons" = "Actieknoppen";
 "settings.display.status.media-style" = "Mediastijl";
 "settings.display.translate-button" = "Show translate button";
@@ -308,6 +309,7 @@
 "status.row.was-boosted" = "geboost";
 "status.row.was-reply" = "Geantwoord op";
 "status.row.you-boosted" = "Je boostte";
+"status.show-boost-content" = "Show boost content";
 "status.show-less" = "Toon minder";
 "status.show-more" = "Toon meer";
 "status.summary.at-time" = " om ";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "settings.display.restore" = "恢复默认设置";
 "settings.display.section.display" = "显示";
 "settings.display.section.theme" = "主题";
+"settings.display.show-boost-content" = "Show boost content";
 "settings.display.status.action-buttons" = "状态操作选项";
 "settings.display.status.media-style" = "状态媒体样式";
 "settings.display.translate-button" = "Show translate button";
@@ -308,6 +309,7 @@
 "status.row.was-boosted" = "转发";
 "status.row.was-reply" = "回复到";
 "status.row.you-boosted" = "你转发了";
+"status.show-boost-content" = "Show boost content";
 "status.show-less" = "显示更少";
 "status.show-more" = "显示更多";
 "status.summary.at-time" = " 在 ";

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -15,6 +15,7 @@ public class UserPreferences: ObservableObject {
   @AppStorage("draft_posts") public var draftsPosts: [String] = []
   @AppStorage("font_size_scale") public var fontSizeScale: Double = 1
   @AppStorage("show_translate_button_inline") public var showTranslateButton: Bool = true
+  @AppStorage("show_boost_content") public var showBoostContent: Bool = true
 
   public var pushNotificationsCount: Int {
     get {

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -22,6 +22,7 @@ public class StatusRowViewModel: ObservableObject {
   @Published var displaySpoiler: Bool = false
   @Published var isEmbedLoading: Bool = true
   @Published var isFiltered: Bool = false
+  @Published var boostedIsExpanded: Bool = false
 
   @Published var translation: String?
   @Published var isLoadingTranslation: Bool = false


### PR DESCRIPTION
For users who prefers only original content (without boosts), this adds a setting to hide the boosts content in the timeline, with a button to reveal it.

![Simulator Screen Recording - iPhone 14 Pro - 2023-01-22 at 13 53 27](https://user-images.githubusercontent.com/485107/213916805-0da429dd-f443-4834-ba16-a9a5861cfccf.gif)
