### PR TITLE
This is a fix for #317

### DIFF
--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -62,9 +62,9 @@ public class RouterPath: ObservableObject {
   }
 
   public func handleStatus(status: AnyStatus, url: URL) -> OpenURLAction.Result {
-    if url.pathComponents.contains(where: { $0 == "tags" }),
-       let tag = url.pathComponents.last
+    if url.pathComponents.count == 3 && url.pathComponents[1] == "tags"
     {
+      let tag = url.pathComponents.last!
       navigate(to: .hashTag(tag: tag, account: nil))
       return .handled
     } else if let mention = status.mentions.first(where: { $0.url == url }) {

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -62,9 +62,10 @@ public class RouterPath: ObservableObject {
   }
 
   public func handleStatus(status: AnyStatus, url: URL) -> OpenURLAction.Result {
-    if url.pathComponents.count == 3 && url.pathComponents[1] == "tags"
+    if url.pathComponents.count == 3 && url.pathComponents[1] == "tags",
+       let tag = url.pathComponents.last
     {
-      let tag = url.pathComponents.last!
+
       navigate(to: .hashTag(tag: tag, account: nil))
       return .handled
     } else if let mention = status.mentions.first(where: { $0.url == url }) {


### PR DESCRIPTION
This is a fix for #317
Well more of an improvement than a fix.
Instead of looking for tags anywhere, we now look for /tags/TagName exactly.  This can still fail if it happens to be a link to somewhere not on the post creator's home server that follows that pattern but by the time the parsing is done the post creator isn't available without a lot of re-plumbing.
But anyway, this should be better.