### PR TITLE
make share and copy links translatable

### DIFF
--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -183,6 +183,7 @@
 "account.action.unblock" = "Desbloca";
 "account.action.mute" = "Silencia";
 "account.action.unmute" = "Deixa de silenciar";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Impulsat per";
 "account.detail.about" = "Quant a";
 "account.detail.familiar-followers" = "També seguit per";
@@ -328,6 +329,8 @@
 "status.action.unfavorite" = "Desfés el preferit";
 "status.action.unpin" = "Deixa de fixar";
 "status.action.view-in-browser" = "Mostra al navegador";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Elimina l'esborrany";
 "status.draft.save" = "Desa l'esborrany";
 "status.editor.ai-prompt.correct" = "Corregeix el text";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -186,6 +186,7 @@
 "account.action.unblock" = "Blockade aufheben";
 "account.action.mute" = "Stummschalten";
 "account.action.unmute" = "Stummschaltung aufheben";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Geboostet von";
 "account.detail.about" = "Über";
 "account.detail.familiar-followers" = "Auch gefolgt von";
@@ -329,6 +330,8 @@
 "status.action.unfavorite" = "Favorit entfernen";
 "status.action.unpin" = "Nicht mehr anheften";
 "status.action.view-in-browser" = "Im Browser öffnen";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Entwurf löschen";
 "status.draft.save" = "Entwurf sichern";
 "status.editor.ai-prompt.correct" = "Text korrigieren";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -185,6 +185,7 @@
 "account.action.unblock" = "Unblock";
 "account.action.mute" = "Mute";
 "account.action.unmute" = "Unmute";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Boosted by";
 "account.detail.about" = "About";
 "account.detail.familiar-followers" = "Also followed by";
@@ -330,6 +331,8 @@
 "status.action.unfavorite" = "Unfavorite";
 "status.action.unpin" = "Unpin";
 "status.action.view-in-browser" = "View in Browser";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Delete Draft";
 "status.draft.save" = "Save Draft";
 "status.editor.ai-prompt.correct" = "Correct text";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -185,6 +185,7 @@
 "account.action.unblock" = "Desbloquear";
 "account.action.mute" = "Silenciar";
 "account.action.unmute" = "Dejar de silenciar";
+"account.action.share" = "Compartir esta cuenta";
 "account.boosted-by" = "Retooteado por";
 "account.detail.about" = "Acerca de";
 "account.detail.familiar-followers" = "Seguido también por";
@@ -330,6 +331,8 @@
 "status.action.unfavorite" = "Eliminar de favoritos";
 "status.action.unpin" = "Desfijar";
 "status.action.view-in-browser" = "Ver en navegador";
+"status.card.share" = "Compartir este enlace";
+"status.card.copy" = "Copiar este enlace";
 "status.draft.delete" = "Eliminar borrador";
 "status.draft.save" = "Guardar borrador";
 "status.editor.ai-prompt.correct" = "Corregir texto";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -184,6 +184,7 @@
 "account.action.unblock" = "Débloquer";
 "account.action.mute" = "Rendre muet";
 "account.action.unmute" = "Annuler le mode muet";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Boosté par";
 "account.detail.about" = "À propos";
 "account.detail.familiar-followers" = "Aussi suivi par";
@@ -325,6 +326,8 @@
 "status.action.unfavorite" = "Retirer des favoris";
 "status.action.unpin" = "Dépingler";
 "status.action.view-in-browser" = "Afficher dans le navigateur";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Supprimer le brouillon";
 "status.draft.save" = "Enregistrer le brouillon";
 "status.editor.ai-prompt.correct" = "Corriger le texte";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -184,6 +184,7 @@
 "account.action.unblock" = "Sblocca";
 "account.action.mute" = "Silenzia";
 "account.action.unmute" = "Sblocca";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Condiviso da";
 "account.detail.about" = "Informazioni";
 "account.detail.familiar-followers" = "Seguito, inoltre, da";
@@ -330,6 +331,8 @@
 "status.action.unfavorite" = "Rimuovi l'apprezzamento";
 "status.action.unpin" = "Non fissare";
 "status.action.view-in-browser" = "Vedi nel Browser";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Cancella la bozza";
 "status.draft.save" = "Salva la bozza";
 "status.editor.ai-prompt.correct" = "Correggi il testo";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -184,6 +184,7 @@
 "account.action.unblock" = "ブロック解除";
 "account.action.mute" = "ミュート";
 "account.action.unmute" = "ミュート解除";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "ブーストしました";
 "account.detail.about" = "詳細";
 "account.detail.familiar-followers" = "知っているかも";
