### PR TITLE
[proposal] Respect OS localization to define translation

### DIFF
--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -290,7 +290,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tradueix";
-"status.action.translate-from-%@" = "Translate from %@";
+"status.action.translate-to-%@" = "Translate to %@";
 "status.action.translated-label" = "Traduït amb DeepL.com";
 "status.action.bookmark" = "Afegeix als marcadors";
 "status.action.boost" = "Impulsa";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Übersetzen";
-"status.action.translate-from-%@" = "Übersetzen aus %@";
+"status.action.translate-to-%@" = "Übersetzen ins %@";
 "status.action.translated-label" = "Übersetzt mit DeepL.com";
 "status.action.bookmark" = "Lesezeichen";
 "status.action.boost" = "Boosten";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -291,7 +291,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
-"status.action.translate-from-%@" = "Translate from %@";
+"status.action.translate-to-%@" = "Translate to %@";
 "status.action.translated-label" = "Translated using DeepL.com";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traducir";
-"status.action.translate-from-%@" = "Traducir desde %@";
+"status.action.translate-to-%@" = "Traducir a %@";
 "status.action.translated-label" = "Traducido usando DeepL.com";
 "status.action.bookmark" = "Añadir a marcadores";
 "status.action.boost" = "Retootear";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -287,7 +287,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduire";
-"status.action.translate-from-%@" = "Traduire de %@";
+"status.action.translate-to-%@" = "Traduire en %@";
 "status.action.translated-label" = "Traduit avec DeepL.com";
 "status.action.bookmark" = "Marquer";
 "status.action.boost" = "Promouvoir";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduci";
-"status.action.translate-from-%@" = "Traduci da %@";
+"status.action.translate-to-%@" = "Traduci in %@";
 "status.action.translated-label" = "Tradotto usando DeepL.com";
 "status.action.bookmark" = "Salva nei segnalibri";
 "status.action.boost" = "Condividi";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -291,7 +291,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻訳";
-"status.action.translate-from-%@" = "翻訳 %@";
+"status.action.translate-to-%@" = "翻訳 %@";
 "status.action.translated-label" = "DeepL.comを使用して翻訳";
 "status.action.bookmark" = "ブックマーク";
 "status.action.boost" = "ブースト";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -291,7 +291,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "번역";
-"status.action.translate-from-%@" = "%@에서 번역";
+"status.action.translate-to-%@" = "%@에서 번역";
 "status.action.translated-label" = "DeepL.com을 통해 번역됨";
 "status.action.bookmark" = "보관함에 추가";
 "status.action.boost" = "부스트";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -291,7 +291,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Oversett";
-"status.action.translate-from-%@" = "Oversett fra %@";
+"status.action.translate-to-%@" = "Oversett til %@";
 "status.action.translated-label" = "Oversatt ved hjelp av DeepL.com";
 "status.action.bookmark" = "Bokmerk";
 "status.action.boost" = "Forsterk";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -285,7 +285,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Vertaal";
-"status.action.translate-from-%@" = "Vertaal uit het %@";
+"status.action.translate-to-%@" = "Vertalen naar %@";
 "status.action.translated-label" = "Vertaald met behulp van DeepL.com";
 "status.action.bookmark" = "Voeg bladwijzer toe";
 "status.action.boost" = "Boosten";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Przetłumacz";
-"status.action.translate-from-%@" = "Przetłumacz z %@";
+"status.action.translate-to-%@" = "Przetłumacz na %@";
 "status.action.translated-label" = "Przetłumaczono za pomocą DeepL.com";
 "status.action.bookmark" = "Dodaj zakładkę";
 "status.action.boost" = "Podbij";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -291,7 +291,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduzir";
-"status.action.translate-from-%@" = "Translate from %@";
+"status.action.translate-to-%@" = "Traduzir para %@";
 "status.action.translated-label" = "Traduzir usando DeepL.com";
 "status.action.bookmark" = "Salvar";
 "status.action.boost" = "Boost";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -273,7 +273,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tercüme et";
-"status.action.translate-from-%@" = "Tercüme et %@";
+"status.action.translate-to-%@" = "Tercüme etmek %@";
 "status.action.translated-label" = "DeepL.com tarafından tercüme edildi";
 "status.action.bookmark" = "Yer İmi Ekle";
 "status.action.boost" = "Yükselt";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻译";
-"status.action.translate-from-%@" = "翻译 %@";
+"status.action.translate-to-%@" = "翻译 %@";
 "status.action.translated-label" = "由 DeepL.com 翻译";
 "status.action.bookmark" = "书签";
 "status.action.boost" = "转发";

--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -77,7 +77,7 @@ struct StatusRowContextMenu: View {
       Label("status.action.copy-text", systemImage: "doc.on.doc")
     }
 
-    if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier,
+    if let lang = Locale.current.language.languageCode?.identifier ?? preferences.serverPreferences?.postLanguage,
        viewModel.status.language != lang
     {
       Button {
@@ -88,7 +88,7 @@ struct StatusRowContextMenu: View {
         if let statusLanguage = viewModel.status.language,
            let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage)
         {
-          Label("status.action.translate-from-\(languageName)", systemImage: "captions.bubble")
+          Label("status.action.translate-to-\(languageName)", systemImage: "captions.bubble")
         } else {
           Label("status.action.translate", systemImage: "captions.bubble")
         }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -322,7 +322,7 @@ public struct StatusRowView: View {
           if let statusLanguage = status.language,
              let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage)
           {
-            Text("status.action.translate-from-\(languageName)")
+            Text("status.action.translate-to-\(languageName)")
           } else {
             Text("status.action.translate")
           }


### PR DESCRIPTION
The translation button is only visible for toot's that are in my operating system language. I think it makes more sense to respect the system configuration and present the button for all other languages.