### PR TITLE
Sort lists and tags in timeline filter button menus

### DIFF
--- a/IceCubesApp/App/Tabs/Timeline/TimelineTab.swift
+++ b/IceCubesApp/App/Tabs/Timeline/TimelineTab.swift
@@ -83,8 +83,9 @@ struct TimelineTab: View {
       }
     }
     if !currentAccount.lists.isEmpty {
+      let sortedLists = currentAccount.lists.sorted { $0.title < $1.title }
       Menu("timeline.filter.lists") {
-        ForEach(currentAccount.lists) { list in
+        ForEach(sortedLists) { list in
           Button {
             timeline = .list(list: list)
           } label: {
@@ -95,8 +96,9 @@ struct TimelineTab: View {
     }
 
     if !currentAccount.tags.isEmpty {
+      let sortedTags = currentAccount.tags.sorted { $0.name < $1.name }
       Menu("timeline.filter.tags") {
-        ForEach(currentAccount.tags) { tag in
+        ForEach(sortedTags) { tag in
           Button {
             timeline = .hashtag(tag: tag.name, accountId: nil)
           } label: {


### PR DESCRIPTION
Sorts alphabetically by `List.title` and `Tag.name` at the point of display in TimelineTab.

Alternatively they could be sorted in `CurrentAccount.fetchLists()` and `.fetchFollowedTags()`.