### PR TITLE
Prepend language list with recently used languages

### DIFF
--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -281,6 +281,7 @@
 "status.editor.drafts.navigation-title" = "Entwürfe";
 "status.editor.error.upload" = "Fehler beim Hochladen";
 "status.editor.language-select.navigation-title" = "Sprache auswählen";
+"status.editor.language-select.recently-used" = "Recently Used";
 "status.editor.media.edit-image" = "Bild bearbeiten";
 "status.editor.media.image-description" = "Bildbeschreibung";
 "status.editor.mode.edit" = "Deinen Post bearbeiten";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -281,6 +281,7 @@
 "status.editor.drafts.navigation-title" = "Drafts";
 "status.editor.error.upload" = "Error uploading";
 "status.editor.language-select.navigation-title" = "Select Language";
+"status.editor.language-select.recently-used" = "Recently Used";
 "status.editor.media.edit-image" = "Edit Image";
 "status.editor.media.image-description" = "Image description";
 "status.editor.mode.edit" = "Editing your post";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -281,6 +281,7 @@
 "status.editor.drafts.navigation-title" = "Borradores";
 "status.editor.error.upload" = "Error subiendo";
 "status.editor.language-select.navigation-title" = "Seleccionar idioma";
+"status.editor.language-select.recently-used" = "Recently Used";
 "status.editor.media.edit-image" = "Editar Imagen";
 "status.editor.media.image-description" = "Descripción de la imagen";
 "status.editor.mode.edit" = "Editando tu publicación";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -281,6 +281,7 @@
 "status.editor.drafts.navigation-title" = "Bozze";
 "status.editor.error.upload" = "Errore durante il caricamento";
 "status.editor.language-select.navigation-title" = "Scegli la lingua";
+"status.editor.language-select.recently-used" = "Recently Used";
 "status.editor.media.edit-image" = "Modifica l'immagine";
 "status.editor.media.image-description" = "Descrizione dell'immagine";
 "status.editor.mode.edit" = "Messaggio in modifica";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -277,6 +277,7 @@
 "status.editor.drafts.navigation-title" = "下書き";
 "status.editor.error.upload" = "アップロードエラー";
 "status.editor.language-select.navigation-title" = "言語設定";
+"status.editor.language-select.recently-used" = "Recently Used";
 "status.editor.media.edit-image" = "イメージの編集";
 "status.editor.media.image-description" = "イメージの説明文";
 "status.editor.mode.edit" = "投稿を編集する";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -281,6 +281,7 @@
 "status.editor.drafts.navigation-title" = "Concepten";
 "status.editor.error.upload" = "Fout tijdens uploaden";
 "status.editor.language-select.navigation-title" = "Taal selecteren";
+"status.editor.language-select.recently-used" = "Recently Used";
 "status.editor.media.edit-image" = "Afbeelding bewerken";
 "status.editor.media.image-description" = "Omschrijving";
 "status.editor.mode.edit" = "Je post bewerken";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -281,6 +281,7 @@
 "status.editor.drafts.navigation-title" = "草稿";
 "status.editor.error.upload" = "上传错误";
 "status.editor.language-select.navigation-title" = "选择语言";
+"status.editor.language-select.recently-used" = "Recently Used";
 "status.editor.media.edit-image" = "编辑图片";
 "status.editor.media.image-description" = "图片描述";
 "status.editor.mode.edit" = "正在编辑你的嘟文";

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -16,6 +16,7 @@ public class UserPreferences: ObservableObject {
   @AppStorage("font_size_scale") public var fontSizeScale: Double = 1
   @AppStorage("show_translate_button_inline") public var showTranslateButton: Bool = true
   @AppStorage("is_open_ai_enabled") public var isOpenAIEnabled: Bool = true
+  @AppStorage("recently_used_languages") public var recentlyUsedLanguages: [String] = []
 
   public var pushNotificationsCount: Int {
     get {
@@ -40,5 +41,14 @@ public class UserPreferences: ObservableObject {
   public func refreshServerPreferences() async {
     guard let client, client.isAuth else { return }
     serverPreferences = try? await client.get(endpoint: Accounts.preferences)
+  }
+
+  public func markLanguageAsSelected(isoCode: String) {
+    var copy = recentlyUsedLanguages
+    if let index = copy.firstIndex(of: isoCode) {
+      copy.remove(at: index)
+    }
+    copy.insert(isoCode, at: 0)
+    recentlyUsedLanguages = Array(copy.prefix(3))
   }
 }

--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -74,6 +74,7 @@ public struct StatusEditorView: View {
         viewModel.client = client
         viewModel.currentAccount = currentAccount.account
         viewModel.theme = theme
+        viewModel.preferences = preferences
         viewModel.prepareStatusText()
         if !client.isAuth {
           dismiss()

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -13,6 +13,7 @@ public class StatusEditorViewModel: ObservableObject {
   var client: Client?
   var currentAccount: Account?
   var theme: Theme?
+  var preferences: UserPreferences?
 
   @Published var statusText = NSMutableAttributedString(string: "") {
     didSet {

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -88,6 +88,7 @@ public class StatusEditorViewModel: ObservableObject {
   @Published var mentionsSuggestions: [Account] = []
   @Published var tagsSuggestions: [Tag] = []
   @Published var selectedLanguage: String?
+  var hasExplicitlySelectedLanguage: Bool = false
   private var currentSuggestionRange: NSRange?
 
   private var embeddedStatusURL: URL? {
@@ -137,6 +138,9 @@ public class StatusEditorViewModel: ObservableObject {
         postStatus = try await client.put(endpoint: Statuses.editStatus(id: status.id, json: data))
       }
       generator.notificationOccurred(.success)
+      if hasExplicitlySelectedLanguage, let selectedLanguage {
+        preferences?.markLanguageAsSelected(isoCode: selectedLanguage)
+      }
       isPosting = false
       return postStatus
     } catch let error {


### PR DESCRIPTION
Adresses issue #93 

Rule: when the user explicitly selects a language when posting, when the post is successful, register the selected language as recently used. The recently used language array contains up to 3 distinct items, starting with the most recently used.

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-24 at 20 23 49](https://user-images.githubusercontent.com/520924/214388914-e4aeb589-1671-407b-b1e6-b7e94d3d2f0b.png)
