### PR TITLE
Allow hiding or showing user boosts

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -157,8 +157,7 @@ struct AccountDetailHeaderView: View {
       }
       .foregroundColor(.gray)
       .font(.footnote)
-      .padding(.top, 4)
-      .padding(.bottom, 5)
+      .padding(.top, 6)
     }
   }
 }

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -104,13 +104,14 @@ struct AccountDetailHeaderView: View {
   private var accountInfoView: some View {
     Group {
       accountAvatarView
-      HStack {
+      HStack(alignment: .firstTextBaseline) {
         VStack(alignment: .leading, spacing: 0) {
           EmojiTextApp(.init(stringValue: account.safeDisplayName), emojis: account.emojis)
             .font(.scaledHeadline)
           Text("@\(account.acct)")
             .font(.scaledCallout)
             .foregroundColor(.gray)
+          joinedAtView
         }
         Spacer()
         if let relationship = viewModel.relationship, !viewModel.isCurrentUser {
@@ -143,6 +144,21 @@ struct AccountDetailHeaderView: View {
       Text(title)
         .font(.scaledFootnote)
         .foregroundColor(.gray)
+    }
+  }
+
+  @ViewBuilder
+  private var joinedAtView: some View {
+    if let joinedAt = viewModel.account?.createdAt.asDate {
+      HStack(spacing: 4) {
+        Image(systemName: "calendar")
+        Text("account.joined")
+        Text(joinedAt, style: .date)
+      }
+      .foregroundColor(.gray)
+      .font(.footnote)
+      .padding(.top, 4)
+      .padding(.bottom, 5)
     }
   }
 }

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -43,8 +43,6 @@ public struct AccountDetailView: View {
       } content: {
         LazyVStack(alignment: .leading) {
           makeHeaderView(proxy: proxy)
-          joinedAtView
-            .offset(y: -36)
           familiarFollowers
             .offset(y: -36)
           featuredTagsView
@@ -147,22 +145,6 @@ public struct AccountDetailView: View {
                               scrollOffset: $scrollOffset)
     case let .error(error):
       Text("Error: \(error.localizedDescription)")
-    }
-  }
-
-  @ViewBuilder
-  private var joinedAtView: some View {
-    if let joinedAt = viewModel.account?.createdAt.asDate {
-      HStack(spacing: 4) {
-        Image(systemName: "calendar")
-        Text("account.joined")
-        Text(joinedAt, style: .date)
-      }
-      .foregroundColor(.gray)
-      .font(.footnote)
-      .padding(.horizontal, .layoutPadding)
-      .padding(.top, 2)
-      .padding(.bottom, 5)
     }
   }
 

--- a/Packages/Account/Sources/Account/Follow/FollowButton.swift
+++ b/Packages/Account/Sources/Account/Follow/FollowButton.swift
@@ -28,7 +28,7 @@ public class FollowButtonViewModel: ObservableObject {
     guard let client else { return }
     isUpdating = true
     do {
-      relationship = try await client.post(endpoint: Accounts.follow(id: accountId, notify: false))
+      relationship = try await client.post(endpoint: Accounts.follow(id: accountId, notify: false, reblogs: true))
       relationshipUpdated(relationship)
     } catch {
       print("Error while following: \(error.localizedDescription)")
@@ -51,10 +51,24 @@ public class FollowButtonViewModel: ObservableObject {
   func toggleNotify() async {
     guard let client else { return }
     do {
-      relationship = try await client.post(endpoint: Accounts.follow(id: accountId, notify: !relationship.notifying))
+      relationship = try await client.post(endpoint: Accounts.follow(id: accountId,
+                                                                     notify: !relationship.notifying,
+                                                                     reblogs: relationship.showingReblogs))
       relationshipUpdated(relationship)
     } catch {
       print("Error while following: \(error.localizedDescription)")
+    }
+  }
+
+  func toggleReboosts() async {
+    guard let client else { return }
+    do {
+      relationship = try await client.post(endpoint: Accounts.follow(id: accountId,
+                                                                     notify: relationship.notifying,
+                                                                     reblogs: !relationship.showingReblogs))
+      relationshipUpdated(relationship)
+    } catch {
+      print("Error while switching reboosts: \(error.localizedDescription)")
     }
   }
 }
@@ -93,6 +107,16 @@ public struct FollowButton: View {
           }
         } label: {
           Image(systemName: viewModel.relationship.notifying ? "bell.fill" : "bell")
+        }
+        .buttonStyle(.bordered)
+        .disabled(viewModel.isUpdating)
+
+        Button {
+          Task {
+            await viewModel.toggleReboosts()
+          }
+        } label: {
+          Image(systemName: viewModel.relationship.showingReblogs ? "arrow.left.arrow.right.circle.fill" : "arrow.left.arrow.right.circle")
         }
         .buttonStyle(.bordered)
         .disabled(viewModel.isUpdating)

--- a/Packages/Account/Sources/Account/Follow/FollowButton.swift
+++ b/Packages/Account/Sources/Account/Follow/FollowButton.swift
@@ -82,7 +82,7 @@ public struct FollowButton: View {
   }
 
   public var body: some View {
-    HStack {
+    VStack {
       Button {
         Task {
           if viewModel.relationship.following {
@@ -101,25 +101,27 @@ public struct FollowButton: View {
       .buttonStyle(.bordered)
       .disabled(viewModel.isUpdating)
       if viewModel.relationship.following, viewModel.shouldDisplayNotify {
-        Button {
-          Task {
-            await viewModel.toggleNotify()
+        HStack {
+          Button {
+            Task {
+              await viewModel.toggleNotify()
+            }
+          } label: {
+            Image(systemName: viewModel.relationship.notifying ? "bell.fill" : "bell")
           }
-        } label: {
-          Image(systemName: viewModel.relationship.notifying ? "bell.fill" : "bell")
-        }
-        .buttonStyle(.bordered)
-        .disabled(viewModel.isUpdating)
-
-        Button {
-          Task {
-            await viewModel.toggleReboosts()
+          .buttonStyle(.bordered)
+          .disabled(viewModel.isUpdating)
+              
+          Button {
+            Task {
+              await viewModel.toggleReboosts()
+            }
+          } label: {
+            Image(systemName: viewModel.relationship.showingReblogs ? "arrow.left.arrow.right.circle.fill" : "arrow.left.arrow.right.circle")
           }
-        } label: {
-          Image(systemName: viewModel.relationship.showingReblogs ? "arrow.left.arrow.right.circle.fill" : "arrow.left.arrow.right.circle")
+          .buttonStyle(.bordered)
+          .disabled(viewModel.isUpdating)
         }
-        .buttonStyle(.bordered)
-        .disabled(viewModel.isUpdating)
       }
     }
     .onAppear {

--- a/Packages/Network/Sources/Network/Endpoint/Accounts.swift
+++ b/Packages/Network/Sources/Network/Endpoint/Accounts.swift
@@ -22,7 +22,7 @@ public enum Accounts: Endpoint {
                 excludeReplies: Bool?,
                 pinned: Bool?)
   case relationships(ids: [String])
-  case follow(id: String, notify: Bool)
+  case follow(id: String, notify: Bool, reblogs: Bool)
   case unfollow(id: String)
   case familiarFollowers(withAccount: String)
   case suggestions
@@ -55,7 +55,7 @@ public enum Accounts: Endpoint {
       return "accounts/\(id)/statuses"
     case .relationships:
       return "accounts/relationships"
-    case let .follow(id, _):
+    case let .follow(id, _, _):
       return "accounts/\(id)/follow"
     case let .unfollow(id):
       return "accounts/\(id)/unfollow"
@@ -106,8 +106,11 @@ public enum Accounts: Endpoint {
       return ids.map {
         URLQueryItem(name: "id[]", value: $0)
       }
-    case let .follow(_, notify):
-      return [.init(name: "notify", value: notify ? "true" : "false")]
+    case let .follow(_, notify, reblogs):
+      return [
+        .init(name: "notify", value: notify ? "true" : "false"),
+        .init(name: "reblogs", value: reblogs ? "true" : "false")
+      ]
     case let .familiarFollowers(withAccount):
       return [.init(name: "id[]", value: withAccount)]
     case let .followers(_, maxId):


### PR DESCRIPTION
This adds a button to show or hide user boost on a per-user basis, like notifications.
I've added a new button, but not sure if it is the correct place (Follow button is wrapped sometimes).

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-23 at 12 02 11](https://user-images.githubusercontent.com/485107/214024271-06aa0325-57d1-4ff0-955d-fa71750fad40.png)
