### PR TITLE
Fix the theme is not applied to a part of the setting screen on iPadOS

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
@@ -110,6 +110,7 @@ struct DisplaySettingsView: View {
         Section("settings.display.section.ipad") {
           Toggle("settings.display.show-ipad-column", isOn: $userPreferences.showiPadSecondaryColumn)
         }
+        .listRowBackground(theme.primaryBackgroundColor)
       }
 
       Section {


### PR DESCRIPTION
![Simulator Screen Shot - iPad mini - 2023-02-09 at 15 11 00](https://user-images.githubusercontent.com/108506642/217734492-3274c0ac-6262-4215-ae1a-964cf1df12c5.png)

Closes: #735