### PR TITLE
Make spelling of "favorite" consistent

### DIFF
--- a/IceCubesApp/App/AppRouter.swift
+++ b/IceCubesApp/App/AppRouter.swift
@@ -31,8 +31,8 @@ extension View {
         AccountsListView(mode: .following(accountId: id))
       case let .followers(id):
         AccountsListView(mode: .followers(accountId: id))
-      case let .favouritedBy(id):
-        AccountsListView(mode: .favouritedBy(statusId: id))
+      case let .favoritedBy(id):
+        AccountsListView(mode: .favoritedBy(statusId: id))
       case let .rebloggedBy(id):
         AccountsListView(mode: .rebloggedBy(statusId: id))
       }

--- a/Packages/Account/Sources/Account/AccountDetailViewModel.swift
+++ b/Packages/Account/Sources/Account/AccountDetailViewModel.swift
@@ -15,10 +15,10 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
   }
 
   enum Tab: Int {
-    case statuses, favourites, bookmarks, followedTags, postsAndReplies, media, lists
+    case statuses, favorites, bookmarks, followedTags, postsAndReplies, media, lists
 
     static var currentAccountTabs: [Tab] {
-      [.statuses, .favourites, .bookmarks, .followedTags, .lists]
+      [.statuses, .favorites, .bookmarks, .followedTags, .lists]
     }
 
     static var accountTabs: [Tab] {
@@ -28,7 +28,7 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
     var iconName: String {
       switch self {
       case .statuses: return "bubble.right"
-      case .favourites: return "star"
+      case .favorites: return "star"
       case .bookmarks: return "bookmark"
       case .followedTags: return "tag"
       case .postsAndReplies: return "bubble.left.and.bubble.right"
@@ -62,9 +62,9 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
 
   @Published var relationship: Relationship?
   @Published var pinned: [Status] = []
-  @Published var favourites: [Status] = []
+  @Published var favorites: [Status] = []
   @Published var bookmarks: [Status] = []
-  private var favouritesNextPage: LinkHandler?
+  private var favoritesNextPage: LinkHandler?
   private var bookmarksNextPage: LinkHandler?
   @Published var featuredTags: [FeaturedTag] = []
   @Published var fields: [Account.Field] = []
@@ -167,7 +167,7 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
                                                            pinned: true))
       }
       if isCurrentUser {
-        (favourites, favouritesNextPage) = try await client.getWithLink(endpoint: Accounts.favourites(sinceId: nil))
+        (favorites, favoritesNextPage) = try await client.getWithLink(endpoint: Accounts.favorites(sinceId: nil))
         (bookmarks, bookmarksNextPage) = try await client.getWithLink(endpoint: Accounts.bookmarks(sinceId: nil))
       }
       reloadTabState()
@@ -193,12 +193,12 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
         statuses.append(contentsOf: newStatuses)
         tabState = .statuses(statusesState: .display(statuses: statuses,
                                                      nextPageState: newStatuses.count < 20 ? .none : .hasNextPage))
-      case .favourites:
-        guard let nextPageId = favouritesNextPage?.maxId else { return }
-        let newFavourites: [Status]
-        (newFavourites, favouritesNextPage) = try await client.getWithLink(endpoint: Accounts.favourites(sinceId: nextPageId))
-        favourites.append(contentsOf: newFavourites)
-        tabState = .statuses(statusesState: .display(statuses: favourites, nextPageState: .hasNextPage))
+      case .favorites:
+        guard let nextPageId = favoritesNextPage?.maxId else { return }
+        let newFavorites: [Status]
+        (newFavorites, favoritesNextPage) = try await client.getWithLink(endpoint: Accounts.favorites(sinceId: nextPageId))
+        favorites.append(contentsOf: newFavorites)
+        tabState = .statuses(statusesState: .display(statuses: favorites, nextPageState: .hasNextPage))
       case .bookmarks:
         guard let nextPageId = bookmarksNextPage?.maxId else { return }
         let newBookmarks: [Status]
@@ -217,9 +217,9 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
     switch selectedTab {
     case .statuses, .postsAndReplies, .media:
       tabState = .statuses(statusesState: .display(statuses: statuses, nextPageState: statuses.count < 20 ? .none : .hasNextPage))
-    case .favourites:
-      tabState = .statuses(statusesState: .display(statuses: favourites,
-                                                   nextPageState: favouritesNextPage != nil ? .hasNextPage : .none))
+    case .favorites:
+      tabState = .statuses(statusesState: .display(statuses: favorites,
+                                                   nextPageState: favoritesNextPage != nil ? .hasNextPage : .none))
     case .bookmarks:
       tabState = .statuses(statusesState: .display(statuses: bookmarks,
                                                    nextPageState: bookmarksNextPage != nil ? .hasNextPage : .none))

--- a/Packages/Account/Sources/Account/AccountsList/AccountsListViewModel.swift
+++ b/Packages/Account/Sources/Account/AccountsList/AccountsListViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 public enum AccountsListMode {
   case following(accountId: String), followers(accountId: String)
-  case favouritedBy(statusId: String), rebloggedBy(statusId: String)
+  case favoritedBy(statusId: String), rebloggedBy(statusId: String)
 
   var title: LocalizedStringKey {
     switch self {
@@ -12,7 +12,7 @@ public enum AccountsListMode {
       return "account.following"
     case .followers:
       return "account.followers"
-    case .favouritedBy:
+    case .favoritedBy:
       return "account.favorited-by"
     case .rebloggedBy:
       return "account.boosted-by"
@@ -64,8 +64,8 @@ class AccountsListViewModel: ObservableObject {
       case let .rebloggedBy(statusId):
         (accounts, link) = try await client.getWithLink(endpoint: Statuses.rebloggedBy(id: statusId,
                                                                                        maxId: nil))
-      case let .favouritedBy(statusId):
-        (accounts, link) = try await client.getWithLink(endpoint: Statuses.favouritedBy(id: statusId,
+      case let .favoritedBy(statusId):
+        (accounts, link) = try await client.getWithLink(endpoint: Statuses.favoritedBy(id: statusId,
                                                                                         maxId: nil))
       }
       nextPageId = link?.maxId
@@ -93,8 +93,8 @@ class AccountsListViewModel: ObservableObject {
       case let .rebloggedBy(statusId):
         (newAccounts, link) = try await client.getWithLink(endpoint: Statuses.rebloggedBy(id: statusId,
                                                                                           maxId: nextPageId))
-      case let .favouritedBy(statusId):
-        (newAccounts, link) = try await client.getWithLink(endpoint: Statuses.favouritedBy(id: statusId,
+      case let .favoritedBy(statusId):
+        (newAccounts, link) = try await client.getWithLink(endpoint: Statuses.favoritedBy(id: statusId,
                                                                                            maxId: nextPageId))
       }
       accounts.append(contentsOf: newAccounts)

--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
@@ -76,7 +76,7 @@ struct ConversationMessageView: View {
       }
     }
     .onAppear {
-      isLiked = message.favourited == true
+      isLiked = message.favorited == true
     }
   }
   
@@ -97,12 +97,12 @@ struct ConversationMessageView: View {
         do {
           let status: Status
           if isLiked {
-            status = try await client.post(endpoint: Statuses.unfavourite(id: message.id))
+            status = try await client.post(endpoint: Statuses.unfavorite(id: message.id))
           } else {
-            status = try await client.post(endpoint: Statuses.favourite(id: message.id))
+            status = try await client.post(endpoint: Statuses.favorite(id: message.id))
           }
           withAnimation {
-            isLiked = status.favourited == true
+            isLiked = status.favorited == true
           }
         } catch { }
       }

--- a/Packages/Env/Sources/Env/PushNotificationsService.swift
+++ b/Packages/Env/Sources/Env/PushNotificationsService.swift
@@ -97,7 +97,7 @@ public class PushNotificationsService: ObservableObject {
                                                          status: isNewPostsNotificationEnabled,
                                                          reblog: isReblogNotificationEnabled,
                                                          follow: isFollowNotificationEnabled,
-                                                         favourite: isFavoriteNotificationEnabled,
+                                                         favorite: isFavoriteNotificationEnabled,
                                                          poll: isPollNotificationEnabled))
         subscriptions.append(sub)
       } catch {}
@@ -120,7 +120,7 @@ public class PushNotificationsService: ObservableObject {
     if let sub = subscriptions.first {
       isPushEnabled = true
       isFollowNotificationEnabled = sub.alerts.follow
-      isFavoriteNotificationEnabled = sub.alerts.favourite
+      isFavoriteNotificationEnabled = sub.alerts.favorite
       isReblogNotificationEnabled = sub.alerts.reblog
       isMentionNotificationEnabled = sub.alerts.mention
       isPollNotificationEnabled = sub.alerts.poll

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -13,7 +13,7 @@ public enum RouterDestinations: Hashable {
   case list(list: Models.List)
   case followers(id: String)
   case following(id: String)
-  case favouritedBy(id: String)
+  case favoritedBy(id: String)
   case rebloggedBy(id: String)
 }
 

--- a/Packages/Models/Sources/Models/Notification.swift
+++ b/Packages/Models/Sources/Models/Notification.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct Notification: Decodable, Identifiable {
   public enum NotificationType: String, CaseIterable {
-    case follow, follow_request, mention, reblog, status, favourite, poll, update
+    case follow, follow_request, mention, reblog, status, favorite, poll, update
   }
 
   public let id: String
@@ -17,7 +17,7 @@ public struct Notification: Decodable, Identifiable {
 
   public static func placeholder() -> Notification {
     .init(id: UUID().uuidString,
-          type: NotificationType.favourite.rawValue,
+          type: NotificationType.favorite.rawValue,
           createdAt: "2022-12-16T10:20:54.000Z",
           account: .placeholder(),
           status: .placeholder())

--- a/Packages/Models/Sources/Models/PushSubscription.swift
+++ b/Packages/Models/Sources/Models/PushSubscription.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct PushSubscription: Identifiable, Decodable {
   public struct Alerts: Decodable {
     public let follow: Bool
-    public let favourite: Bool
+    public let favorite: Bool
     public let reblog: Bool
     public let mention: Bool
     public let poll: Bool

--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -36,9 +36,9 @@ public protocol AnyStatus {
   var mentions: [Mention] { get }
   var repliesCount: Int { get }
   var reblogsCount: Int { get }
-  var favouritesCount: Int { get }
+  var favoritesCount: Int { get }
   var card: Card? { get }
-  var favourited: Bool? { get }
+  var favorited: Bool? { get }
   var reblogged: Bool? { get }
   var pinned: Bool? { get }
   var bookmarked: Bool? { get }
@@ -77,9 +77,9 @@ public struct Status: AnyStatus, Decodable, Identifiable, Equatable, Hashable {
   public let mentions: [Mention]
   public let repliesCount: Int
   public let reblogsCount: Int
-  public let favouritesCount: Int
+  public let favoritesCount: Int
   public let card: Card?
-  public let favourited: Bool?
+  public let favorited: Bool?
   public let reblogged: Bool?
   public let pinned: Bool?
   public let bookmarked: Bool?
@@ -105,9 +105,9 @@ public struct Status: AnyStatus, Decodable, Identifiable, Equatable, Hashable {
           mentions: [],
           repliesCount: 0,
           reblogsCount: 0,
-          favouritesCount: 0,
+          favoritesCount: 0,
           card: nil,
-          favourited: false,
+          favorited: false,
           reblogged: false,
           pinned: false,
           bookmarked: false,
@@ -150,9 +150,9 @@ public struct ReblogStatus: AnyStatus, Decodable, Identifiable, Equatable, Hasha
   public let mentions: [Mention]
   public let repliesCount: Int
   public let reblogsCount: Int
-  public let favouritesCount: Int
+  public let favoritesCount: Int
   public let card: Card?
-  public let favourited: Bool?
+  public let favorited: Bool?
   public let reblogged: Bool?
   public let pinned: Bool?
   public let bookmarked: Bool?

--- a/Packages/Network/Sources/Network/Endpoint/Accounts.swift
+++ b/Packages/Network/Sources/Network/Endpoint/Accounts.swift
@@ -3,7 +3,7 @@ import Models
 
 public enum Accounts: Endpoint {
   case accounts(id: String)
-  case favourites(sinceId: String?)
+  case favorites(sinceId: String?)
   case bookmarks(sinceId: String?)
   case followedTags
   case featuredTags(id: String)
@@ -39,8 +39,8 @@ public enum Accounts: Endpoint {
     switch self {
     case let .accounts(id):
       return "accounts/\(id)"
-    case .favourites:
-      return "favourites"
+    case .favorites:
+      return "favorites"
     case .bookmarks:
       return "bookmarks"
     case .followedTags:
@@ -117,7 +117,7 @@ public enum Accounts: Endpoint {
       return makePaginationParam(sinceId: nil, maxId: maxId, mindId: nil)
     case let .following(_, maxId):
       return makePaginationParam(sinceId: nil, maxId: maxId, mindId: nil)
-    case let .favourites(sinceId):
+    case let .favorites(sinceId):
       guard let sinceId else { return nil }
       return [.init(name: "max_id", value: sinceId)]
     case let .bookmarks(sinceId):

--- a/Packages/Network/Sources/Network/Endpoint/Push.swift
+++ b/Packages/Network/Sources/Network/Endpoint/Push.swift
@@ -9,7 +9,7 @@ public enum Push: Endpoint {
                  status: Bool,
                  reblog: Bool,
                  follow: Bool,
-                 favourite: Bool,
+                 favorite: Bool,
                  poll: Bool)
 
   public func path() -> String {
@@ -21,7 +21,7 @@ public enum Push: Endpoint {
 
   public func queryItems() -> [URLQueryItem]? {
     switch self {
-    case let .createSub(endpoint, p256dh, auth, mentions, status, reblog, follow, favourite, poll):
+    case let .createSub(endpoint, p256dh, auth, mentions, status, reblog, follow, favorite, poll):
       var params: [URLQueryItem] = []
       params.append(.init(name: "subscription[endpoint]", value: endpoint))
       params.append(.init(name: "subscription[keys][p256dh]", value: p256dh.base64UrlEncodedString()))
@@ -30,7 +30,7 @@ public enum Push: Endpoint {
       params.append(.init(name: "data[alerts][status]", value: status ? "true" : "false"))
       params.append(.init(name: "data[alerts][follow]", value: follow ? "true" : "false"))
       params.append(.init(name: "data[alerts][reblog]", value: reblog ? "true" : "false"))
-      params.append(.init(name: "data[alerts][favourite]", value: favourite ? "true" : "false"))
+      params.append(.init(name: "data[alerts][favorite]", value: favorite ? "true" : "false"))
       params.append(.init(name: "data[alerts][poll]", value: poll ? "true" : "false"))
       params.append(.init(name: "policy", value: "all"))
       return params

--- a/Packages/Network/Sources/Network/Endpoint/Statuses.swift
+++ b/Packages/Network/Sources/Network/Endpoint/Statuses.swift
@@ -6,12 +6,12 @@ public enum Statuses: Endpoint {
   case editStatus(id: String, json: StatusData)
   case status(id: String)
   case context(id: String)
-  case favourite(id: String)
-  case unfavourite(id: String)
+  case favorite(id: String)
+  case unfavorite(id: String)
   case reblog(id: String)
   case unreblog(id: String)
   case rebloggedBy(id: String, maxId: String?)
-  case favouritedBy(id: String, maxId: String?)
+  case favoritedBy(id: String, maxId: String?)
   case pin(id: String)
   case unpin(id: String)
   case bookmark(id: String)
@@ -28,18 +28,18 @@ public enum Statuses: Endpoint {
       return "statuses/\(id)"
     case let .context(id):
       return "statuses/\(id)/context"
-    case let .favourite(id):
-      return "statuses/\(id)/favourite"
-    case let .unfavourite(id):
-      return "statuses/\(id)/unfavourite"
+    case let .favorite(id):
+      return "statuses/\(id)/favorite"
+    case let .unfavorite(id):
+      return "statuses/\(id)/unfavorite"
     case let .reblog(id):
       return "statuses/\(id)/reblog"
     case let .unreblog(id):
       return "statuses/\(id)/unreblog"
     case let .rebloggedBy(id, _):
       return "statuses/\(id)/reblogged_by"
-    case let .favouritedBy(id, _):
-      return "statuses/\(id)/favourited_by"
+    case let .favoritedBy(id, _):
+      return "statuses/\(id)/favorited_by"
     case let .pin(id):
       return "statuses/\(id)/pin"
     case let .unpin(id):
@@ -57,7 +57,7 @@ public enum Statuses: Endpoint {
     switch self {
     case let .rebloggedBy(_, maxId):
       return makePaginationParam(sinceId: nil, maxId: maxId, mindId: nil)
-    case let .favouritedBy(_, maxId):
+    case let .favoritedBy(_, maxId):
       return makePaginationParam(sinceId: nil, maxId: maxId, mindId: nil)
     default:
       return nil

--- a/Packages/Notifications/Sources/Notifications/NotificationTypeExt.swift
+++ b/Packages/Notifications/Sources/Notifications/NotificationTypeExt.swift
@@ -14,7 +14,7 @@ extension Models.Notification.NotificationType {
       return "notifications.label.follow"
     case .follow_request:
       return "notifications.label.follow-request"
-    case .favourite:
+    case .favorite:
       return "notifications.label.favorite"
     case .poll:
       return "notifications.label.poll"
@@ -33,7 +33,7 @@ extension Models.Notification.NotificationType {
       return "arrow.left.arrow.right.circle.fill"
     case .follow, .follow_request:
       return "person.fill.badge.plus"
-    case .favourite:
+    case .favorite:
       return "star.fill"
     case .poll:
       return "chart.bar.fill"
@@ -54,7 +54,7 @@ extension Models.Notification.NotificationType {
       return "notifications.menu-title.follow"
     case .follow_request:
       return "notifications.menu-title.follow-request"
-    case .favourite:
+    case .favorite:
       return "notifications.menu-title.favorite"
     case .poll:
       return "notifications.menu-title.poll"

--- a/Packages/Status/Sources/Status/Row/StatusActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusActionsView.swift
@@ -14,7 +14,7 @@ struct StatusActionsView: View {
 
   @MainActor
   enum Actions: CaseIterable {
-    case respond, boost, favourite, bookmark, share
+    case respond, boost, favorite, bookmark, share
 
     func iconName(viewModel: StatusRowViewModel) -> String {
       switch self {
@@ -22,8 +22,8 @@ struct StatusActionsView: View {
         return "arrowshape.turn.up.left"
       case .boost:
         return viewModel.isReblogged ? "arrow.left.arrow.right.circle.fill" : "arrow.left.arrow.right.circle"
-      case .favourite:
-        return viewModel.isFavourited ? "star.fill" : "star"
+      case .favorite:
+        return viewModel.isFavorited ? "star.fill" : "star"
       case .bookmark:
         return viewModel.isBookmarked ? "bookmark.fill" : "bookmark"
       case .share:
@@ -38,8 +38,8 @@ struct StatusActionsView: View {
       switch self {
       case .respond:
         return viewModel.repliesCount
-      case .favourite:
-        return viewModel.favouritesCount
+      case .favorite:
+        return viewModel.favoritesCount
       case .boost:
         return viewModel.reblogsCount
       case .share, .bookmark:
@@ -51,8 +51,8 @@ struct StatusActionsView: View {
       switch self {
       case .respond, .share:
         return nil
-      case .favourite:
-        return viewModel.isFavourited ? .yellow : nil
+      case .favorite:
+        return viewModel.isFavorited ? .yellow : nil
       case .bookmark:
         return viewModel.isBookmarked ? .pink : nil
       case .boost:
@@ -134,10 +134,10 @@ struct StatusActionsView: View {
       .foregroundColor(.gray)
     }
 
-    if viewModel.favouritesCount > 0 {
+    if viewModel.favoritesCount > 0 {
       Divider()
-      NavigationLink(value: RouterDestinations.favouritedBy(id: viewModel.status.id)) {
-        Text("status.summary.n-favorites \(viewModel.favouritesCount)")
+      NavigationLink(value: RouterDestinations.favoritedBy(id: viewModel.status.id)) {
+        Text("status.summary.n-favorites \(viewModel.favoritesCount)")
           .font(.scaledCallout)
         Spacer()
         Image(systemName: "chevron.right")
@@ -160,11 +160,11 @@ struct StatusActionsView: View {
       switch action {
       case .respond:
         routerPath.presentedSheet = .replyToStatusEditor(status: viewModel.status)
-      case .favourite:
-        if viewModel.isFavourited {
-          await viewModel.unFavourite()
+      case .favorite:
+        if viewModel.isFavorited {
+          await viewModel.unFavorite()
         } else {
-          await viewModel.favourite()
+          await viewModel.favorite()
         }
       case .bookmark:
         if viewModel.isBookmarked {

--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -14,13 +14,13 @@ struct StatusRowContextMenu: View {
   var body: some View {
     if !viewModel.isRemote {
       Button { Task {
-        if viewModel.isFavourited {
-          await viewModel.unFavourite()
+        if viewModel.isFavorited {
+          await viewModel.unFavorite()
         } else {
-          await viewModel.favourite()
+          await viewModel.favorite()
         }
       } } label: {
-        Label(viewModel.isFavourited ? "status.action.unfavorite" : "status.action.favorite", systemImage: "star")
+        Label(viewModel.isFavorited ? "status.action.unfavorite" : "status.action.favorite", systemImage: "star")
       }
       Button { Task {
         if viewModel.isReblogged {

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -11,8 +11,8 @@ public class StatusRowViewModel: ObservableObject {
   let isRemote: Bool
   let showActions: Bool
 
-  @Published var favouritesCount: Int
-  @Published var isFavourited: Bool
+  @Published var favoritesCount: Int
+  @Published var isFavorited: Bool
   @Published var isReblogged: Bool
   @Published var isPinned: Bool
   @Published var isBookmarked: Bool
@@ -44,17 +44,17 @@ public class StatusRowViewModel: ObservableObject {
     self.isRemote = isRemote
     self.showActions = showActions
     if let reblog = status.reblog {
-      isFavourited = reblog.favourited == true
+      isFavorited = reblog.favorited == true
       isReblogged = reblog.reblogged == true
       isPinned = reblog.pinned == true
       isBookmarked = reblog.bookmarked == true
     } else {
-      isFavourited = status.favourited == true
+      isFavorited = status.favorited == true
       isReblogged = status.reblogged == true
       isPinned = status.pinned == true
       isBookmarked = status.bookmarked == true
     }
-    favouritesCount = status.reblog?.favouritesCount ?? status.favouritesCount
+    favoritesCount = status.reblog?.favoritesCount ?? status.favoritesCount
     reblogsCount = status.reblog?.reblogsCount ?? status.reblogsCount
     repliesCount = status.reblog?.repliesCount ?? status.repliesCount
     displaySpoiler = !(status.reblog?.spoilerText.asRawText ?? status.spoilerText.asRawText).isEmpty
@@ -104,29 +104,29 @@ public class StatusRowViewModel: ObservableObject {
     }
   }
 
-  func favourite() async {
+  func favorite() async {
     guard let client, client.isAuth else { return }
-    isFavourited = true
-    favouritesCount += 1
+    isFavorited = true
+    favoritesCount += 1
     do {
-      let status: Status = try await client.post(endpoint: Statuses.favourite(id: status.reblog?.id ?? status.id))
+      let status: Status = try await client.post(endpoint: Statuses.favorite(id: status.reblog?.id ?? status.id))
       updateFromStatus(status: status)
     } catch {
-      isFavourited = false
-      favouritesCount -= 1
+      isFavorited = false
+      favoritesCount -= 1
     }
   }
 
-  func unFavourite() async {
+  func unFavorite() async {
     guard let client, client.isAuth else { return }
-    isFavourited = false
-    favouritesCount -= 1
+    isFavorited = false
+    favoritesCount -= 1
     do {
-      let status: Status = try await client.post(endpoint: Statuses.unfavourite(id: status.reblog?.id ?? status.id))
+      let status: Status = try await client.post(endpoint: Statuses.unfavorite(id: status.reblog?.id ?? status.id))
       updateFromStatus(status: status)
     } catch {
-      isFavourited = true
-      favouritesCount += 1
+      isFavorited = true
+      favoritesCount += 1
     }
   }
 
@@ -209,17 +209,17 @@ public class StatusRowViewModel: ObservableObject {
 
   private func updateFromStatus(status: Status) {
     if let reblog = status.reblog {
-      isFavourited = reblog.favourited == true
+      isFavorited = reblog.favorited == true
       isReblogged = reblog.reblogged == true
       isPinned = reblog.pinned == true
       isBookmarked = reblog.bookmarked == true
     } else {
-      isFavourited = status.favourited == true
+      isFavorited = status.favorited == true
       isReblogged = status.reblogged == true
       isPinned = status.pinned == true
       isBookmarked = status.bookmarked == true
     }
-    favouritesCount = status.reblog?.favouritesCount ?? status.favouritesCount
+    favoritesCount = status.reblog?.favoritesCount ?? status.favoritesCount
     reblogsCount = status.reblog?.reblogsCount ?? status.reblogsCount
     repliesCount = status.reblog?.repliesCount ?? status.repliesCount
   }


### PR DESCRIPTION
"Favorite" was spelled using both UK English and US English variations: 113 favourite
64 favorite

I made them consistent, using the US spelling.

I can change this to support the UK spelling if that's preferred, but my informal survey of existing words appears to support US spellings.