### PR TITLE
Ignore twitter handle taps

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -233,7 +233,9 @@ public struct StatusRowView: View {
           EmojiTextApp(status.content, emojis: status.emojis, language: status.language)
             .font(.scaledBody)
             .environment(\.openURL, OpenURLAction { url in
-              routerPath.handleStatus(status: status, url: url)
+              guard !url.absoluteString.hasPrefix("mailto:") else { return .discarded }
+
+              return routerPath.handleStatus(status: status, url: url)
             })
           Spacer()
         }


### PR DESCRIPTION
Temporarily ignore the tapping of Twitter handles so the app will stop crashing.

Twitter handle example: 
<img width="292" alt="CleanShot 2023-01-22 at 17 22 48@2x" src="https://user-images.githubusercontent.com/169561/213946074-343978f3-aa8c-41d4-a855-f02b6e4c7c17.png">
