### PR TITLE
Improved stretchy account header

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -25,7 +25,11 @@ struct AccountDetailHeaderView: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      headerImageView
+      Rectangle()
+        .frame(height: 200)
+        .overlay {
+            headerImageView
+        }
       accountInfoView
     }
   }

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -347,7 +347,7 @@ public struct AccountDetailView: View {
   @ToolbarContentBuilder
   private var toolbarContent: some ToolbarContent {
     ToolbarItem(placement: .principal) {
-      if scrollOffset < -200 {
+      if scrollOffset < -170 {
         switch viewModel.accountState {
         case let .data(account):
           EmojiTextApp(.init(stringValue: account.safeDisplayName), emojis: account.emojis)
@@ -531,7 +531,7 @@ public struct AccountDetailView: View {
           }
         }
       } label: {
-        if scrollOffset < -40 {
+        if scrollOffset < -5 {
           Image(systemName: "ellipsis.circle")
         } else {
           Image(systemName: "ellipsis.circle.fill")


### PR DESCRIPTION
This improves the behaviour of the sticky & stretchy header on the account detail screen. Previously pulling down resulted in the content being scrolled too fast and there was a gap between header and content. This was caused by modifying the header height which had an impact on the entire scroll view. By doing putting the header in an overlay (and keeping the rectangle above the content at a fixed height), it feels much better with a more natural resistance.

I also changed some constants to show the navigation bar title earlier and also optimized the transitioning between filled and regular ellipsis icon in the navigation bar.

https://user-images.githubusercontent.com/211709/215345560-4749430a-e659-4801-aa22-6785aee3abd5.mp4
