### PR TITLE
Fix handling of polls

### DIFF
--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -384,6 +384,7 @@
 "status.poll.duration" = "Durada de l'enquesta";
 "status.poll.frequency" = "Freqüència de l'enquesta";
 "status.poll.option-n %lld" = "Opció %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Publicació de: %@";
 "status.row.was-boosted" = "impulsat";
 "status.row.was-reply" = "Ha respost a";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -385,6 +385,7 @@
 "status.poll.duration" = "Umfragedauer";
 "status.poll.frequency" = "Auswahlmöglichkeiten";
 "status.poll.option-n %lld" = "Option %lld";
+"status.poll.send" = "Auswahl absenden";
 "status.post-from-%@" = "Beitrag von %@";
 "status.row.was-boosted" = "hat geboostet";
 "status.row.was-reply" = "Antwort auf";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -385,6 +385,7 @@
 "status.poll.duration" = "Poll Duration";
 "status.poll.frequency" = "Polling Frequency";
 "status.poll.option-n %lld" = "Option %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Post from %@";
 "status.row.was-boosted" = "boosted";
 "status.row.was-reply" = "Replied to";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -386,6 +386,7 @@
 "status.poll.duration" = "Poll Duration";
 "status.poll.frequency" = "Polling Frequency";
 "status.poll.option-n %lld" = "Option %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Post from %@";
 "status.row.was-boosted" = "boosted";
 "status.row.was-reply" = "Replied to";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -386,6 +386,7 @@
 "status.poll.duration" = "Duración de la encuesta";
 "status.poll.frequency" = "Frecuencia de la encuesta";
 "status.poll.option-n %lld" = "Opción %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Publicado por %@";
 "status.row.was-boosted" = "retooteó";
 "status.row.was-reply" = "Respuesta a";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -381,6 +381,7 @@
 "status.poll.duration" = "Durée du sondage";
 "status.poll.frequency" = "Fréquence de sondage";
 "status.poll.option-n %lld" = "Option %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Publication de %@";
 "status.row.was-boosted" = "a boosté";
 "status.row.was-reply" = "Répondu à";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -386,6 +386,7 @@
 "status.poll.duration" = "Durata del sondaggio";
 "status.poll.frequency" = "Frequenza di voto";
 "status.poll.option-n %lld" = "Opzione %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Post da %@";
 "status.row.was-boosted" = "ha condiviso";
 "status.row.was-reply" = "Risposta per";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -386,6 +386,7 @@
 "status.poll.frequency" = "投票頻度";
 "status.poll.option-n %lld" = "オプション %lld";
 "status.post-from-%@" = "%@ の投稿";
+"status.poll.send" = "Send Vote";
 "status.row.was-boosted" = "ブーストした";
 "status.row.was-reply" = "返信";
 "status.row.you-boosted" = "ブーストしました";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -387,6 +387,7 @@
 "status.poll.duration" = "투표 기간";
 "status.poll.frequency" = "투표 선택 옵션";
 "status.poll.option-n %lld" = "선택지 %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "%@님의 글";
 "status.row.was-boosted" = "님이 부스트함";
 "status.row.was-reply" = "댓글:";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -385,6 +385,7 @@
 "status.poll.duration" = "Avstemningens varighet";
 "status.poll.frequency" = "Avstemningsfrekvens";
 "status.poll.option-n %lld" = "Valg %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Innlegg fra %@";
 "status.row.was-boosted" = "forsterket";
 "status.row.was-reply" = "Svar til";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -379,6 +379,7 @@
 "status.poll.duration" = "Pollduur";
 "status.poll.frequency" = "Pollingfrequentie";
 "status.poll.option-n %lld" = "Optie %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Post van %@";
 "status.row.was-boosted" = "geboost";
 "status.row.was-reply" = "Geantwoord op";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "status.poll.duration" = "Czas trwania sondażu";
 "status.poll.frequency" = "Częstotliwość odpytywania";
 "status.poll.option-n %lld" = "Opcja %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Post od %@";
 "status.row.was-boosted" = "podbił(a)";
 "status.row.was-reply" = "Odpowiedział(a) do";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -385,6 +385,7 @@
 "status.poll.duration" = "Duração da votação";
 "status.poll.frequency" = "Frequência da votação";
 "status.poll.option-n %lld" = "Opção %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Postar de %@";
 "status.row.was-boosted" = "deu boost";
 "status.row.was-reply" = "Respondeu a";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -381,6 +381,7 @@
 "status.poll.duration" = "Anket Süresi";
 "status.poll.frequency" = "Anket Sıklığı";
 "status.poll.option-n %lld" = "Seçenek %lld";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "Gönderi tarafından %@";
 "status.row.was-boosted" = "yükseltildi";
 "status.row.was-reply" = "Şuna cevap verildi";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -386,6 +386,7 @@
 "status.poll.duration" = "投票持续时间";
 "status.poll.frequency" = "投票频率";
 "status.poll.option-n %lld" = "%lld 选项";
