### PR TITLE
Suggestion: Improve Status text visibility when context menu is opened.

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -62,6 +62,7 @@ public struct StatusRowView: View {
           }
         }
       }
+      .background(theme.primaryBackgroundColor)
       .onAppear {
         if reasons.isEmpty {
           viewModel.client = client


### PR DESCRIPTION
## Motivation

I'd like to improve text readability and visibility when status context menu is opened in Light mode settings.

## Changed 

- make it set background color to S tatusRowView's VStack which use `theme.primaryBackgroundColor`

## Evidence

### Light
before | after
--- | ---
![Light-Before mp4](https://user-images.githubusercontent.com/31161372/214849314-31a14d7a-caf1-43b3-894b-43bc5eabcaa5.gif) | ![Light-After mp4](https://user-images.githubusercontent.com/31161372/214849327-96b413fc-3bad-427c-a00c-21cea8d31c64.gif)

### Dark

before | after
--- | ---
![Dark-Beforee mp4](https://user-images.githubusercontent.com/31161372/214849432-886ee349-d8df-4fde-8da3-a2618540cf07.gif) | ![Dark-After mp4](https://user-images.githubusercontent.com/31161372/214849427-2f3872c3-8a10-4507-95f8-20f01f92d77f.gif)

## Consideration

If non color specified to StatusRowView's VStack, make it easy color management on view which useing StatusRowView.

So, if you intended this, please close this pull-request.