### PR TITLE
Clean up HapticManager

### DIFF
--- a/IceCubesApp/App/IceCubesApp.swift
+++ b/IceCubesApp/App/IceCubesApp.swift
@@ -140,9 +140,7 @@ struct IceCubesApp: App {
         }
       }
       selectedTab = newTab
-      if userPreferences.hapticTabSelectionEnabled {
-        HapticManager.shared.selectionChanged()
-      }
+      HapticManager.shared.fireHaptic(of: .tabSelection)
     })) {
       ForEach(availableTabs) { tab in
         tab.makeContentView(popToRootTab: $popToRootTab)

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -102,9 +102,11 @@ struct SettingsTabs: View {
       NavigationLink(destination: DisplaySettingsView()) {
         Label("settings.general.display", systemImage: "paintpalette")
       }
-      NavigationLink(destination: HapticSettingsView()) {
-        Label("settings.general.haptic", systemImage: "waveform.path")
-      }
+        if HapticManager.shared.supportsHaptics {
+            NavigationLink(destination: HapticSettingsView()) {
+                Label("settings.general.haptic", systemImage: "waveform.path")
+            }
+        }
       NavigationLink(destination: remoteLocalTimelinesView) {
         Label("settings.general.remote-timelines", systemImage: "dot.radiowaves.right")
       }

--- a/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
@@ -38,9 +38,7 @@ public struct AppAccountsSelectorView: View {
       }
     }
     .onTapGesture {
-      if UserPreferences.shared.hapticButtonPressEnabled {
-        HapticManager.shared.impact()
-      }
+      HapticManager.shared.fireHaptic(of: .buttonPress)
     }
     .onAppear {
       refreshAccounts()
@@ -80,9 +78,7 @@ public struct AppAccountsSelectorView: View {
             appAccounts.currentAccount = viewModel.appAccount
           }
 
-          if UserPreferences.shared.hapticButtonPressEnabled {
-            HapticManager.shared.impact()
-          }
+          HapticManager.shared.fireHaptic(of: .buttonPress)
         } label: {
           HStack {
             if viewModel.account?.id == currentAccount.account?.id {
@@ -96,9 +92,7 @@ public struct AppAccountsSelectorView: View {
     if accountCreationEnabled {
       Divider()
       Button {
-        if UserPreferences.shared.hapticButtonPressEnabled {
-          HapticManager.shared.impact()
-        }
+        HapticManager.shared.fireHaptic(of: .buttonPress)
         routerPath.presentedSheet = .addAccount
       } label: {
         Label("app-account.button.add", systemImage: "person.badge.plus")
@@ -108,9 +102,7 @@ public struct AppAccountsSelectorView: View {
     if UIDevice.current.userInterfaceIdiom == .phone {
       Divider()
       Button {
-        if UserPreferences.shared.hapticButtonPressEnabled {
-          HapticManager.shared.impact()
-        }
+        HapticManager.shared.fireHaptic(of: .buttonPress)
         routerPath.presentedSheet = .settings
       } label: {
         Label("tab.settings", systemImage: "gear")

--- a/Packages/DesignSystem/Sources/DesignSystem/Views/StatusEditorToolbarItem.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/StatusEditorToolbarItem.swift
@@ -8,9 +8,7 @@ public extension View {
     ToolbarItem(placement: .navigationBarTrailing) {
       Button {
         routerPath.presentedSheet = .newStatusEditor(visibility: visibility)
-        if UserPreferences.shared.hapticButtonPressEnabled {
-          HapticManager.shared.impact()
-        }
+        HapticManager.shared.fireHaptic(of: .buttonPress)
       } label: {
         Image(systemName: "square.and.pencil")
       }
@@ -31,9 +29,7 @@ public struct StatusEditorToolbarItem: ToolbarContent {
     ToolbarItem(placement: .navigationBarTrailing) {
       Button {
         routerPath.presentedSheet = .newStatusEditor(visibility: visibility)
-        if UserPreferences.shared.hapticButtonPressEnabled {
-          HapticManager.shared.impact()
-        }
+        HapticManager.shared.fireHaptic(of: .buttonPress)
       } label: {
         Image(systemName: "square.and.pencil")
       }

--- a/Packages/Env/Sources/Env/HapticManager.swift
+++ b/Packages/Env/Sources/Env/HapticManager.swift
@@ -27,4 +27,8 @@ public class HapticManager {
   public func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
     notificationGenerator.notificationOccurred(type)
   }
+
+    public var supportsHaptics: Bool {
+        CHHapticEngine.capabilitiesForHardware().supportsHaptics
+    }
 }

--- a/Packages/Env/Sources/Env/HapticManager.swift
+++ b/Packages/Env/Sources/Env/HapticManager.swift
@@ -1,34 +1,73 @@
+import CoreHaptics
 import UIKit
 
 public class HapticManager {
   public static let shared: HapticManager = .init()
 
+  public enum HapticType {
+    case buttonPress
+    case notification(_ type: UINotificationFeedbackGenerator.FeedbackType)
+    case dataRefersh(intensity: CGFloat)
+    case tabSelection
+    case timeline
+  }
+
   private let selectionGenerator = UISelectionFeedbackGenerator()
   private let impactGenerator = UIImpactFeedbackGenerator(style: .heavy)
   private let notificationGenerator = UINotificationFeedbackGenerator()
+
+  private let userPreferences = UserPreferences.shared
 
   private init() {
     selectionGenerator.prepare()
     impactGenerator.prepare()
   }
 
-  public func selectionChanged() {
+  @MainActor
+  public func fireHaptic(of type: HapticType) {
+    guard supportsHaptics else { return }
+
+    switch type {
+    case let .dataRefersh(intensity):
+      if userPreferences.hapticTimelineEnabled {
+        impact(intensity: intensity)
+      }
+    case .timeline:
+      if userPreferences.hapticTimelineEnabled {
+        selectionChanged()
+      }
+    case .tabSelection:
+      if userPreferences.hapticTabSelectionEnabled {
+        selectionChanged()
+      }
+    case .buttonPress:
+      if userPreferences.hapticButtonPressEnabled {
+        impact()
+      }
+    case let .notification(type):
+      if userPreferences.hapticButtonPressEnabled {
+        notification(type)
+      }
+    }
+  }
+
+  private func selectionChanged() {
     selectionGenerator.selectionChanged()
   }
 
-  public func impact() {
+  private func impact() {
     impactGenerator.impactOccurred()
   }
 
-  public func impact(intensity: CGFloat) {
+  private func impact(intensity: CGFloat) {
     impactGenerator.impactOccurred(intensity: intensity)
   }
 
-  public func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
+  private func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
     notificationGenerator.notificationOccurred(type)
   }
 
-    public var supportsHaptics: Bool {
-        CHHapticEngine.capabilitiesForHardware().supportsHaptics
-    }
+  public var supportsHaptics: Bool {
+    CHHapticEngine.capabilitiesForHardware().supportsHaptics
+  }
 }

--- a/Packages/Env/Sources/Env/HapticManager.swift
+++ b/Packages/Env/Sources/Env/HapticManager.swift
@@ -6,7 +6,7 @@ public class HapticManager {
 
   public enum HapticType {
     case buttonPress
-    case dataRefersh(intensity: CGFloat)
+    case dataRefresh(intensity: CGFloat)
     case notification(_ type: UINotificationFeedbackGenerator.FeedbackType)
     case tabSelection
     case timeline
@@ -32,7 +32,7 @@ public class HapticManager {
       if userPreferences.hapticButtonPressEnabled {
         impact()
       }
-    case let .dataRefersh(intensity):
+    case let .dataRefresh(intensity):
       if userPreferences.hapticTimelineEnabled {
         impact(intensity: intensity)
       }

--- a/Packages/Env/Sources/Env/HapticManager.swift
+++ b/Packages/Env/Sources/Env/HapticManager.swift
@@ -6,8 +6,8 @@ public class HapticManager {
 
   public enum HapticType {
     case buttonPress
-    case notification(_ type: UINotificationFeedbackGenerator.FeedbackType)
     case dataRefersh(intensity: CGFloat)
+    case notification(_ type: UINotificationFeedbackGenerator.FeedbackType)
     case tabSelection
     case timeline
   }
@@ -28,25 +28,25 @@ public class HapticManager {
     guard supportsHaptics else { return }
 
     switch type {
+    case .buttonPress:
+      if userPreferences.hapticButtonPressEnabled {
+        impact()
+      }
     case let .dataRefersh(intensity):
       if userPreferences.hapticTimelineEnabled {
         impact(intensity: intensity)
       }
-    case .timeline:
-      if userPreferences.hapticTimelineEnabled {
-        selectionChanged()
+    case let .notification(type):
+      if userPreferences.hapticButtonPressEnabled {
+        notification(type)
       }
     case .tabSelection:
       if userPreferences.hapticTabSelectionEnabled {
         selectionChanged()
       }
-    case .buttonPress:
-      if userPreferences.hapticButtonPressEnabled {
-        impact()
-      }
-    case let .notification(type):
-      if userPreferences.hapticButtonPressEnabled {
-        notification(type)
+    case .timeline:
+      if userPreferences.hapticTimelineEnabled {
+        selectionChanged()
       }
     }
   }

--- a/Packages/Env/Sources/Env/HapticManager.swift
+++ b/Packages/Env/Sources/Env/HapticManager.swift
@@ -30,41 +30,25 @@ public class HapticManager {
     switch type {
     case .buttonPress:
       if userPreferences.hapticButtonPressEnabled {
-        impact()
+        impactGenerator.impactOccurred()
       }
     case let .dataRefresh(intensity):
       if userPreferences.hapticTimelineEnabled {
-        impact(intensity: intensity)
+        impactGenerator.impactOccurred(intensity: intensity)
       }
     case let .notification(type):
       if userPreferences.hapticButtonPressEnabled {
-        notification(type)
+        notificationGenerator.notificationOccurred(type)
       }
     case .tabSelection:
       if userPreferences.hapticTabSelectionEnabled {
-        selectionChanged()
+        selectionGenerator.selectionChanged()
       }
     case .timeline:
       if userPreferences.hapticTimelineEnabled {
-        selectionChanged()
+        selectionGenerator.selectionChanged()
       }
     }
-  }
-
-  private func selectionChanged() {
-    selectionGenerator.selectionChanged()
-  }
-
-  private func impact() {
-    impactGenerator.impactOccurred()
-  }
-
-  private func impact(intensity: CGFloat) {
-    impactGenerator.impactOccurred(intensity: intensity)
-  }
-
-  private func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
-    notificationGenerator.notificationOccurred(type)
   }
 
   public var supportsHaptics: Bool {

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -174,9 +174,7 @@ public class StatusEditorViewModel: ObservableObject {
       case let .edit(status):
         postStatus = try await client.put(endpoint: Statuses.editStatus(id: status.id, json: data))
       }
-      if UserPreferences.shared.hapticButtonPressEnabled {
-        HapticManager.shared.notification(type: .success)
-      }
+      HapticManager.shared.fireHaptic(of: .notification(.success))
       if hasExplicitlySelectedLanguage, let selectedLanguage {
         preferences?.markLanguageAsSelected(isoCode: selectedLanguage)
       }
@@ -188,9 +186,7 @@ public class StatusEditorViewModel: ObservableObject {
         showPostingErrorAlert = true
       }
       isPosting = false
-      if UserPreferences.shared.hapticButtonPressEnabled {
-        HapticManager.shared.notification(type: .error)
-      }
+      HapticManager.shared.fireHaptic(of: .notification(.error))
       return nil
     }
   }

--- a/Packages/Status/Sources/Status/Row/StatusActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusActionsView.swift
@@ -179,9 +179,7 @@ struct StatusActionsView: View {
 
   private func handleAction(action: Actions) {
     Task {
-      if UserPreferences.shared.hapticButtonPressEnabled {
-        HapticManager.shared.notification(type: .success)
-      }
+      HapticManager.shared.fireHaptic(of: .notification(.success))
       switch action {
       case .respond:
         routerPath.presentedSheet = .replyToStatusEditor(status: viewModel.status)

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -425,9 +425,7 @@ public struct StatusRowView: View {
   private var trailinSwipeActions: some View {
     Button {
       Task {
-        if UserPreferences.shared.hapticButtonPressEnabled {
-          HapticManager.shared.notification(type: .success)
-        }
+        HapticManager.shared.fireHaptic(of: .notification(.success))
         if viewModel.isFavorited {
           await viewModel.unFavorite()
         } else {
@@ -440,9 +438,7 @@ public struct StatusRowView: View {
     .tint(.yellow)
     Button {
       Task {
-        if UserPreferences.shared.hapticButtonPressEnabled {
-          HapticManager.shared.notification(type: .success)
-        }
+        HapticManager.shared.fireHaptic(of: .notification(.success))
         if viewModel.isReblogged {
           await viewModel.unReblog()
         } else {
@@ -458,9 +454,7 @@ public struct StatusRowView: View {
   @ViewBuilder
   private var leadingSwipeActions: some View {
     Button {
-      if UserPreferences.shared.hapticButtonPressEnabled {
-        HapticManager.shared.notification(type: .success)
-      }
+      HapticManager.shared.fireHaptic(of: .notification(.success))
       routerPath.presentedSheet = .replyToStatusEditor(status: viewModel.status)
     } label: {
       Image(systemName: "arrowshape.turn.up.left")

--- a/Packages/Timeline/Sources/Timeline/PendingStatusesObserver.swift
+++ b/Packages/Timeline/Sources/Timeline/PendingStatusesObserver.swift
@@ -19,9 +19,7 @@ class PendingStatusesObserver: ObservableObject {
   func removeStatus(status: Status) {
     if !disableUpdate, let index = pendingStatuses.firstIndex(of: status.id) {
       pendingStatuses.removeSubrange(index ... (pendingStatuses.count - 1))
-      if UserPreferences.shared.hapticTimelineEnabled {
-        HapticManager.shared.selectionChanged()
-      }
+      HapticManager.shared.fireHaptic(of: .timeline)
     }
   }
 

--- a/Packages/Timeline/Sources/Timeline/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineView.swift
@@ -112,13 +112,9 @@ public struct TimelineView: View {
       viewModel.isTimelineVisible = false
     }
     .refreshable {
-      if UserPreferences.shared.hapticTimelineEnabled {
-        HapticManager.shared.impact(intensity: 0.3)
-      }
+      HapticManager.shared.fireHaptic(of: .dataRefersh(intensity: 0.3))
       await viewModel.fetchStatuses()
-      if UserPreferences.shared.hapticTimelineEnabled {
-        HapticManager.shared.impact(intensity: 0.7)
-      }
+      HapticManager.shared.fireHaptic(of: .dataRefersh(intensity: 0.7))
     }
     .onChange(of: watcher.latestEvent?.id) { _ in
       if let latestEvent = watcher.latestEvent {

--- a/Packages/Timeline/Sources/Timeline/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineView.swift
@@ -112,9 +112,9 @@ public struct TimelineView: View {
       viewModel.isTimelineVisible = false
     }
     .refreshable {
-      HapticManager.shared.fireHaptic(of: .dataRefersh(intensity: 0.3))
+      HapticManager.shared.fireHaptic(of: .dataRefresh(intensity: 0.3))
       await viewModel.fetchStatuses()
-      HapticManager.shared.fireHaptic(of: .dataRefersh(intensity: 0.7))
+      HapticManager.shared.fireHaptic(of: .dataRefresh(intensity: 0.7))
     }
     .onChange(of: watcher.latestEvent?.id) { _ in
       if let latestEvent = watcher.latestEvent {


### PR DESCRIPTION
1. The view now only knows that it wants to _fire_ a haptic event.
2. The HapticManager verifies the user's settings before firing a haptic event.
3. Haptic setting menu will **not** show up if the device does not support haptics (for instance, an iPad).