### PR TITLE
Add link to system settings

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -107,6 +107,9 @@ struct SettingsTabs: View {
       }
       Link(destination: URL(string: UIApplication.openSettingsURLString)!) {
         Label("settings.system", systemImage: "gear")
+          // Tint our label black, so that it matches the other NavigationLink instead of
+          // defaulting to highlighted like a Link
+          .tint(.black)
       }
     }
     .listRowBackground(theme.primaryBackgroundColor)

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -2,6 +2,7 @@ import Account
 import AppAccount
 import DesignSystem
 import Env
+import Foundation
 import Models
 import Network
 import SwiftUI
@@ -103,6 +104,9 @@ struct SettingsTabs: View {
       }
       NavigationLink(destination: ContentSettingsView()) {
         Label("settings.general.content", systemImage: "rectangle.fill.on.rectangle.fill")
+      }
+      Link(destination: URL(string: UIApplication.openSettingsURLString)!) {
+        Label("settings.system", systemImage: "gear")
       }
     }
     .listRowBackground(theme.primaryBackgroundColor)

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -111,6 +111,7 @@
 "settings.other.hide-openai" = "Aktiviere 🤖 Helfer";
 "settings.other.social-keyboard" = "Soziale Tastatur aktivieren";
 "settings.general.content" = "Inhaltseinstellungen";
+"settings.system" = "System Settings";
 "settings.content.navigation-title" = "Inhaltseinstellungen";
 "settings.content.use-instance-settings" = "Servereinstellungen verwenden";
 "settings.content.main-toggle.description" = "Die Einstellungen von der Heiminstanz übernehmen";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -87,6 +87,7 @@
 "settings.push.new-posts" = "New Posts";
 "settings.push.polls" = "Poll Results";
 "settings.general.content" = "Content Settings";
+"settings.system" = "System Settings";
 "settings.content.navigation-title" = "Content Settings";
 "settings.content.use-instance-settings" = "Use server settings";
 "settings.content.main-toggle.description" = "Use the settings from your home Instance";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -111,6 +111,7 @@
 "settings.other.hide-openai" = "Activar ayudante 🤖";
 "settings.other.social-keyboard" = "Activar teclado social";
 "settings.general.content" = "Ajustes de contenido";
+"settings.system" = "System Settings";
 "settings.content.navigation-title" = "Ajustes de contenido";
 "settings.content.use-instance-settings" = "Usar ajustes del servidor";
 "settings.content.main-toggle.description" = "Usar ajustes de tu instancia inicial";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -111,6 +111,7 @@
 "settings.other.hide-openai" = "Abilita l'aiuto del 🤖";
 "settings.other.social-keyboard" = "Abilita social keyboard";
 "settings.general.content" = "Impostazioni dei contenuti";
+"settings.system" = "System Settings";
 "settings.content.navigation-title" = "Impostazioni dei contenuti";
 "settings.content.use-instance-settings" = "Utilizza le impostazioni del server";
 "settings.content.main-toggle.description" = "Utilizza le impostazioni provenienti dalla tua istanza Mastodon";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -341,6 +341,7 @@
 "status.visibility.public" = "全員";
 "status.visibility.unlisted" = "リスト外";
 "settings.general.content" = "コンテンツ設定";
+"settings.system" = "System Settings";
 "settings.content.navigation-title" = "コンテンツ設定";
 "settings.content.use-instance-settings" = "サーバー設定を使用する";
 "settings.content.main-toggle.description" = "ホームインスタンスの設定を使用する";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -111,6 +111,7 @@
 "settings.other.hide-openai" = "Schakel 🤖-hulp in";
 "settings.other.social-keyboard" = "Schakel social-toetsenbord in";
 "settings.general.content" = "Inhoud";
+"settings.system" = "System Settings";
 "settings.content.navigation-title" = "Inhoud";
 "settings.content.use-instance-settings" = "Gebruik serverinstellingen";
 "settings.content.main-toggle.description" = "Gebruik de instellingen van jouw thuisinstantie.";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 "settings.other.social-keyboard" = "启用社交键盘";
 
 "settings.general.content" = "内容设置";
+"settings.system" = "System Settings";
 "settings.content.navigation-title" = "内容设置";
 "settings.content.use-instance-settings" = "使用服务器设置";
 "settings.content.main-toggle.description" = "使用你主服务器的设置";


### PR DESCRIPTION
I've often found it useful when an app had a shortcut directly to the system settings. Is this something you might consider?

It's unstyled/untranslated right now because I just wanted a quick sketch to see if this was something you would be interested in, before I actually dug into the translated strings :) 

<img width="374" alt="system settings" src="https://user-images.githubusercontent.com/89725/214804842-743d52e3-9800-4be5-a8aa-06afab77975c.png">
<img width="403" alt="ios settings" src="https://user-images.githubusercontent.com/89725/214804853-0bc9947b-1408-4dc4-bbf8-32d0e47c130f.png">
