### PR TITLE
Better profile header

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -34,20 +34,20 @@ struct AccountDetailHeaderView: View {
     ZStack(alignment: .bottomTrailing) {
       if reasons.contains(.placeholder) {
         Rectangle()
-          .foregroundColor(.gray)
+          .foregroundColor(theme.secondaryBackgroundColor)
           .frame(height: bannerHeight)
       } else {
         LazyImage(url: account.header) { state in
           if let image = state.image {
             image
               .resizingMode(.aspectFill)
-              .overlay(.black.opacity(0.50))
+              .overlay(account.haveHeader ? .black.opacity(0.50) : .clear)
           } else if state.isLoading {
-            Color.gray
+            theme.secondaryBackgroundColor
               .frame(height: bannerHeight)
               .shimmering()
           } else {
-            Color.gray
+            theme.secondaryBackgroundColor
               .frame(height: bannerHeight)
           }
         }
@@ -64,7 +64,7 @@ struct AccountDetailHeaderView: View {
           .padding(8)
       }
     }
-    .background(Color.gray)
+    .background(theme.secondaryBackgroundColor)
     .frame(height: bannerHeight)
     .offset(y: scrollOffset > 0 ? -scrollOffset : 0)
     .contentShape(Rectangle())

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -69,6 +69,9 @@ struct AccountDetailHeaderView: View {
     .offset(y: scrollOffset > 0 ? -scrollOffset : 0)
     .contentShape(Rectangle())
     .onTapGesture {
+      guard account.haveHeader else {
+        return
+      }
       Task {
         await quickLook.prepareFor(urls: [account.header], selectedURL: account.header)
       }
@@ -79,6 +82,9 @@ struct AccountDetailHeaderView: View {
     HStack {
       AvatarView(url: account.avatar, size: .account)
         .onTapGesture {
+          guard account.haveAvatar else {
+            return
+          }
           Task {
             await quickLook.prepareFor(urls: [account.avatar], selectedURL: account.avatar)
           }

--- a/Packages/Models/Sources/Models/Account.swift
+++ b/Packages/Models/Sources/Models/Account.swift
@@ -43,6 +43,14 @@ public struct Account: Decodable, Identifiable, Equatable, Hashable {
   public let bot: Bool
   public let discoverable: Bool?
 
+  public var haveAvatar: Bool {
+    return header.lastPathComponent != "missing.png"
+  }
+
+  public var haveHeader: Bool {
+    return header.lastPathComponent != "missing.png"
+  }
+
   public static func placeholder() -> Account {
     .init(id: UUID().uuidString,
           username: "Username",

--- a/Packages/Models/Sources/Models/Account.swift
+++ b/Packages/Models/Sources/Models/Account.swift
@@ -44,7 +44,7 @@ public struct Account: Decodable, Identifiable, Equatable, Hashable {
   public let discoverable: Bool?
 
   public var haveAvatar: Bool {
-    return header.lastPathComponent != "missing.png"
+    return avatar.lastPathComponent != "missing.png"
   }
 
   public var haveHeader: Bool {


### PR DESCRIPTION
Motivation:
- When a header is missing, we can still open quicklook #127
- When a header is missing, we're using a basic gray background

Proposition:
- Stop opening header & avatar quicklook when it's missing
- Using secondary background instead of standard gray when header is missing

Before / After:
<img alt="before" src="https://user-images.githubusercontent.com/8696821/215361461-9febc020-b0a8-4d1a-8b70-9c5036c84b93.PNG" width="320"> <img alt="after" src="https://user-images.githubusercontent.com/8696821/215361460-09c74a69-c71a-414f-a0cf-2e309a02fec8.PNG" width="320">


