### PR TITLE
Hide timeline scroll view indicators

### DIFF
--- a/Packages/Timeline/Sources/Timeline/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineView.swift
@@ -34,7 +34,7 @@ public struct TimelineView: View {
   public var body: some View {
     ScrollViewReader { proxy in
       ZStack(alignment: .top) {
-        ScrollView {
+        ScrollView(showsIndicators: false) {
           Rectangle()
             .frame(height: 0)
             .id(Constants.scrollToTop)


### PR DESCRIPTION
I noticed that infinite scrolling on the timeline caused the scroll view indicators to jump around a lot, which was distracting. This pull request hides scroll view indicators on the timeline and removes that distraction. I've attached some screen recordings to show my test plan and the proposed changes.

### Before proposed change

https://user-images.githubusercontent.com/28012/213953798-ad8f7fee-4153-43fd-8dd1-0559c22d838b.mov

### After proposed change

https://user-images.githubusercontent.com/28012/213953800-c8d4ed1e-2352-477c-bcf4-ef326e8cbe6d.mov