### PR TITLE
Fix Conversation.lastStatus nullability issue

### DIFF
--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationDetailView.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationDetailView.swift
@@ -113,12 +113,14 @@ public struct ConversationDetailView: View {
   private var inputTextView: some View {
     VStack {
       HStack(alignment: .bottom, spacing: 8) {
-        Button {
-          routerPath.presentedSheet = .replyToStatusEditor(status: viewModel.conversation.lastStatus)
-        } label: {
-          Image(systemName: "plus")
+        if viewModel.conversation.lastStatus != nil {
+          Button {
+            routerPath.presentedSheet = .replyToStatusEditor(status: viewModel.conversation.lastStatus!)
+          } label: {
+            Image(systemName: "plus")
+          }
+          .padding(.bottom, 7)
         }
-        .padding(.bottom, 7)
 
         TextField("conversations.new.message.placeholder", text: $viewModel.newMessageText, axis: .vertical)
           .focused($isMessageFieldFocused)

--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationDetailViewModel.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationDetailViewModel.swift
@@ -17,7 +17,7 @@ class ConversationDetailViewModel: ObservableObject {
 
   init(conversation: Conversation) {
     self.conversation = conversation
-    messages = [conversation.lastStatus]
+    messages = conversation.lastStatus != nil ?  [conversation.lastStatus!] : []
   }
 
   func fetchMessages() async {
@@ -64,7 +64,9 @@ class ConversationDetailViewModel: ObservableObject {
               event.conversation.id == conversation.id
     {
       conversation = event.conversation
-      appendNewStatus(status: conversation.lastStatus)
+      if conversation.lastStatus != nil {
+        appendNewStatus(status: conversation.lastStatus!)
+      }
     }
   }
 

--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
@@ -60,8 +60,8 @@ struct ConversationMessageView: View {
           .padding(.leading, isOwnMessage ? 24 : 0)
           .padding(.trailing, isOwnMessage ? 0 : 24)
       }
-
-      if message.id == conversation.lastStatus.id {
+      
+      if message.id == String(conversation.lastStatus?.id ?? "")  {
         HStack {
           if isOwnMessage {
             Spacer()

--- a/Packages/Conversations/Sources/Conversations/List/ConversationsListRow.swift
+++ b/Packages/Conversations/Sources/Conversations/List/ConversationsListRow.swift
@@ -75,6 +75,8 @@ struct ConversationsListRow: View {
           .contentShape(Rectangle())
       }
     }
+    .padding(.leading, 48)
+    .foregroundColor(.gray)
   }
 
   @ViewBuilder

--- a/Packages/Conversations/Sources/Conversations/List/ConversationsListRow.swift
+++ b/Packages/Conversations/Sources/Conversations/List/ConversationsListRow.swift
@@ -31,10 +31,12 @@ struct ConversationsListRow: View {
                 .foregroundColor(theme.tintColor)
                 .frame(width: 10, height: 10)
             }
-            Text(conversation.lastStatus.createdAt.relativeFormatted)
-              .font(.scaledFootnote)
+            if conversation.lastStatus != nil {
+              Text(conversation.lastStatus!.createdAt.relativeFormatted)
+                .font(.scaledFootnote)
+            }
           }
-          EmojiTextApp(conversation.lastStatus.content, emojis: conversation.lastStatus.emojis)
+          EmojiTextApp(conversation.lastStatus?.content ?? HTMLString(stringValue: ""), emojis: conversation.lastStatus?.emojis ?? [])
             .multilineTextAlignment(.leading)
             .font(.scaledBody)
         }
@@ -48,8 +50,10 @@ struct ConversationsListRow: View {
         routerPath.navigate(to: .conversationDetail(conversation: conversation))
       }
       .padding(.top, 4)
-      actionsView
-        .padding(.bottom, 4)
+      if conversation.lastStatus != nil {
+        actionsView
+          .padding(.bottom, 4)
+      }
     }
     .contextMenu {
       contextMenu
@@ -59,7 +63,7 @@ struct ConversationsListRow: View {
   private var actionsView: some View {
     HStack(spacing: 12) {
       Button {
-        routerPath.presentedSheet = .replyToStatusEditor(status: conversation.lastStatus)
+        routerPath.presentedSheet = .replyToStatusEditor(status: conversation.lastStatus!)
       } label: {
         Image(systemName: "arrowshape.turn.up.left.fill")
       }
@@ -71,8 +75,6 @@ struct ConversationsListRow: View {
           .contentShape(Rectangle())
       }
     }
-    .padding(.leading, 48)
-    .foregroundColor(.gray)
   }
 
   @ViewBuilder

--- a/Packages/Conversations/Sources/Conversations/List/ConversationsListViewModel.swift
+++ b/Packages/Conversations/Sources/Conversations/List/ConversationsListViewModel.swift
@@ -64,7 +64,7 @@ class ConversationsListViewModel: ObservableObject {
         conversations.remove(at: index)
       }
       conversations.insert(event.conversation, at: 0)
-      conversations = conversations.sorted(by: { $0.lastStatus.createdAt.asDate > $1.lastStatus.createdAt.asDate })
+      conversations = conversations.sorted(by: { ($0.lastStatus?.createdAt.asDate ?? Date.now) > ($1.lastStatus?.createdAt.asDate ?? Date.now) })
     }
   }
 }

--- a/Packages/Models/Sources/Models/Conversation.swift
+++ b/Packages/Models/Sources/Models/Conversation.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct Conversation: Identifiable, Decodable, Hashable, Equatable {
   public let id: String
   public let unread: Bool
-  public let lastStatus: Status
+  public let lastStatus: Status?
   public let accounts: [Account]
 
   public static func placeholder() -> Conversation {


### PR DESCRIPTION
#696 comes up when the /conversations endpoint returns a conversation where the `last_status` property is nil. This is allowed according to the [API documentation](https://docs.joinmastodon.org/entities/Conversation/#last_status).

I changed the corresponding property in `Conversation` to `public let lastStatus: Status?`, the rest of the code changes are adaptions to this now optional property.

Closes #696 