### PR TITLE
Add direct status highlighting

### DIFF
--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -55,7 +55,7 @@ public protocol AnyStatus {
 }
 
 protocol StatusUI {
-  var uiShouldHighlight: Bool? { get set }
+  var userMentioned: Bool? { get set }
 }
 
 public struct Status: AnyStatus, Codable, Identifiable, Equatable, Hashable, StatusUI {
@@ -63,7 +63,7 @@ public struct Status: AnyStatus, Codable, Identifiable, Equatable, Hashable, Sta
     id + createdAt + (editedAt ?? "")
   }
 
-  public var uiShouldHighlight: Bool?
+  public var userMentioned: Bool?
 
   public static func == (lhs: Status, rhs: Status) -> Bool {
     lhs.id == rhs.id

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -83,7 +83,7 @@ public struct StatusRowView: View {
       .contextMenu {
         contextMenu
       }
-      .listRowBackground(viewModel.shouldHighlightRow ? theme.secondaryBackgroundColor : theme.primaryBackgroundColor)
+      .listRowBackground(viewModel.highlightRowColor)
       .swipeActions(edge: .trailing) {
         if !viewModel.isCompact {
           trailinSwipeActions

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -3,6 +3,8 @@ import Models
 import Network
 import SwiftUI
 
+import DesignSystem
+
 @MainActor
 public class StatusRowViewModel: ObservableObject {
   let status: Status
@@ -30,6 +32,8 @@ public class StatusRowViewModel: ObservableObject {
 
   @Published var favoriters: [Account] = []
   @Published var rebloggers: [Account] = []
+
+  private let theme = Theme.shared
   
   var seen = false
 
@@ -37,8 +41,15 @@ public class StatusRowViewModel: ObservableObject {
     status.reblog?.filtered?.first ?? status.filtered?.first
   }
 
-  var shouldHighlightRow: Bool {
-    status.uiShouldHighlight != nil
+  var highlightRowColor: Color {
+
+    if status.visibility == .direct {
+      return theme.tintColor.opacity(0.15)
+    } else if status.userMentioned != nil {
+      return theme.secondaryBackgroundColor
+    } else {
+      return theme.primaryBackgroundColor
+    }
   }
 
   var client: Client?

--- a/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
@@ -96,7 +96,7 @@ class TimelineViewModel: ObservableObject {
       var newStatus = event.status
       if let accountId {
         if newStatus.mentions.first(where: { $0.id == accountId }) != nil {
-          newStatus.uiShouldHighlight = true
+          newStatus.userMentioned = true
         }
       }
       statuses.insert(newStatus, at: 0)
@@ -329,7 +329,7 @@ extension TimelineViewModel: StatusesFetcher {
     if !statuses.isEmpty, let accountId {
       for i in statuses.indices {
         if statuses[i].mentions.first(where: { $0.id == accountId }) != nil {
-          statuses[i].uiShouldHighlight = true
+          statuses[i].userMentioned = true
         }
       }
     }


### PR DESCRIPTION
This opens the door for future enhancements to add a direct message and/or mention colour to the existing themes system. 

I am not good at picking individual colour choices, so I didn't add additional items to the theming system.

*This PR sets things up to implement #553 and #715.*

<img width="431" alt="CleanShot 2023-02-08 at 05 36 14@2x" src="https://user-images.githubusercontent.com/169561/217519142-9f50c84d-6c6a-4bfd-929f-aa1f21194aa3.png">
<img width="428" alt="CleanShot 2023-02-08 at 05 35 24@2x" src="https://user-images.githubusercontent.com/169561/217519146-7294982a-04c6-4487-86c6-16d15374a24e.png">
