### PR TITLE
Fix for launching app using just URL scheme

### DIFF
--- a/IceCubesApp/App/SafariRouter.swift
+++ b/IceCubesApp/App/SafariRouter.swift
@@ -25,7 +25,7 @@ private struct SafariRouter: ViewModifier {
       .onOpenURL(perform: { url in
         // Open external URL (from icecubesapp://)
         let urlString = url.absoluteString.replacingOccurrences(of: "icecubesapp://", with: "https://")
-        guard let url = URL(string: urlString) else { return }
+        guard let url = URL(string: urlString), url.host != nil else { return }
         _ = routerPath.handle(url: url)
       })
       .onAppear {


### PR DESCRIPTION
Skip blank, host-less URLs so that app launchers can launch the app using just the scheme (e.g. icecubesapp://) without invoking a safari error page