### PR TITLE
Add indicator to which language a status is set

### DIFF
--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -289,6 +289,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Übersetzen";
+"status.action.translate-from-%@" = "Übersetzen aus %@";
 "status.action.translated-label" = "Übersetzt mit DeepL.com";
 "status.action.bookmark" = "Lesezeichen";
 "status.action.boost" = "Boosten";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
+"status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label" = "Translated using DeepL.com";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traducir";
+"status.action.translate-from-%@" = "Traducir desde %@";
 "status.action.translated-label" = "Traducido usando DeepL.com";
 "status.action.bookmark" = "Añadir a marcadores";
 "status.action.boost" = "Retootear";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduire";
+"status.action.translate-from-%@" = "Traduire de %@";
 "status.action.translated-label" = "Traduit avec DeepL.com";
 "status.action.bookmark" = "Marquer";
 "status.action.boost" = "Promouvoir";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -288,6 +288,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduci";
+"status.action.translate-from-%@" = "Traduci da %@";
 "status.action.translated-label" = "Tradotto usando DeepL.com";
 "status.action.bookmark" = "Salva nei segnalibri";
 "status.action.boost" = "Condividi";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -270,6 +270,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻訳";
+"status.action.translate-from-%@" = "翻訳 %@";
 "status.action.translated-label" = "DeepL.comを使用して翻訳";
 "status.action.bookmark" = "ブックマーク";
 "status.action.boost" = "ブースト";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -285,6 +285,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Vertaal";
+"status.action.translate-from-%@" = "Vertaal uit %@";
 "status.action.translated-label" = "Vertaald met behulp van DeepL.com";
 "status.action.bookmark" = "Voeg bladwijzer toe";
 "status.action.boost" = "Boosten";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -269,6 +269,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tercüme et";
+"status.action.translate-from-%@" = "Tercüme et %@";
 "status.action.translated-label" = "DeepL.com tarafından tercüme edildi";
 "status.action.bookmark" = "Yer İmi Ekle";
 "status.action.boost" = "Yükselt";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻译";
+"status.action.translate-from-%@" = "翻译 %@";
 "status.action.translated-label" = "使用 DeepL.com 翻译";
 "status.action.bookmark" = "书签";
 "status.action.boost" = "转发";

--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -85,7 +85,12 @@ struct StatusRowContextMenu: View {
           await viewModel.translate(userLang: lang)
         }
       } label: {
-        Label("status.action.translate", systemImage: "captions.bubble")
+        if let statusLanguage = viewModel.status.language,
+           let lanugageName = Locale.current.localizedString(forLanguageCode: statusLanguage) {
+          Label("status.action.translate-from-\(lanugageName)", systemImage: "captions.bubble")
+        } else {
+          Label("status.action.translate", systemImage: "captions.bubble")
+        }
       }
     }
 

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -329,7 +329,12 @@ public struct StatusRowView: View {
         if viewModel.isLoadingTranslation {
           ProgressView()
         } else {
-          Text("status.action.translate")
+          if let statusLanguage = status.language,
+             let lanugageName = Locale.current.localizedString(forLanguageCode: statusLanguage) {
+            Text("status.action.translate-from-\(lanugageName)")
+          } else {
+            Text("status.action.translate")
+          }
         }
       }
     }


### PR DESCRIPTION
I added a small indicator showing which language was set for a post, similar to Mastodon's web UI. Unfortunately, this often doesn't match the actual content of a post, but that's a different problem.

![image](https://user-images.githubusercontent.com/38211057/215223064-3cf9e440-c31f-4290-86bd-737c67e35cd4.png)

Since this feature is probably only relevant to a few people (or power users), I could add a setting to only show if the user enables it (default: not visible). Please let me know if such a setting would make sense.
