### PR TITLE
This is a more conservative fix for #328

### DIFF
--- a/Packages/Models/Sources/Models/Alias/HTMLString.swift
+++ b/Packages/Models/Sources/Models/Alias/HTMLString.swift
@@ -4,7 +4,7 @@ import SwiftSoup
 import SwiftUI
 
 public struct HTMLString: Decodable, Equatable, Hashable {
-  public let htmlValue: String
+  public var htmlValue: String
   public let asMarkdown: String
   public let asRawText: String
   public let statusesURLs: [URL]
@@ -18,6 +18,15 @@ public struct HTMLString: Decodable, Equatable, Hashable {
       htmlValue = ""
     }
 
+    // https://daringfireball.net/projects/markdown/syntax
+    // HTML2Markdown only auto escapes * on the way out
+    // so we pre-escape \ ` _ and [ as these are the only
+    // other characters the markdown parser used picks up
+    // when it renders to attributed text
+    if let regex = try? NSRegularExpression(pattern: "([\\_\\`\\[\\\\])", options: .caseInsensitive) {
+      htmlValue = regex.stringByReplacingMatches(in: htmlValue, options: [], range: NSRange(location: 0, length:  htmlValue.count), withTemplate: "\\\\$1")
+    }
+    
     do {
       asMarkdown = try HTMLParser().parse(html: htmlValue)
         .toMarkdown()


### PR DESCRIPTION
Having checked the markdown -> attributedtext conversion, lots of things I was escaping before are actually ingored.

This change only escapes things that are definitely rendered and as far as I can tell doesn't break anything now.

Test post to look at with maximal Markdown: https://mas.to/@elbrux/109743775703438333

My only worry is that it makes things slower, but I did some profiling and it didn't show anything.  So that could just be running under the debugger, it could be paranoia or it could be my lack of skill with the profiler.