### PR TITLE
Update SideBarView.swift

### DIFF
--- a/IceCubesApp/App/SideBarView.swift
+++ b/IceCubesApp/App/SideBarView.swift
@@ -132,7 +132,7 @@ struct SideBarView<Content: View>: View {
       .scrollContentBackground(.hidden)
       .background(.thinMaterial)
       Divider()
-        .edgesIgnoringSafeArea(.top)
+        .ignoresSafeArea(edges: .bottom)
       content()
     }
     .background(.thinMaterial)


### PR DESCRIPTION
Change .edgesIgnoringSafeArea(.top) -> .ignoresSafeArea(edges: .bottom) on line 135 (Divider). On iPad with SideBarView, the divider would cut into the status bar clock