### PR TITLE
Fix hasConnection

### DIFF
--- a/Packages/Network/Sources/Network/Client.swift
+++ b/Packages/Network/Sources/Network/Client.swift
@@ -50,7 +50,13 @@ public class Client: ObservableObject, Equatable {
 
   public func hasConnection(with url: URL) -> Bool {
     guard let host = url.host else { return false }
-    return connections.contains(host)
+    if let rootHost = host.split(separator: ".", maxSplits: 1).last {
+      // Sometimes the connection is with the root host instead of a subdomain
+      // eg. Mastodon runs on mastdon.domain.com but the connection is with domain.com
+      return connections.contains(host) || connections.contains(String(rootHost))
+    } else {
+      return connections.contains(host)
+    }
   }
 
   private func makeURL(scheme: String = "https", endpoint: Endpoint, forceVersion: Version? = nil) -> URL {


### PR DESCRIPTION
Sometimes the connection is with the root domain instead of the subdomain

eg. Mastodon runs on mastdon.domain.com but the connection is with domain.com

As seems to be the case with `mastodon.macstories.net` of which the connection API returns `macstories.net` instead of `mastodon.macstories.net`

Fixes #375 

This intentionally only removes the first subdomain as there are many cases of "fake" subdomains e.g. `mastodon.domain.co.uk` where when only taking the last two would be invalid and result in `co.uk` instead of `domain.co.uk`.

Unless we want to import a known list of TLDs I don't think its possible to determine that, but just dropping the first subdomain should cover most cases.
