### PR TITLE
Add swipe-to-dismiss to QLPreviewController

### DIFF
--- a/IceCubesApp/App/IceCubesApp.swift
+++ b/IceCubesApp/App/IceCubesApp.swift
@@ -53,9 +53,10 @@ struct IceCubesApp: App {
         .environmentObject(theme)
         .environmentObject(watcher)
         .environmentObject(PushNotificationsService.shared)
-        .sheet(item: $quickLook.url, content: { url in
+        .fullScreenCover(item: $quickLook.url, content: { url in
           QuickLookPreview(selectedURL: url, urls: quickLook.urls)
             .edgesIgnoringSafeArea(.bottom)
+            .background(TransparentBackground())
         })
     }
     .commands {

--- a/Packages/Env/Sources/Env/QuickLook.swift
+++ b/Packages/Env/Sources/Env/QuickLook.swift
@@ -11,7 +11,9 @@ public class QuickLook: ObservableObject {
   public init() {}
 
   public func prepareFor(urls: [URL], selectedURL: URL) async {
-    withAnimation {
+    var transaction = Transaction(animation: .default)
+    transaction.disablesAnimations = true
+    withTransaction(transaction) {
       isPreparing = true
     }
     do {
@@ -27,18 +29,18 @@ public class QuickLook: ObservableObject {
         }
         return paths
       })
-      self.urls = paths
-      url = paths.first(where: { $0.lastPathComponent == selectedURL.lastPathComponent })
-      withAnimation {
+      withTransaction(transaction) {
+        self.urls = paths
+        url = paths.first(where: { $0.lastPathComponent == selectedURL.lastPathComponent })
         isPreparing = false
       }
     } catch {
-      withAnimation {
+      withTransaction(transaction) {
         isPreparing = false
+        self.urls = []
+        url = nil
+        latestError = error
       }
-      self.urls = []
-      url = nil
-      latestError = error
     }
   }
 


### PR DESCRIPTION
Work-around issue with QLPreviewController not supporting swipe-to-dismiss and pinch-to-dismiss when presented from SwiftUI by creating a transparent UIViewController wrapper around QLPreviewController that presents it using UIKit instead.

I tried many different ways to workaround this issue and this was the best way that I could figure it out. I've also filed feedback to Apple about the fact that SwiftUI has different behavior when presenting QLPreviewController than UIKit, so if they ever fix it, this workaround would be no longer needed.