### PR TITLE
Add option to start in-app browser in reader view.

### DIFF
--- a/IceCubesApp/App/SafariRouter.swift
+++ b/IceCubesApp/App/SafariRouter.swift
@@ -46,23 +46,25 @@ private struct SafariRouter: ViewModifier {
             return .systemAction
           }
 
-
-
           presentedURL = url
           return .handled
         }
       }
       .sheet(item: $presentedURL, content: { url in
-        SafariView(url: url)
+        SafariView(url: url, inAppBrowserReaderView: preferences.inAppBrowserReaderView)
           .edgesIgnoringSafeArea(.all)
       })
   }
 
   struct SafariView: UIViewControllerRepresentable {
     let url: URL
-
+    let inAppBrowserReaderView: Bool
+         
     func makeUIViewController(context _: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
-      let safari = SFSafariViewController(url: url)
+      let configuration = SFSafariViewController.Configuration()
+      configuration.entersReaderIfAvailable = inAppBrowserReaderView
+
+      let safari = SFSafariViewController(url: url, configuration: configuration)
       safari.preferredBarTintColor = UIColor(Theme.shared.primaryBackgroundColor)
       safari.preferredControlTintColor = UIColor(Theme.shared.tintColor)
       return safari

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -129,11 +129,10 @@ struct SettingsTabs: View {
         } label: {
           Label("settings.general.browser", systemImage: "network")
         }
-        if(preferences.preferredBrowser == PreferredBrowser.inAppSafari) {
-          Toggle(isOn: $preferences.inAppBrowserReaderView) {
-            Label("settings.general.browser.in-app.readerview", systemImage: "doc.plaintext")
-          }
+        Toggle(isOn: $preferences.inAppBrowserReaderView) {
+          Label("settings.general.browser.in-app.readerview", systemImage: "doc.plaintext")
         }
+        .disabled(preferences.preferredBrowser != PreferredBrowser.inAppSafari)
       }
       Toggle(isOn: $preferences.isOpenAIEnabled) {
         Label("settings.other.hide-openai", systemImage: "faxmachine")

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -129,6 +129,11 @@ struct SettingsTabs: View {
         } label: {
           Label("settings.general.browser", systemImage: "network")
         }
+        if(preferences.preferredBrowser == PreferredBrowser.inAppSafari) {
+          Toggle(isOn: $preferences.inAppBrowserReaderView) {
+            Label("settings.general.browser.in-app.readerview", systemImage: "doc.plaintext")
+          }
+        }
       }
       Toggle(isOn: $preferences.isOpenAIEnabled) {
         Label("settings.other.hide-openai", systemImage: "faxmachine")

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.general.browser" = "Navegador";
 "settings.general.browser.in-app" = "Navegador integrat";
 "settings.general.browser.system" = "Navegador del sistema";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.display" = "Configuració d'aparença";
 "settings.general.instance" = "Informació de la instància";
 "settings.general.push-notifications" = "Notificacions emergents";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.display.theme.systemColor" = "Systemeinstellung verwenden";
 "settings.general.browser" = "Browser";
 "settings.general.browser.in-app" = "In-App-Browser";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "Systembrowser";
 "settings.general.display" = "Anzeigeeinstellungen";
 "settings.general.instance" = "Instanz-Informationen";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "settings.display.theme.systemColor" = "Match System";
 "settings.general.browser" = "Browser";
 "settings.general.browser.in-app" = "In-App Browser";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "System Browser";
 "settings.general.display" = "Display Settings";
 "settings.general.instance" = "Instance Information";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "settings.display.theme.systemColor" = "Match System";
 "settings.general.browser" = "Browser";
 "settings.general.browser.in-app" = "In-App Browser";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "System Browser";
 "settings.general.display" = "Display Settings";
 "settings.general.instance" = "Instance Information";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.display.theme.systemColor" = "Sistema de coincidencia";
 "settings.general.browser" = "Navegador";
 "settings.general.browser.in-app" = "Interno";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "Sistema";
 "settings.general.display" = "Ajustes de apariencia";
 "settings.general.instance" = "Información de la instancia";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.display.theme.systemColor" = "Correspondre au système";
 "settings.general.browser" = "Navigateur";
 "settings.general.browser.in-app" = "Navigateur intégré";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "Navigateur système";
 "settings.general.display" = "Paramètres d'affichage";
 "settings.general.instance" = "Information sur l'instance";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -74,6 +74,7 @@
 "settings.general.browser" = "Browser";
 "settings.general.browser.in-app" = "In-App Browser";
 "settings.general.browser.system" = "Browser di sistema";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.display" = "Impostazioni di visualizzazione";
 "settings.general.instance" = "Informazioni sull'istanza";
 "settings.general.push-notifications" = "Notifiche";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "settings.display.theme.systemColor" = "システムに合わせる";
 "settings.general.browser" = "ブラウザ";
 "settings.general.browser.in-app" = "アプリ内ブラウザ";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "システムブラウザ";
 "settings.general.display" = "表示設定";
 "settings.general.instance" = "インスタンス情報";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.display.theme.systemColor" = "시스템 설정에 맞추기";
 "settings.general.browser" = "브라우저";
 "settings.general.browser.in-app" = "인 앱 브라우저";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "시스템 기본 브라우저";
 "settings.general.display" = "화면 설정";
 "settings.general.instance" = "인스턴스 정보";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "settings.display.theme.systemColor" = "Match system";
 "settings.general.browser" = "Nettleser";
 "settings.general.browser.in-app" = "Nettleser i appen";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "Systemnettleser";
 "settings.general.display" = "Visningsinnstillinger";
 "settings.general.instance" = "Instansinformasjon";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.display.theme.systemColor" = "Automatisch";
 "settings.general.browser" = "Browser";
 "settings.general.browser.in-app" = "In-app";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "Systeem";
 "settings.general.display" = "Weergaveopties";
 "settings.general.instance" = "Instantie-informatie";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.display.theme.systemColor" = "Zgodny z systemowym";
 "settings.general.browser" = "Przeglądarka";
 "settings.general.browser.in-app" = "W aplikacji";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "Systemowa";
 "settings.general.display" = "Ustawienia ekranu";
 "settings.general.instance" = "Informacja o serwerze";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.display.theme.systemColor" = "Padrão do Sistema";
 "settings.general.browser" = "Navegador";
 "settings.general.browser.in-app" = "Navegador do App";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "Navegador do sistema";
 "settings.general.display" = "Exibir configurações";
 "settings.general.instance" = "Informação da Instância";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -74,6 +74,7 @@
 "settings.general.browser" = "Tarayıcı";
 "settings.general.browser.in-app" = "Uygulama İçi Tarayıcı";
 "settings.general.browser.system" = "Sistem Tarayıcısı";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.display" = "Gösterim Ayarları";
 "settings.general.instance" = "Oluşum Bilgisi";
 "settings.general.push-notifications" = "İleti Bildirimleri";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.display.theme.systemColor" = "匹配系统";
 "settings.general.browser" = "默认浏览器";
 "settings.general.browser.in-app" = "应用内浏览器";
+"settings.general.browser.in-app.readerview" = "In-App Browser Reader View";
 "settings.general.browser.system" = "系统浏览器";
 "settings.general.display" = "显示设置";
 "settings.general.instance" = "服务器设置";

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -30,6 +30,8 @@ public class UserPreferences: ObservableObject {
 
   @AppStorage("suppress_dupe_reblogs") public var suppressDupeReblogs: Bool = false
   
+  @AppStorage("inAppBrowserReaderView") public var inAppBrowserReaderView = false
+  
   public var postVisibility: Models.Visibility {
     if useInstanceContentSettings {
       return serverPreferences?.postVisibility ?? .pub


### PR DESCRIPTION
This PR adds a settings toggle (only when the in-app browser is selected) to choose whether the in-app browser should open the link in the reader view and passes this flag to the browser.

Closes #269