+"status.poll.send" = "Send Vote";
 "status.post-from-%@" = "%@ 的嘟文";
 "status.row.was-boosted" = "转发";
 "status.row.was-reply" = "回复到";

--- a/Packages/Status/Sources/Status/Poll/StatusPollView.swift
+++ b/Packages/Status/Sources/Status/Poll/StatusPollView.swift
@@ -69,7 +69,7 @@ public struct StatusPollView: View {
         HStack {
           makeBarView(for: option, buttonImage: buttonImage(option: option))
             .disabled(viewModel.poll.expired || (viewModel.poll.voted ?? false))
-          if !viewModel.votes.isEmpty || viewModel.poll.expired || status.account.id == currentAccount.account?.id {
+          if viewModel.showResults || status.account.id == currentAccount.account?.id {
             Spacer()
             Text("\(percentForOption(option: option))%")
               .font(.scaledSubheadline)
@@ -77,7 +77,7 @@ public struct StatusPollView: View {
           }
         }
       }
-      if !viewModel.poll.expired, !(viewModel.poll.voted ?? false) {
+      if !viewModel.poll.expired, !(viewModel.poll.voted ?? false), !viewModel.votes.isEmpty {
         Button("status.poll.send") {
           Task {
             do {

--- a/Packages/Status/Sources/Status/Poll/StatusPollViewModel.swift
+++ b/Packages/Status/Sources/Status/Poll/StatusPollViewModel.swift
@@ -11,7 +11,7 @@ public class StatusPollViewModel: ObservableObject {
   @Published var votes: [Int] = []
 
   var showResults: Bool {
-    !votes.isEmpty || poll.expired
+    poll.ownVotes?.isEmpty == false || poll.expired
   }
 
   public init(poll: Poll) {

--- a/Packages/Status/Sources/Status/Poll/StatusPollViewModel.swift
+++ b/Packages/Status/Sources/Status/Poll/StatusPollViewModel.swift
@@ -38,4 +38,16 @@ public class StatusPollViewModel: ObservableObject {
       print(error)
     }
   }
+  
+  public func handleSelection(_ pollIndex: Int) {
+    if poll.multiple {
+      if let voterIndex = votes.firstIndex(of: pollIndex) {
+        votes.remove(at: voterIndex)
+      } else {
+        votes.append(pollIndex)
+      }
+    } else {
+      votes = [pollIndex]
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes the incomplete handling of polls and enables working with multi-choice polls.

I made the following changes:

For both kind of polls, all options are displayed in rows as before, multiple choice and single choice options look like the classical checkboxes or radio-buttons. The user can select different options, the behaviour is like usual for these types of buttons.

As long as it is possible to vote, there is a `Send Vote` button below them, which will post the poll to the server.

![image](https://user-images.githubusercontent.com/8456476/217619868-dbc55b06-f17f-4718-a90c-c8bd60290dd2.png)

When it is not possible to vote, either because the user has already voted or the vote is expired, the send button is removed.

![image](https://user-images.githubusercontent.com/8456476/217618691-94402bd1-1cb2-4f47-91ae-8c652ea876c5.png)


Closes #625 
Closes #332