### PR TITLE
Allow editing photo description/alt-text after posting

### DIFF
--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
@@ -121,14 +121,12 @@ struct StatusEditorMediaView: View {
 
   @ViewBuilder
   private func makeImageMenu(container: StatusEditorMediaContainer) -> some View {
-    if !viewModel.mode.isEditing {
-      Button {
+    Button {
         editingContainer = container
-      } label: {
-        Label(container.mediaAttachment?.description?.isEmpty == false ?
+    } label: {
+      Label(container.mediaAttachment?.description?.isEmpty == false ?
           "status.editor.description.edit" : "status.editor.description.add",
           systemImage: "pencil.line")
-      }
     }
     Button(role: .destructive) {
       withAnimation {


### PR DESCRIPTION
Naively fixes #401
I'll do some more research to see if we can hide the add description menu item based on whether the image has been uploaded.