### PR TITLE
Updated Basque translations — plurals

### DIFF
--- a/IceCubesApp/Resources/Localization/Plurals/eu.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/eu.lproj/Localizable.stringsdict
@@ -13,9 +13,9 @@
             <key>NSStringFormatValueTypeKey</key>
             <string>lld</string>
             <key>one</key>
-            <string>%lld new post</string>
+            <string>%bidalketa berri lld</string>
             <key>other</key>
-            <string>%lld new posts</string>
+            <string>%lld bidalketa berri</string>
         </dict>
     </dict>
     <key>notifications-others-count %lld</key>
@@ -29,9 +29,9 @@
             <key>NSStringFormatValueTypeKey</key>
             <string>lld</string>
             <key>one</key>
-            <string> and %lld other </string>
+            <string> eta beste %lld </string>
             <key>other</key>
-            <string> and %lld others </string>
+            <string> eta beste %lld </string>
         </dict>
     </dict>
 </dict>


### PR DESCRIPTION
Translated missing strings for Basque.