### PR TITLE
Digest: Popular posts from timeline

### DIFF
--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -240,7 +240,10 @@
 "timeline.home" = "Startseite";
 "timeline.local" = "Lokal";
 "timeline.n-recent-from-n-participants %lld %lld" = "%lld aktuelle Beiträge von %lld Teilnehmer:innen";
+"timeline.digest.title" = "Popular posts you may have missed";
+"timeline.digest-of-n-posts-over-n-hours %lld %lld" = "Analyzed %lld posts from your timeline over the last %lld hours";
 "timeline.trending" = "Im Trend";
+"timeline.digest" = "Digest";
 
 // MARK: Package: Status
 "status.action.translate" = "Übersetzen";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -241,7 +241,7 @@
 "timeline.local" = "Lokal";
 "timeline.n-recent-from-n-participants %lld %lld" = "%lld aktuelle Beiträge von %lld Teilnehmer:innen";
 "timeline.digest.title" = "Popular posts you may have missed";
-"timeline.digest-of-n-posts-over-n-hours %lld %lld" = "Analyzed %lld posts from your timeline over the last %lld hours";
+"timeline.digest-of-n-posts %lld" = "Based on %lld posts from your timeline";
 "timeline.trending" = "Im Trend";
 "timeline.digest" = "Digest";
 

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -241,7 +241,7 @@
 "timeline.local" = "Local";
 "timeline.n-recent-from-n-participants %lld %lld" = "%lld recent posts from %lld participants";
 "timeline.digest.title" = "Popular posts you may have missed";
-"timeline.digest-of-n-posts-over-n-hours %lld %lld" = "Analyzed %lld posts from your timeline over the last %lld hours";
+"timeline.digest-of-n-posts %lld" = "Based on %lld posts from your timeline";
 "timeline.trending" = "Trending";
 "timeline.digest" = "Digest";
 

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -240,7 +240,10 @@
 "timeline.home" = "Home";
 "timeline.local" = "Local";
 "timeline.n-recent-from-n-participants %lld %lld" = "%lld recent posts from %lld participants";
+"timeline.digest.title" = "Popular posts you may have missed";
+"timeline.digest-of-n-posts-over-n-hours %lld %lld" = "Analyzed %lld posts from your timeline over the last %lld hours";
 "timeline.trending" = "Trending";
+"timeline.digest" = "Digest";
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "timeline.n-recent-from-n-participants %lld %lld" = "%lld publicaciones recientes de %lld participantes";
 "timeline.trending" = "Tendencia";
 "timeline.digest.title" = "Popular posts you may have missed";
-"timeline.digest-of-n-posts-over-n-hours %lld %lld" = "Analyzed %lld posts from your timeline over the last %lld hours";
+"timeline.digest-of-n-posts %lld" = "Based on %lld posts from your timeline";
 
 // MARK: Package: Status
 "status.action.translate" = "Traducir";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -238,8 +238,11 @@
 "timeline.federated" = "Federado";
 "timeline.home" = "Inicio";
 "timeline.local" = "Local";
+"timeline.digest" = "Digest";
 "timeline.n-recent-from-n-participants %lld %lld" = "%lld publicaciones recientes de %lld participantes";
 "timeline.trending" = "Tendencia";
+"timeline.digest.title" = "Popular posts you may have missed";
+"timeline.digest-of-n-posts-over-n-hours %lld %lld" = "Analyzed %lld posts from your timeline over the last %lld hours";
 
 // MARK: Package: Status
 "status.action.translate" = "Traducir";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -105,6 +105,8 @@
 "tab.settings" = "Instellingen";
 "tab.timeline" = "Tijdlijn";
 "tab.trending" = "Trending";
+"timeline.digest" = "Digest";
+
 
 // MARK: Timeline
 "timeline.%@-is-valid" = "%@ is een geldige instantie";
@@ -241,6 +243,8 @@
 "timeline.local" = "Lokaal";
 "timeline.n-recent-from-n-participants %lld %lld" = "%lld recente posts van %lld deelnemers";
 "timeline.trending" = "Trending";
+"timeline.digest.title" = "Popular posts you may have missed";
+"timeline.digest-of-n-posts-over-n-hours %lld %lld" = "Analyzed %lld posts from your timeline over the last %lld hours";
 
 // MARK: Package: Status
 "status.action.translate" = "Vertalen";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -244,7 +244,7 @@
 "timeline.n-recent-from-n-participants %lld %lld" = "%lld recente posts van %lld deelnemers";
 "timeline.trending" = "Trending";
 "timeline.digest.title" = "Popular posts you may have missed";
