### PR TITLE
Fix translate button for boosts in context menu

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -76,16 +76,15 @@ struct StatusRowContextMenu: View {
     }
 
     if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier,
-       viewModel.status.language != lang
+       let statusLanguage = viewModel.status.reblog?.language ?? viewModel.status.language,
+       statusLanguage != lang
     {
       Button {
         Task {
           await viewModel.translate(userLang: lang)
         }
       } label: {
-        if let statusLanguage = viewModel.status.language,
-           let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage)
-        {
+        if let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage) {
           Label("status.action.translate-from-\(languageName)", systemImage: "captions.bubble")
         } else {
           Label("status.action.translate", systemImage: "captions.bubble")


### PR DESCRIPTION
Boosted posts would not show the correct "Translate" button in the context menu. Instead, the booster's default language decided if the button was visible.
This PR fixes this.

Screenshot of how it was before (expected button text: "Translate from Spanish"):
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-03 at 11 38 09](https://user-images.githubusercontent.com/38211057/216580984-9f82ea28-e7d1-4b09-933e-2ce929bf7f69.png)

