### PR TITLE
Clarify the difference between screen name and username

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/AccountExt.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/AccountExt.swift
@@ -11,7 +11,7 @@ public extension Account {
 
   var safeDisplayName: String {
     if displayName.isEmpty || displayName == "" {
-      return username
+      return "@\(username)"
     }
     return displayName
   }


### PR DESCRIPTION
Clarify that this is the username that will be displayed if the screen name is an empty string.