### PR TITLE
Update to the newest version of nuke

### DIFF
--- a/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "2e9337168d08acccf72c039bf9324be24a1cf7d7",
-        "version" : "11.5.3"
+        "revision" : "67bd45931180f652159e3342575277a7f197b3ab",
+        "version" : "11.6.2"
       }
     },
     {

--- a/Packages/DesignSystem/Package.swift
+++ b/Packages/DesignSystem/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .package(name: "Models", path: "../Models"),
     .package(name: "Env", path: "../Env"),
     .package(url: "https://github.com/markiv/SwiftUI-Shimmer", exact: "1.1.0"),
-    .package(url: "https://github.com/kean/Nuke", from: "11.5.0"),
+    .package(url: "https://github.com/kean/Nuke", from: "11.6.0"),
     .package(url: "https://github.com/divadretlaw/EmojiText", from: "1.1.0"),
   ],
   targets: [


### PR DESCRIPTION
Static gifs as avatars are now rendered correctly. (See also #304)
Examples: https://social.bund.de/@bfdi, https://mastodon.social/@FARBfernsehen