@@ -329,6 +330,8 @@
 "status.action.unfavorite" = "お気に入りから外す";
 "status.action.unpin" = "固定しない";
 "status.action.view-in-browser" = "ブラウザで見る";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "下書きを削除";
 "status.draft.save" = "下書きを保存";
 "status.editor.ai-prompt.correct" = "テキストを修正する";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -185,6 +185,7 @@
 "account.action.unblock" = "차단 해제";
 "account.action.mute" = "뮤트";
 "account.action.unmute" = "뮤트 해제";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "부스트한 사용자";
 "account.detail.about" = "정보";
 "account.detail.familiar-followers" = "내가 아는 팔로워";
@@ -331,6 +332,8 @@
 "status.action.unfavorite" = "좋아요 취소";
 "status.action.unpin" = "고정 해제";
 "status.action.view-in-browser" = "브라우저에서 보기";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "삭제";
 "status.draft.save" = "임시 보관함에 저장";
 "status.editor.ai-prompt.correct" = "맞게 고치기";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -184,6 +184,7 @@
 "account.action.unblock" = "Opphev blokkering";
 "account.action.mute" = "Demp";
 "account.action.unmute" = "Opphev demping";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Forsterket av";
 "account.detail.about" = "Om";
 "account.detail.familiar-followers" = "Også fulgt av";
@@ -329,6 +330,8 @@
 "status.action.unfavorite" = "Ikke favoritt";
 "status.action.unpin" = "Løsne";
 "status.action.view-in-browser" = "Vis i nettleser";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Slett utkast";
 "status.draft.save" = "Arkiver utkast";
 "status.editor.ai-prompt.correct" = "Korrekt tekst";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -181,6 +181,7 @@
 "account.action.unblock" = "Deblokkeer";
 "account.action.mute" = "Dempen";
 "account.action.unmute" = "Dempen opheffen";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Geboost door";
 "account.detail.about" = "Over";
 "account.detail.familiar-followers" = "Ook gevolgd door";
@@ -323,6 +324,8 @@
 "status.action.unfavorite" = "Verwijder favoriet";
 "status.action.unpin" = "Maak los";
 "status.action.view-in-browser" = "Open in browser";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Verwijder concept";
 "status.draft.save" = "Bewaar concept";
 "status.editor.ai-prompt.correct" = "Corrigeer tekst";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -184,6 +184,7 @@
 "account.action.unblock" = "Odblokuj";
 "account.action.mute" = "Wycisz";
 "account.action.unmute" = "Wyłącz wyciszenie";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Podbity przez";
 "account.detail.about" = "Opis";
 "account.detail.familiar-followers" = "Obserwowany także przez";
@@ -325,6 +326,8 @@
 "status.action.unfavorite" = "Usuń z polubionych";
 "status.action.unpin" = "Odepnij";
 "status.action.view-in-browser" = "Otwórz w przeglądarce";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Usuń wersję roboczą";
 "status.draft.save" = "Zachowaj wersję roboczą";
 "status.editor.ai-prompt.correct" = "Popraw tekst";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -184,6 +184,7 @@
 "account.action.unblock" = "Desbloquear";
 "account.action.mute" = "Mutar";
 "account.action.unmute" = "Reativar";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Boosted por";
 "account.detail.about" = "Sobre";
 "account.detail.familiar-followers" = "Também seguido por";
@@ -329,6 +330,8 @@
 "status.action.unfavorite" = "Desfavoritar";
 "status.action.unpin" = "Unpin";
 "status.action.view-in-browser" = "Abrir no Navegador";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Excluir Rascunho";
 "status.draft.save" = "Salvar Rascunho";
 "status.editor.ai-prompt.correct" = "Corrigir texto";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -110,7 +110,7 @@
 "settings.section.app.footer %@" = "Uygulama Versiyonu: %@";
 "settings.section.general" = "Genel";
 "settings.support.alert.error.message" = "Uygulama içi satın alımınızda hata oluştu, lütfen tekrar deneyin.";
