### PR TITLE
Some fixes for spanish localization and double done button on QuickLook preview

### DIFF
--- a/IceCubesApp/App/QuickLookRepresentable.swift
+++ b/IceCubesApp/App/QuickLookRepresentable.swift
@@ -51,19 +51,19 @@ struct QuickLookPreview: UIViewControllerRepresentable {
 
 class AppQLPreviewController: QLPreviewController {
   private var closeButton: UIBarButtonItem {
-    .init(title: "Done", style: .plain, target: self, action: #selector(onCloseButton))
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    if UIDevice.current.userInterfaceIdiom != .pad {
-      navigationItem.rightBarButtonItem = closeButton
-    }
+      .init(
+        title: NSLocalizedString("action.done", comment: ""),
+        style: .plain,
+        target: self,
+        action: #selector(onCloseButton)
+      )
   }
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    navigationItem.rightBarButtonItem = closeButton
+    if UIDevice.current.userInterfaceIdiom != .pad {
+      navigationItem.rightBarButtonItem = closeButton
+    }
   }
 
   @objc private func onCloseButton() {

--- a/IceCubesApp/Resources/Localization/Plurals/es.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/es.lproj/Localizable.stringsdict
@@ -13,7 +13,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lld</string>
 			<key>one</key>
-			<string>%lld new post</string>
+			<string>%lld nueva publicación</string>
 			<key>other</key>
 			<string>%lld nuevas publicaciones</string>
 		</dict>


### PR DESCRIPTION
- Fixed spanish location plural for single new post
- Fix for double Done button appearing on iPhone
- Added localized text for "Done" on QuickLook preview navigation bar