### PR TITLE
Consolidate new notifications with the latest one

### DIFF
--- a/Packages/Models/Sources/Models/ConsolidatedNotification.swift
+++ b/Packages/Models/Sources/Models/ConsolidatedNotification.swift
@@ -1,0 +1,43 @@
+//
+//  ConsolidatedNotification.swift
+//
+//
+//  Created by Jérôme Danthinne on 31/01/2023.
+//
+
+import Foundation
+
+public struct ConsolidatedNotification: Identifiable {
+  public let notifications: [Notification]
+  public let type: Notification.NotificationType
+  public let createdAt: ServerDate
+  public let accounts: [Account]
+  public let status: Status?
+
+  public var id: String? { notifications.first?.id }
+
+  public init(notifications: [Notification],
+              type: Notification.NotificationType,
+              createdAt: ServerDate,
+              accounts: [Account],
+              status: Status?)
+  {
+    self.notifications = notifications
+    self.type = type
+    self.createdAt = createdAt
+    self.accounts = accounts
+    self.status = status
+  }
+
+  public static func placeholder() -> ConsolidatedNotification {
+    .init(notifications: [Notification.placeholder()],
+          type: .favourite,
+          createdAt: "2022-12-16T10:20:54.000Z",
+          accounts: [.placeholder()],
+          status: .placeholder())
+  }
+
+  public static func placeholders() -> [ConsolidatedNotification] {
+    [.placeholder(), .placeholder(), .placeholder(), .placeholder(), .placeholder(), .placeholder(), .placeholder(), .placeholder()]
+  }
+}

--- a/Packages/Models/Sources/Models/Notification.swift
+++ b/Packages/Models/Sources/Models/Notification.swift
@@ -14,4 +14,12 @@ public struct Notification: Decodable, Identifiable {
   public var supportedType: NotificationType? {
     .init(rawValue: type)
   }
+
+  public static func placeholder() -> Notification {
+    .init(id: UUID().uuidString,
+          type: NotificationType.favourite.rawValue,
+          createdAt: "2022-12-16T10:20:54.000Z",
+          account: .placeholder(),
+          status: .placeholder())
+  }
 }

--- a/Packages/Notifications/Sources/Notifications/ConsolidatedNotificationExt.swift
+++ b/Packages/Notifications/Sources/Notifications/ConsolidatedNotificationExt.swift
@@ -1,0 +1,18 @@
+//
+//  ConsolidatedNotificationExt.swift
+//
+//
+//  Created by Jérôme Danthinne on 31/01/2023.
+//
+
+import Models
+
+extension ConsolidatedNotification {
+  var notificationIds: [String] { notifications.map(\.id) }
+}
+
+extension Array where Element == ConsolidatedNotification {
+  var notificationCount: Int {
+    reduce(0) { $0 + ($1.accounts.isEmpty ? 1 : $1.accounts.count) }
+  }
+}

--- a/Packages/Notifications/Sources/Notifications/Notification+Consolidated.swift
+++ b/Packages/Notifications/Sources/Notifications/Notification+Consolidated.swift
@@ -1,0 +1,29 @@
+//
+//  Notification+Consolidated.swift
+//
+//
+//  Created by Jérôme Danthinne on 31/01/2023.
+//
+
+import Models
+
+extension Array where Element == Notification {
+  func consolidated(selectedType: Notification.NotificationType?) -> [ConsolidatedNotification] {
+    Dictionary(grouping: self) { $0.consolidationId(selectedType: selectedType) }
+      .values
+      .compactMap { notifications in
+        guard let notification = notifications.first,
+              let supportedType = notification.supportedType
+        else { return nil }
+
+        return ConsolidatedNotification(notifications: notifications,
+                                        type: supportedType,
+                                        createdAt: notification.createdAt,
+                                        accounts: notifications.map(\.account),
+                                        status: notification.status)
+      }
+      .sorted {
+        $0.createdAt > $1.createdAt
+      }
+  }
+}

--- a/Packages/Notifications/Sources/Notifications/NotificationExt.swift
+++ b/Packages/Notifications/Sources/Notifications/NotificationExt.swift
@@ -1,0 +1,31 @@
+//
+//  NotificationExt.swift
+//
+//
+//  Created by Jérôme Danthinne on 31/01/2023.
+//
+
+import Models
+
+extension Notification {
+  func consolidationId(selectedType: Models.Notification.NotificationType?) -> String? {
+    guard let supportedType else { return nil }
+
+    switch supportedType {
+    case .follow where selectedType != .follow:
+      // Always group followers, so use the type to group
+      return supportedType.rawValue
+    case .reblog, .favourite:
+      // Group boosts and favourites by status, so use the type + the related status id
+      return "\(supportedType.rawValue)-\(status?.id ?? "")"
+    default:
+      // Never group remaining ones, so use the notification id itself
+      return id
+    }
+  }
+
+  func isConsolidable(selectedType: Models.Notification.NotificationType?) -> Bool {
+    // Notification is consolidable onlt if the consolidation id is not the notication id (unique) itself
+    consolidationId(selectedType: selectedType) != id
+  }
+}


### PR DESCRIPTION
This remove the need of a shadow array of notifications, and try to consolidate the newly received notification with the latest notifications, if of the same type.
Made some cleanup in the Models as well not to pollute the NotificationsViewModel.