### PR TITLE
Also sort tags and lists in profile view

### DIFF
--- a/IceCubesApp/App/Tabs/Timeline/TimelineTab.swift
+++ b/IceCubesApp/App/Tabs/Timeline/TimelineTab.swift
@@ -112,9 +112,8 @@ struct TimelineTab: View {
       }
     }
     if !currentAccount.lists.isEmpty {
-      let sortedLists = currentAccount.lists.sorted { $0.title.lowercased() < $1.title.lowercased() }
       Menu("timeline.filter.lists") {
-        ForEach(sortedLists) { list in
+        ForEach(currentAccount.sortedLists) { list in
           Button {
             timeline = .list(list: list)
           } label: {
@@ -125,9 +124,8 @@ struct TimelineTab: View {
     }
 
     if !currentAccount.tags.isEmpty {
-      let sortedTags = currentAccount.tags.sorted { $0.name.lowercased() < $1.name.lowercased() }
       Menu("timeline.filter.tags") {
-        ForEach(sortedTags) { tag in
+        ForEach(currentAccount.sortedTags) { tag in
           Button {
             timeline = .hashtag(tag: tag.name, accountId: nil)
           } label: {

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -264,7 +264,7 @@ public struct AccountDetailView: View {
 
   private var tagsListView: some View {
     Group {
-      ForEach(currentAccount.tags) { tag in
+      ForEach(currentAccount.sortedTags) { tag in
         HStack {
           TagRowView(tag: tag)
           Spacer()
@@ -280,7 +280,7 @@ public struct AccountDetailView: View {
 
   private var listsListView: some View {
     Group {
-      ForEach(currentAccount.lists) { list in
+      ForEach(currentAccount.sortedLists) { list in
         NavigationLink(value: RouterDestinations.list(list: list)) {
           HStack {
             Text(list.title)

--- a/Packages/Env/Sources/Env/CurrentAccount.swift
+++ b/Packages/Env/Sources/Env/CurrentAccount.swift
@@ -16,6 +16,14 @@ public class CurrentAccount: ObservableObject {
 
   public static let shared = CurrentAccount()
 
+  public var sortedLists: [List] {
+    lists.sorted { $0.title.lowercased() < $1.title.lowercased() }
+  }
+
+  public var sortedTags: [Tag] {
+    tags.sorted { $0.name.lowercased() < $1.name.lowercased() }
+  }
+
   private init() {}
 
   public func setClient(client: Client) {


### PR DESCRIPTION
### Adds to and improves on the previously merged #370.
As tags and lists are also displayed in the profile view, I refactored the sorting routines and promoted them to CurrentAccount. Positioned them as as public computed vars between vars and funcs . Tags and lists views in profile now also display sorted: alphabetically/lowercased, ascending.