-"timeline.digest-of-n-posts-over-n-hours %lld %lld" = "Analyzed %lld posts from your timeline over the last %lld hours";
+"timeline.digest-of-n-posts %lld" = "Based on %lld posts from your timeline";
 
 // MARK: Package: Status
 "status.action.translate" = "Vertalen";

--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -118,6 +118,39 @@ public struct Status: AnyStatus, Decodable, Identifiable {
   public static func placeholders() -> [Status] {
     [.placeholder(), .placeholder(), .placeholder(), .placeholder(), .placeholder()]
   }
+
+  public func didInteract() -> Bool {
+    var postInfo: AnyStatus = self
+    if let rebloggedStatus = reblog {
+      postInfo = rebloggedStatus
+    }
+    return (postInfo.reblogged ?? false) || (postInfo.favourited ?? false) || (postInfo.bookmarked ?? false)
+  }
+
+  public func isRelevant() -> Bool {
+    var postInfo: AnyStatus = self
+    if let rebloggedStatus = reblog {
+      postInfo = rebloggedStatus
+    }
+    return postInfo.repliesCount > 0 || postInfo.reblogsCount > 0 || postInfo.favouritesCount > 0
+  }
+
+  public var popularity: Double {
+    var postInfo: AnyStatus = self
+    if let rebloggedStatus = reblog {
+      postInfo = rebloggedStatus
+    }
+    let criterias = [
+      Double(postInfo.reblogsCount + 1),
+      Double(postInfo.favouritesCount + 1),
+      Double(postInfo.repliesCount + 1)
+    ]
+    var weight = Double(0)
+    if postInfo.account.followersCount > 0 {
+      weight = 1 / sqrt(Double(postInfo.account.followersCount))
+    }
+    return pow(criterias.reduce(Double(1), {x, y in x * y}), 1/Double(criterias.count)) * weight
+  }
 }
 
 public struct ReblogStatus: AnyStatus, Decodable, Identifiable {

--- a/Packages/Timeline/Sources/Timeline/Digest.swift
+++ b/Packages/Timeline/Sources/Timeline/Digest.swift
@@ -1,0 +1,47 @@
+import Models
+import Foundation
+
+public struct Digest: Identifiable {
+  public let generatedAt: String
+  public let hoursSince: Int
+  public let totalStatuses: Int
+
+  public var id: String {
+    "\(generatedAt)-\(hoursSince)"
+  }
+}
+
+public extension Status {
+  func didInteract() -> Bool {
+    var postInfo: AnyStatus = self
+    if let rebloggedStatus = reblog {
+      postInfo = rebloggedStatus
+    }
+    return (postInfo.reblogged ?? false) || (postInfo.favourited ?? false) || (postInfo.bookmarked ?? false)
+  }
+
+  func isRelevant() -> Bool {
+    var postInfo: AnyStatus = self
+    if let rebloggedStatus = reblog {
+      postInfo = rebloggedStatus
+    }
+    return postInfo.repliesCount > 0 || postInfo.reblogsCount > 0 || postInfo.favouritesCount > 0
+  }
+
+  func popularity() -> Double {
+    var postInfo: AnyStatus = self
+    if let rebloggedStatus = reblog {
+      postInfo = rebloggedStatus
+    }
+    let criterias = [
+      Double(postInfo.reblogsCount + 1),
+      Double(postInfo.favouritesCount + 1),
+      Double(postInfo.repliesCount + 1)
+    ]
+    var weight = Double(0)
+    if postInfo.account.followersCount > 0 {
+      weight = 1 / sqrt(Double(postInfo.account.followersCount))
+    }
+    return pow(criterias.reduce(Double(1), {x, y in x * y}), 1/Double(criterias.count)) * weight
+  }
+}

--- a/Packages/Timeline/Sources/Timeline/TimelineFilter.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineFilter.swift
@@ -17,7 +17,7 @@ public enum TimelineFilter: Hashable, Equatable {
     if !client.isAuth {
       return [.local, .federated, .trending]
     }
-    return [.home, .local, .federated, .trending]
+    return [.home, .local, .federated, .trending, .digest]
   }
 
   public func title() -> String {

--- a/Packages/Timeline/Sources/Timeline/TimelineFilter.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineFilter.swift
@@ -4,7 +4,7 @@ import Network
 import SwiftUI
 
 public enum TimelineFilter: Hashable, Equatable {
-  case home, local, federated, trending
+  case home, local, federated, trending, digest
   case hashtag(tag: String, accountId: String?)
   case list(list: Models.List)
   case remoteLocal(server: String)
@@ -30,6 +30,8 @@ public enum TimelineFilter: Hashable, Equatable {
       return "Trending"
     case .home:
       return "Home"
+    case .digest:
+      return "Digest"
     case let .hashtag(tag, _):
       return "#\(tag)"
     case let .list(list):
@@ -49,6 +51,8 @@ public enum TimelineFilter: Hashable, Equatable {
       return "timeline.trending"
     case .home:
       return "timeline.home"
+    case .digest:
+      return "timeline.digest"
     case let .hashtag(tag, _):
       return "#\(tag)"
     case let .list(list):
@@ -68,6 +72,8 @@ public enum TimelineFilter: Hashable, Equatable {
       return "chart.line.uptrend.xyaxis"
     case .home:
       return "house"
+    case .digest:
+      return "newspaper"
     case .list:
       return "list.bullet"
     case .remoteLocal:
@@ -83,6 +89,7 @@ public enum TimelineFilter: Hashable, Equatable {
     case .local: return Timelines.pub(sinceId: sinceId, maxId: maxId, minId: minId, local: true)
     case .remoteLocal: return Timelines.pub(sinceId: sinceId, maxId: maxId, minId: minId, local: true)
     case .home: return Timelines.home(sinceId: sinceId, maxId: maxId, minId: minId)
+    case .digest: return Timelines.home(sinceId: sinceId, maxId: maxId, minId: minId)
     case .trending: return Trends.statuses(offset: offset)
     case let .list(list): return Timelines.list(listId: list.id, sinceId: sinceId, maxId: maxId, minId: minId)
     case let .hashtag(tag, accountId):

--- a/Packages/Timeline/Sources/Timeline/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineView.swift
@@ -146,7 +146,7 @@ public struct TimelineView: View {
       VStack(alignment: .leading, spacing: 4) {
         Text("timeline.digest.title")
           .font(.scaledHeadline)
-        Text("timeline.digest-of-n-posts-over-n-hours \(digest.totalStatuses) \(digest.hoursSince)")
+        Text("timeline.digest-of-n-posts \(digest.totalStatuses)")
           .font(.scaledFootnote)
           .foregroundColor(.gray)
         }

--- a/Packages/Timeline/Sources/Timeline/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineView.swift
@@ -41,6 +41,8 @@ public struct TimelineView: View {
           LazyVStack {
             tagHeaderView
               .padding(.bottom, 16)
+            digestHeaderView
+              .padding(.bottom, 16)
             switch viewModel.timeline {
             case .remoteLocal:
               StatusesListView(fetcher: viewModel, isRemote: true)
@@ -65,6 +67,7 @@ public struct TimelineView: View {
       if viewModel.client == nil {
         viewModel.client = client
         viewModel.timeline = timeline
+        viewModel.acct = account.account?.acct
       }
     }
     .refreshable {
@@ -133,6 +136,25 @@ public struct TimelineView: View {
         }
       }
       .padding(.top, 6)
+    }
+  }
+  
+  @ViewBuilder
+  private var digestHeaderView: some View {
+    if let digest = viewModel.digest {
+      HStack {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("timeline.digest.title")
+          .font(.scaledHeadline)
+        Text("timeline.digest-of-n-posts-over-n-hours \(digest.totalStatuses) \(digest.hoursSince)")
+          .font(.scaledFootnote)
+          .foregroundColor(.gray)
+        }
+        Spacer()
+      }
+      .padding(.horizontal, .layoutPadding)
+      .padding(.vertical, 8)
+      .background(theme.secondaryBackgroundColor)
     }
   }
 

--- a/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
@@ -67,6 +67,8 @@ class TimelineViewModel: ObservableObject, StatusesFetcher {
 
   func fetchStatuses(userIntent: Bool) async {
     guard let client else { return }
+    // TODO: Check if the timeline is TimelineFilter.digest
+    // TODO: fetch the statuses until specified time (last 24 hours) and then run the algorithm
     do {
       if statuses.isEmpty {
         pendingStatuses = []

--- a/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
@@ -90,7 +90,7 @@ class TimelineViewModel: ObservableObject, StatusesFetcher {
         if timeline == TimelineFilter.digest {
           return
         }
-        var newStatuses: [Status] = await fetchNewPages(minId: first.id, maxPages: 20, maxStatuses: nil)
+        var newStatuses: [Status] = await fetchNewPages(minId: first.id, maxPages: 20)
         if userIntent || !pendingStatusesEnabled {
           pendingStatuses.insert(contentsOf: newStatuses, at: 0)
           statuses.insert(contentsOf: pendingStatuses, at: 0)
@@ -123,7 +123,7 @@ class TimelineViewModel: ObservableObject, StatusesFetcher {
       to: Date()
     )!
     let timestamp = ISO8601DateFormatter().string(from: earlyDate)
-    let allStatuses = await fetchNewPages(minId: timestamp, maxPages: nil, maxStatuses: 1000)
+    let allStatuses = await fetchNewPages(minId: timestamp, maxPages: 400)
 
     var originals: [Status] = []
     var boosts: [Status] = []
@@ -150,7 +150,7 @@ class TimelineViewModel: ObservableObject, StatusesFetcher {
     return originals.gatherPopular(percentile: 95) + boosts.gatherPopular(percentile: 95)
   }
 
-  func fetchNewPages(minId: String, maxPages: Int?, maxStatuses: Int?) async -> [Status] {
+  func fetchNewPages(minId: String, maxPages: Int) async -> [Status] {
     guard let client else { return [] }
     var pagesLoaded = 0
     var allStatuses: [Status] = []
@@ -161,8 +161,7 @@ class TimelineViewModel: ObservableObject, StatusesFetcher {
                                                                                          minId: latestMinId,
                                                                                          offset: statuses.count)),
         !newStatuses.isEmpty,
-        pagesLoaded < (maxPages ?? Int.max),
-        allStatuses.count < (maxStatuses ?? Int.max)
+        pagesLoaded < maxPages
       {
         pagesLoaded += 1
         allStatuses.insert(contentsOf: newStatuses, at: 0)

--- a/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
@@ -134,7 +134,10 @@ class TimelineViewModel: ObservableObject, StatusesFetcher {
         status.isRelevant() &&
         !status.didInteract() &&
         !postsSeen.contains(status.reblog?.url ?? status.url ?? "") &&
-        acct?.lowercased() != status.account.acct.lowercased() {
+        acct?.lowercased() != status.account.acct.lowercased() &&
+        !status.account.note.asRawText.lowercased().contains("#noindex") &&
+        !status.account.note.asRawText.lowercased().contains("#nobot")
+    {
           if status.reblog == nil {
             originals.append(status)
           } else {

--- a/Packages/Timeline/Tests/TimelineTests/TimelineTests.swift
+++ b/Packages/Timeline/Tests/TimelineTests/TimelineTests.swift
@@ -6,7 +6,6 @@ final class TimelineTests: XCTestCase {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct
     // results.
-    let tl = TimelineFilter.digest
-    XCTAssertEqual(tl.title(), "Hello, World!")
+    XCTAssertEqual(TimelineFilter.digest.title(), "Digest")
   }
 }

--- a/Packages/Timeline/Tests/TimelineTests/TimelineTests.swift
+++ b/Packages/Timeline/Tests/TimelineTests/TimelineTests.swift
@@ -6,6 +6,7 @@ final class TimelineTests: XCTestCase {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct
     // results.
-    XCTAssertEqual(Timeline().text, "Hello, World!")
+    let tl = TimelineFilter.digest
+    XCTAssertEqual(tl.title(), "Hello, World!")
   }
 }


### PR DESCRIPTION
Fixes  #132

I'm not sure that this is something you are interested in having in the Ice Cubes app, but maybe nice to consider. The "algorithm" is based on the https://github.com/hodgesmr/mastodon_digest project and uses a fixed configuration (equivalent to `SimpleWeighted` option and using the `home` timeline). If this is something you want to explore, then other options could be added in the user settings, or an entirely new set of views for the Digest feature could also be considered.

Mastodon API has a limit on how many toots are visible in the user's home timeline (400 toots). More details here: https://github.com/mastodon/mastodon/issues/2301 Based on that list, the code in this PR creates a digest of "popular posts".

I keep running the [mastodon_digest](https://github.com/hodgesmr/mastodon_digest) myself from time to time, and I thought it would be nice to have it embedded in a client like Ice Cubes.

As a side note, those are my first semi-complex lines of Swift. I'm happy to refactor and eager to learn how it could be better.