### PR TITLE
Remove "iPhone" and "iPad" from translatable strings

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
@@ -98,14 +98,14 @@ struct DisplaySettingsView: View {
       .listRowBackground(theme.primaryBackgroundColor)
 
       if UIDevice.current.userInterfaceIdiom == .phone {
-        Section("settings.display.section.phone") {
+        Section("iPhone") {
           Toggle("settings.display.show-tab-label", isOn: $userPreferences.showiPhoneTabLabel)
         }
         .listRowBackground(theme.primaryBackgroundColor)
       }
 
       if UIDevice.current.userInterfaceIdiom == .pad {
-        Section("settings.display.section.ipad") {
+        Section("iPad") {
           Toggle("settings.display.show-ipad-column", isOn: $userPreferences.showiPadSecondaryColumn)
         }
         .listRowBackground(theme.primaryBackgroundColor)

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -156,10 +156,8 @@
 "settings.haptic.tab-selection" = "Selecció de pestanyes";
 "settings.haptic.buttons" = "Pressió de botó";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Mostra el nom de la pestanya";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Habilitar columna secondària";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -154,10 +154,8 @@
 "settings.haptic.tab-selection" = "Tabauswahl";
 "settings.haptic.buttons" = "Knopfdruck";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Tabtitel anzeigen";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Zweite Spalte aktivieren";
 
 "enum.expand-media.show" = "Alle zeigen";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -160,10 +160,8 @@
 "settings.haptic.tab-selection" = "Tab Selection";
 "settings.haptic.buttons" = "Button Press";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Show tab name";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Enable secondary column";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -158,10 +158,8 @@
 "settings.haptic.tab-selection" = "Tab Selection";
 "settings.haptic.buttons" = "Button Press";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Show tab name";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Enable secondary column";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -154,10 +154,8 @@
 "settings.haptic.tab-selection" = "Tab Selection";
 "settings.haptic.buttons" = "Button Press";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Show tab name";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Enable secondary column";
 
 "enum.expand-media.show" = "Siempre";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -154,10 +154,8 @@
 "settings.haptic.tab-selection" = "Fitxak hautatzean";
 "settings.haptic.buttons" = "Botoiak sakatzean";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Erakutsi fitxen izena";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Gaitu bigarren zutabea";
 
 "enum.expand-media.show" = "Erakutsi guztia";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.haptic.tab-selection" = "Sélection d'onglet";
 "settings.haptic.buttons" = "Appui bouton";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Montrer le nom de l'onglet";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Activer la colonne secondaire";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.haptic.tab-selection" = "Selezione Tab";
 "settings.haptic.buttons" = "Pressione dei bottoni";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Show tab name";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Attiva la seconda colonna";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.haptic.tab-selection" = "タブセレクト";
 "settings.haptic.buttons" = "ボタン操作時";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "タブ名を表示";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "セカンドカラムを有効にする";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.haptic.tab-selection" = "하단 탭 바를 누를 때";
 "settings.haptic.buttons" = "버튼을 누를 때";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Show tab name";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Enable secondary column";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.haptic.tab-selection" = "Tab Selection";
 "settings.haptic.buttons" = "Button Press";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Show tab name";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Enable secondary column";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -154,10 +154,8 @@
 "settings.haptic.tab-selection" = "Tabselectie";
 "settings.haptic.buttons" = "Knoppen";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Toon label bij tab";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Toon tweede kolom";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.haptic.tab-selection" = "Wybór zakładki";
 "settings.haptic.buttons" = "Naciśnięcie przycisku";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Pokazuj nazwy zakładek";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Włącz dodatkową kolumnę";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.haptic.tab-selection" = "Tab Selection";
 "settings.haptic.buttons" = "Button Press";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Show tab name";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Enable secondary column";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.haptic.tab-selection" = "Tab Selection";
 "settings.haptic.buttons" = "Button Press";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "Show tab name";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "Enable secondary column";
 
 // MARK: Tabs

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -157,10 +157,8 @@
 "settings.display.font.custom" = "自定义";
 "settings.display.font.scaling-%@" = "字体缩放：%@";
 
-"settings.display.section.phone" = "iPhone";
 "settings.display.show-tab-label" = "显示 Tab 标签";
 
-"settings.display.section.ipad" = "iPad";
 "settings.display.show-ipad-column" = "启用边栏";
 
 // MARK: Tabs


### PR DESCRIPTION
I actually don't think `iPhone` and `iPad` should be translatable.

This removes `settings.display.section.phone` and `settings.display.section.ipad` from `Localizable.strings` and replace them with hard-coded strings.