### PR TITLE
Small tweaks to making scrolling smoother

### DIFF
--- a/Packages/Status/Sources/Status/Embed/StatusEmbededView.swift
+++ b/Packages/Status/Sources/Status/Embed/StatusEmbededView.swift
@@ -45,6 +45,7 @@ public struct StatusEmbeddedView: View {
         }
         .font(.scaledCaption)
         .foregroundColor(.gray)
+        .drawingGroup()
       }
     }
   }

--- a/Packages/Status/Sources/Status/Row/StatusCardView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusCardView.swift
@@ -34,17 +34,17 @@ public struct StatusCardView: View {
           VStack(alignment: .leading, spacing: 6) {
             Text(title)
               .font(.scaledHeadline)
-              .lineLimit(3)
+              .lineLimit(2, reservesSpace: true)
             if let description = card.description, !description.isEmpty {
               Text(description)
                 .font(.scaledBody)
                 .foregroundColor(.gray)
-                .lineLimit(3)
+                .lineLimit(3, reservesSpace: true)
             }
             Text(url.host() ?? url.absoluteString)
               .font(.scaledFootnote)
               .foregroundColor(theme.tintColor)
-              .lineLimit(1)
+              .lineLimit(1, reservesSpace: true)
           }
           Spacer()
         }.padding(8)

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -148,6 +148,7 @@ public struct StatusRowView: View {
       .font(.scaledFootnote)
       .foregroundColor(.gray)
       .fontWeight(.semibold)
+      .drawingGroup()
       .onTapGesture {
         if viewModel.isRemote, let url = viewModel.status.account.url {
           Task {
@@ -246,6 +247,7 @@ public struct StatusRowView: View {
           .accessibility(label: viewModel.displaySpoiler ? Text("status.show-more") : Text("status.show-less"))
           .accessibilityHidden(true)
         }
+        .drawingGroup()
         .onTapGesture { // make whole row tapable to make up for smaller button size
           withAnimation {
             viewModel.displaySpoiler.toggle()
@@ -262,6 +264,7 @@ public struct StatusRowView: View {
             })
           Spacer()
         }
+        .drawingGroup()
 
         makeTranslateView(status: status)
 
@@ -297,6 +300,7 @@ public struct StatusRowView: View {
         }
         .font(.scaledFootnote)
         .foregroundColor(.gray)
+        .drawingGroup()
       }
     }
   }


### PR DESCRIPTION
This has 2 changes to improve scrolling a tiny bit:

- Reserve a fixed number of lines for text in web cards, and reduce the title to 2 lines so it doesn't look terrible when there's only one line. This is a step backwards for aesthetics and maybe it's not a good trade-off for you. I think it's worth it but it's subjective.

- Use [`drawingGroup`](https://developer.apple.com/documentation/swiftui/view/drawinggroup(opaque:colormode:)) to rasterize and cache expensive text views. I added it on all of them in the whole row but maybe it should be a bit more targeted and only on the status body.

**Measuring**

Measuring these in the hitches instrument consistently shows a reduction in the max hitch time by a few milliseconds on a 14 Pro so I think they're sound optimizations, not for reducing hitches but making them a bit less severe. I should measure on an older device here too and see if the drawing group is still faster. (update: measured on a 2018 iPad Pro and don't see any difference there so maybe this doesn't even improve anything)

Because the gains are so small though it's hard to know for sure whether `drawingGroup` helps all that much. When measuring, it's always on a different set of posts and you can't scroll the exact same way each run so it's not very scientific but I tried to choose a similar 5s sample for comparisons and got consistently better results.

**Other observations**

I tried removing everything except the status text and a few other things and there are still hitches and lots of primitive button configuration updates in the SwiftUI list. It seems impossible to eliminate them entirely with such a large view so making them shorter might be the only way to improve things without a big refactor. At least not with my optimization skills!