### PR TITLE
[CRASH AT START-UP] Revert emjoi fix due to startup crash

### DIFF
--- a/Packages/Models/Sources/Models/Alias/HTMLString.swift
+++ b/Packages/Models/Sources/Models/Alias/HTMLString.swift
@@ -11,10 +11,10 @@ public struct HTMLString: Codable, Equatable, Hashable {
   public var asMarkdown: String = ""
   public var asRawText: String = ""
   public var statusesURLs = [URL]()
-  
+
   public var asSafeMarkdownAttributedString: AttributedString = .init()
-  private var main_regex: NSRegularExpression?
-  private var underscore_regex: NSRegularExpression?
+  private var regex: NSRegularExpression?
+
   public init(from decoder: Decoder) {
     var alreadyDecoded: Bool = false
     do {
@@ -38,9 +38,7 @@ public struct HTMLString: Codable, Equatable, Hashable {
       // Pre-escape \ ` _ * and [ as these are the only
       // characters the markdown parser used picks up
       // when it renders to attributed text
-      main_regex = try? NSRegularExpression(pattern: "([\\*\\`\\[\\\\])", options: .caseInsensitive)
-      // don't escape underscores that are between colons, they are most likely custom emoji
-      underscore_regex = try? NSRegularExpression(pattern: "(?!\\B:[^:]*)(_)(?![^:]*:\\B)", options: .caseInsensitive)
+      regex = try? NSRegularExpression(pattern: "([\\_\\*\\`\\[\\\\])", options: .caseInsensitive)
 
       asMarkdown = ""
       do {
@@ -67,7 +65,7 @@ public struct HTMLString: Codable, Equatable, Hashable {
         asRawText = htmlValue
       }
     }
-    
+
     do {
       let options = AttributedString.MarkdownParsingOptions(allowsExtendedAttributes: true,
                                                             interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -152,10 +150,9 @@ public struct HTMLString: Codable, Equatable, Hashable {
       } else if node.nodeName() == "#text" {
         var txt = node.description
 
-        if let underscore_regex, let main_regex {
+        if let regex {
           //  This is the markdown escaper
-          txt = main_regex.stringByReplacingMatches(in: txt, options: [], range: NSRange(location: 0, length: txt.count), withTemplate: "\\\\$1")
-          txt = underscore_regex.stringByReplacingMatches(in: txt, options: [], range: NSRange(location: 0, length: txt.count), withTemplate: "\\\\$1")
+          txt = regex.stringByReplacingMatches(in: txt, options: [], range: NSRange(location: 0, length: txt.count), withTemplate: "\\\\$1")
         }
 
         asMarkdown += txt


### PR DESCRIPTION
I did an "erase all content and settings" on my simulator and ran into this start-up crasher.

<img width="1717" alt="CleanShot 2023-02-07 at 05 22 59@2x" src="https://user-images.githubusercontent.com/169561/217232649-ce5b1dee-7ce1-4606-bd32-ebb833b6a188.png">

The crash appears to be due to the regex update in #687. After reverting this, everything started to work again.