-"settings.support.alert.message" = "Bağışınızdan dolayı teşekkür ederiz! Minnettarız!";   
+"settings.support.alert.message" = "Bağışınızdan dolayı teşekkür ederiz! Minnettarız!";
 "settings.support.alert.title" = "Teşekkürler!";
 "settings.support.message-from-dev" = "Merhaba! Benim adım Thomas ve açık kaynak kodlu uygulamalar oluşturmayı seviyorum. Ice Cubes benim şu ana kadarki en çok gurur duyduğum projelerden biri - ve doğrusu, Mastodon ve sosyal medyanın durmadan değişen yapısı nedeniyle en çok bakım gerektireni. Eğer Ice Cubes'u kullanmaktan memnunsanız, ufak bir bağış göndermeyi düşünebilirsiniz. Bu gerçekten günümü güzelleştirir (ve uygulamanın senin için daha da düzgün çalışmasına yardımcı olur). 🚀";
 "settings.support.navigation-title" = "Ice Cubes'u destekleyin";
@@ -184,6 +184,7 @@
 "account.action.unblock" = "Engeli Kaldır";
 "account.action.mute" = "Sustur";
 "account.action.unmute" = "Susturmayı Kaldır";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "Tarafından Geliştirildi";
 "account.detail.about" = "Hakkında";
 "account.detail.familiar-followers" = "Şunlar tarafından da takip edilir";
@@ -325,6 +326,8 @@
 "status.action.unfavorite" = "Favoriyi Kaldır";
 "status.action.unpin" = "Sabitlemeyi Kaldır";
 "status.action.view-in-browser" = "Tarayıcıda Göster";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "Taslağı Sil";
 "status.draft.save" = "Taslağı Kaydet";
 "status.editor.ai-prompt.correct" = "Yazıyı Düzelt";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -184,6 +184,7 @@
 "account.action.unblock" = "取消屏蔽";
 "account.action.mute" = "免打扰";
 "account.action.unmute" = "取消免打扰";
+"account.action.share" = "Share this account";
 "account.boosted-by" = "转发";
 "account.detail.about" = "附加信息";
 "account.detail.familiar-followers" = "同样关注此账号的有";
@@ -330,6 +331,8 @@
 "status.action.unfavorite" = "取消收藏";
 "status.action.unpin" = "取消固定";
 "status.action.view-in-browser" = "在浏览器中打开";
+"status.card.share" = "Share this link";
+"status.card.copy" = "Copy this link";
 "status.draft.delete" = "删除草稿";
 "status.draft.save" = "保存草稿";
 "status.editor.ai-prompt.correct" = "检查拼写和语法";

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -500,7 +500,9 @@ public struct AccountDetailView: View {
             }
 
             if let url = account.url {
-              ShareLink(item: url)
+              ShareLink(item: url) {
+                Label("account.action.share", systemImage: "square.and.arrow.up")
+              }
               Button { UIApplication.shared.open(url) } label: {
                 Label("status.action.view-in-browser", systemImage: "safari")
               }

--- a/Packages/Status/Sources/Status/Row/StatusCardView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusCardView.swift
@@ -62,7 +62,7 @@ public struct StatusCardView: View {
       }
       .contextMenu {
         ShareLink(item: url) {
-          Label("Share this link", systemImage: "square.and.arrow.up")
+          Label("status.card.share", systemImage: "square.and.arrow.up")
         }
         Button { openURL(url) } label: {
           Label("status.action.view-in-browser", systemImage: "safari")
@@ -71,7 +71,7 @@ public struct StatusCardView: View {
         Button {
           UIPasteboard.general.url = url
         } label: {
-          Label("Copy link", systemImage: "doc.on.doc")
+          Label("status.card.copy", systemImage: "doc.on.doc")
         }
       }
     }


### PR DESCRIPTION
I was filing a ticket about the following when I realized I could just fix it, so here's an explanation of the bug, along with a PR for the fix. I'm unsure if I need to add the untranslated English one to every other language file, or if it'll automatically fall back to English. (I would guess it varies by programming language & framework.) So, if I need to add the  English as placeholders in other files, please just let me know.

The `ShareLink()` in `AccountDetailView.swift` (and elsewhere) is called without passing an argument for the label, so the text is left untranslated. For example, here's a screenshot from my phone, which is in Spanish:
![IMG_BF2AEBBAB7B2-1](https://user-images.githubusercontent.com/401264/215649263-bbbe8fbb-1f48-4feb-be51-9743ead894f9.jpeg)

Similarly, the `ShareLink` in `StatusCardView.swift` _does_ have a label, but it's a hard-coded string, not translatable. Same for the copy option.
![IMG_29F5617133DC-1](https://user-images.githubusercontent.com/401264/215649901-436a43d2-4ead-48b9-8687-52d51ba0e7d3.jpeg)
