### PR TITLE
Prevented authenticated network calls for unauthenticated users. 

### DIFF
--- a/Packages/Env/Sources/Env/CurrentAccount.swift
+++ b/Packages/Env/Sources/Env/CurrentAccount.swift
@@ -18,7 +18,7 @@ public class CurrentAccount: ObservableObject {
 
   public func setClient(client: Client) {
     self.client = client
-
+    guard client.isAuth else { return }
     Task(priority: .userInitiated) {
       await fetchUserData()
     }


### PR DESCRIPTION
All the APIs called in CurrentAccount is authenticated endpoint which needs bearer token, for unauthenticated user, oauthtoken will not be available and no need to call authenticated endpoints. 