### PR TITLE
Automatically detect language of posts, improve language detection when posting

### DIFF
--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -360,6 +360,8 @@
 "status.editor.error.upload" = "Error en la pujada";
 "status.editor.language-select.navigation-title" = "Selecciona la llengua";
 "status.editor.language-select.recently-used" = "Recents";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Edita la imatge";
 "status.editor.media.image-description" = "Descripció de la imatge";
 "status.editor.mode.edit" = "Edita la publicació";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -337,10 +337,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tradueix";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Tradueix del %@";
 "status.action.translated-label" = "Traduït amb DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Afegeix als marcadors";
 "status.action.boost" = "Impulsa";
 "status.action.copy-text" = "Copia el text";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -321,8 +321,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tradueix";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Tradueix del %@";
 "status.action.translated-label" = "Traduït amb DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Afegeix als marcadors";
 "status.action.boost" = "Impulsa";
 "status.action.copy-text" = "Copia el text";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -322,8 +322,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Übersetzen";
+"status.action.translate-secondary" = "Aus Sekundärsprache übersetzen";
 "status.action.translate-from-%@" = "Aus %@ übersetzen";
 "status.action.translated-label" = "Übersetzt mit DeepL.com";
+"status.action.translated-label-from-%@" = "Übersetzt aus %@ mit DeepL.com";
 "status.action.bookmark" = "Lesezeichen";
 "status.action.boost" = "Boosten";
 "status.action.copy-text" = "Text kopieren";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -338,10 +338,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Übersetzen";
-"status.action.translate-secondary" = "Aus Sekundärsprache übersetzen";
 "status.action.translate-from-%@" = "Aus %@ übersetzen";
 "status.action.translated-label" = "Übersetzt mit DeepL.com";
-"status.action.translated-label-from-%@" = "Übersetzt aus %@ mit DeepL.com";
 "status.action.bookmark" = "Lesezeichen";
 "status.action.boost" = "Boosten";
 "status.action.copy-text" = "Text kopieren";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -361,6 +361,8 @@
 "status.editor.error.upload" = "Fehler beim Hochladen";
 "status.editor.language-select.navigation-title" = "Sprache auswählen";
 "status.editor.language-select.recently-used" = "Kürzlich genutzt";
+"status.editor.language-select.confirmation.detected-%@" = "Auf %@ posten (Erkannte Sprache)";
+"status.editor.language-select.confirmation.selected-%@" = "Auf %@ posten (Ausgewählte Sprache)";
 "status.editor.media.edit-image" = "Bild bearbeiten";
 "status.editor.media.image-description" = "Bildbeschreibung";
 "status.editor.mode.edit" = "Deinen Beitrag bearbeiten";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -340,10 +340,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label" = "Translated using DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copy Text";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -324,8 +324,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label" = "Translated using DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copy Text";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -361,6 +361,8 @@
 "status.editor.error.upload" = "Error uploading";
 "status.editor.language-select.navigation-title" = "Select Language";
 "status.editor.language-select.recently-used" = "Recently Used";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Edit Image";
 "status.editor.media.image-description" = "Image description";
 "status.editor.mode.edit" = "Editing your post";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -339,10 +339,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label" = "Translated using DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copy Text";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -323,8 +323,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label" = "Translated using DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copy Text";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -362,6 +362,8 @@
 "status.editor.error.upload" = "Error uploading";
 "status.editor.language-select.navigation-title" = "Select Language";
 "status.editor.language-select.recently-used" = "Recently Used";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Edit Image";
 "status.editor.media.image-description" = "Image description";
 "status.editor.mode.edit" = "Editing your post";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -339,10 +339,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traducir";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Traducir desde %@";
 "status.action.translated-label" = "Traducido usando DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Añadir a marcadores";
 "status.action.boost" = "Retootear";
 "status.action.copy-text" = "Copiar texto";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -323,8 +323,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traducir";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Traducir desde %@";
 "status.action.translated-label" = "Traducido usando DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Añadir a marcadores";
 "status.action.boost" = "Retootear";
 "status.action.copy-text" = "Copiar texto";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -362,6 +362,8 @@
 "status.editor.error.upload" = "Error subiendo";
 "status.editor.language-select.navigation-title" = "Seleccionar idioma";
 "status.editor.language-select.recently-used" = "Usado recientemente";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Editar Imagen";
 "status.editor.media.image-description" = "Descripción de la imagen";
 "status.editor.mode.edit" = "Editando tu publicación";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -361,6 +361,8 @@
 "status.editor.error.upload" = "Errorea igotzerakoan";
 "status.editor.language-select.navigation-title" = "Hautatu hizkuntza";
 "status.editor.language-select.recently-used" = "Duela gutxi erabilitakoak";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Editatu irudiak";
 "status.editor.media.image-description" = "Irudiaren deskribapena";
 "status.editor.mode.edit" = "Bidalketa editatzen";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -322,8 +322,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Itzuli";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Egin %@(a)ren itzulpena";
 "status.action.translated-label" = "DeepL.com erabiliz itzulia";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Jarri laster-marka";
 "status.action.boost" = "Bultzatu";
 "status.action.copy-text" = "Kopiatu testua";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -338,10 +338,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Itzuli";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Egin %@(a)ren itzulpena";
 "status.action.translated-label" = "DeepL.com erabiliz itzulia";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Jarri laster-marka";
 "status.action.boost" = "Bultzatu";
 "status.action.copy-text" = "Kopiatu testua";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -357,6 +357,8 @@
 "status.editor.error.upload" = "Erreur de téléchargement";
 "status.editor.language-select.navigation-title" = "Sélectionner la langue";
 "status.editor.language-select.recently-used" = "Utilisé récemment";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Modifier l'image";
 "status.editor.media.image-description" = "Description de l'image";
 "status.editor.mode.edit" = "Modification de votre publication";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -334,10 +334,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduire";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Traduire de %@";
 "status.action.translated-label" = "Traduit avec DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Marquer";
 "status.action.boost" = "Promouvoir";
 "status.action.copy-text" = "Copier le texte";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -318,8 +318,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduire";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Traduire de %@";
 "status.action.translated-label" = "Traduit avec DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Marquer";
 "status.action.boost" = "Promouvoir";
 "status.action.copy-text" = "Copier le texte";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -323,8 +323,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduci";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Traduci da %@";
 "status.action.translated-label" = "Tradotto usando DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Salva nei segnalibri";
 "status.action.boost" = "Condividi";
 "status.action.copy-text" = "Copia il testo";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -339,10 +339,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduci";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Traduci da %@";
 "status.action.translated-label" = "Tradotto usando DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Salva nei segnalibri";
 "status.action.boost" = "Condividi";
 "status.action.copy-text" = "Copia il testo";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -362,6 +362,8 @@
 "status.editor.error.upload" = "Errore durante il caricamento";
 "status.editor.language-select.navigation-title" = "Scegli la lingua";
 "status.editor.language-select.recently-used" = "Usato recentemente";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Modifica l'immagine";
 "status.editor.media.image-description" = "Descrizione dell'immagine";
 "status.editor.mode.edit" = "Modifica post";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -338,10 +338,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻訳";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "翻訳 %@";
 "status.action.translated-label" = "DeepL.comを使用して翻訳";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "ブックマーク";
 "status.action.boost" = "ブースト";
 "status.action.copy-text" = "テキストをコピー";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -322,8 +322,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻訳";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "翻訳 %@";
 "status.action.translated-label" = "DeepL.comを使用して翻訳";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "ブックマーク";
 "status.action.boost" = "ブースト";
 "status.action.copy-text" = "テキストをコピー";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -361,6 +361,8 @@
 "status.editor.error.upload" = "アップロードエラー";
 "status.editor.language-select.navigation-title" = "言語設定";
 "status.editor.language-select.recently-used" = "最近使用した";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "イメージの編集";
 "status.editor.media.image-description" = "イメージの説明文";
 "status.editor.mode.edit" = "投稿を編集する";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -323,8 +323,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "번역";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "%@에서 번역";
 "status.action.translated-label" = "DeepL.com을 통해 번역됨";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "보관함에 추가";
 "status.action.boost" = "부스트";
 "status.action.copy-text" = "복사";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -362,6 +362,8 @@
 "status.editor.error.upload" = "전송 오류";
 "status.editor.language-select.navigation-title" = "언어 선택";
 "status.editor.language-select.recently-used" = "최근 사용";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "이미지 편집";
 "status.editor.media.image-description" = "이미지 설명";
 "status.editor.mode.edit" = "글 수정";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -339,10 +339,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "번역";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "%@에서 번역";
 "status.action.translated-label" = "DeepL.com을 통해 번역됨";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "보관함에 추가";
 "status.action.boost" = "부스트";
 "status.action.copy-text" = "복사";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -322,8 +322,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Oversett";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Oversett fra %@";
 "status.action.translated-label" = "Oversatt ved hjelp av DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Bokmerk";
 "status.action.boost" = "Forsterk";
 "status.action.copy-text" = "Kopier tekst";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -338,10 +338,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Oversett";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Oversett fra %@";
 "status.action.translated-label" = "Oversatt ved hjelp av DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Bokmerk";
 "status.action.boost" = "Forsterk";
 "status.action.copy-text" = "Kopier tekst";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -361,6 +361,8 @@
 "status.editor.error.upload" = "Feil ved opplasting";
 "status.editor.language-select.navigation-title" = "Velg språk";
 "status.editor.language-select.recently-used" = "Nylig brukt";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Rediger bilde";
 "status.editor.media.image-description" = "Bildebeskrivelse";
 "status.editor.mode.edit" = "Redigerer innlegget ditt";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -332,10 +332,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Vertaal";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Vertaal uit het %@";
 "status.action.translated-label" = "Vertaald met behulp van DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Voeg bladwijzer toe";
 "status.action.boost" = "Boosten";
 "status.action.copy-text" = "Kopieer tekst";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -316,8 +316,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Vertaal";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Vertaal uit het %@";
 "status.action.translated-label" = "Vertaald met behulp van DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Voeg bladwijzer toe";
 "status.action.boost" = "Boosten";
 "status.action.copy-text" = "Kopieer tekst";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -355,6 +355,8 @@
 "status.editor.error.upload" = "Fout tijdens uploaden";
 "status.editor.language-select.navigation-title" = "Taal selecteren";
 "status.editor.language-select.recently-used" = "Onlangs gebruikt";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Afbeelding bewerken";
 "status.editor.media.image-description" = "Omschrijving";
 "status.editor.mode.edit" = "Post bewerken";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -318,8 +318,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Przetłumacz";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Przetłumacz tekst %@";
 "status.action.translated-label" = "Przetłumaczono za pomocą DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Dodaj zakładkę";
 "status.action.boost" = "Podbij";
 "status.action.copy-text" = "Kopiuj tekst";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -334,10 +334,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Przetłumacz";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Przetłumacz tekst %@";
 "status.action.translated-label" = "Przetłumaczono za pomocą DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Dodaj zakładkę";
 "status.action.boost" = "Podbij";
 "status.action.copy-text" = "Kopiuj tekst";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -357,6 +357,8 @@
 "status.editor.error.upload" = "Błąd wysyłania";
 "status.editor.language-select.navigation-title" = "Wybierz język";
 "status.editor.language-select.recently-used" = "Ostatnio użyty";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Edytuj obrazek";
 "status.editor.media.image-description" = "Opis obrazka";
 "status.editor.mode.edit" = "Edycja twojego postu";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -361,6 +361,8 @@
 "status.editor.error.upload" = "Erro ao fazer upload";
 "status.editor.language-select.navigation-title" = "Selecionar Idioma";
 "status.editor.language-select.recently-used" = "Usado recentemente";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Editar Imagem";
 "status.editor.media.image-description" = "Descrição da imagem";
 "status.editor.mode.edit" = "Editando sua postagem";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -322,8 +322,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduzir";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Traduzir do %@";
 "status.action.translated-label" = "Traduzir usando DeepL.com";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Salvar";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copiar Texto";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -338,10 +338,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduzir";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Traduzir do %@";
 "status.action.translated-label" = "Traduzir usando DeepL.com";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Salvar";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copiar Texto";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -318,8 +318,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tercüme et";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Tercüme et %@";
 "status.action.translated-label" = "DeepL.com tarafından tercüme edildi";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Yer İmi Ekle";
 "status.action.boost" = "Yükselt";
 "status.action.copy-text" = "Yazıyı Kopyala";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -334,10 +334,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tercüme et";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "Tercüme et %@";
 "status.action.translated-label" = "DeepL.com tarafından tercüme edildi";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "Yer İmi Ekle";
 "status.action.boost" = "Yükselt";
 "status.action.copy-text" = "Yazıyı Kopyala";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -357,6 +357,8 @@
 "status.editor.error.upload" = "Yüklerken Hata Oluştu";
 "status.editor.language-select.navigation-title" = "Dil Seç";
 "status.editor.language-select.recently-used" = "Son Kullanılanlar";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "Görüntüyü Düzenle";
 "status.editor.media.image-description" = "Görüntü Açıklaması";
 "status.editor.mode.edit" = "Gönderin Düzenleniyor";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -323,8 +323,10 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻译";
+"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "翻译 %@";
 "status.action.translated-label" = "由 DeepL.com 翻译";
+"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "书签";
 "status.action.boost" = "转发";
 "status.action.copy-text" = "拷贝文本";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -339,10 +339,8 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻译";
-"status.action.translate-secondary" = "Translate from secondary language";
 "status.action.translate-from-%@" = "翻译 %@";
 "status.action.translated-label" = "由 DeepL.com 翻译";
-"status.action.translated-label-from-%@" = "Translated from %@ using DeepL.com";
 "status.action.bookmark" = "书签";
 "status.action.boost" = "转发";
 "status.action.copy-text" = "拷贝文本";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -362,6 +362,8 @@
 "status.editor.error.upload" = "上传错误";
 "status.editor.language-select.navigation-title" = "选择语言";
 "status.editor.language-select.recently-used" = "最近使用";
+"status.editor.language-select.confirmation.detected-%@" = "Post in %@ (Detected language)";
+"status.editor.language-select.confirmation.selected-%@" = "Post in %@ (Selected language)";
 "status.editor.media.edit-image" = "编辑图片";
 "status.editor.media.image-description" = "图片描述";
 "status.editor.mode.edit" = "正在编辑你的嘟文";

--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -21,6 +21,7 @@ public struct StatusEditorView: View {
   @FocusState private var isSpoilerTextFocused: Bool
 
   @State private var isDismissAlertPresented: Bool = false
+    @State private var isLanguageConfirmPresented = false
 
   public init(mode: StatusEditorViewModel.Mode) {
     _viewModel = StateObject(wrappedValue: .init(mode: mode))
@@ -104,12 +105,12 @@ public struct StatusEditorView: View {
         ToolbarItem(placement: .navigationBarTrailing) {
           Button {
             Task {
-              let status = await viewModel.postStatus()
-              if status != nil {
-                dismiss()
-                NotificationCenter.default.post(name: NotificationsName.shareSheetClose,
-                                                object: nil)
-              }
+                viewModel.evaluateLanguages()
+                if let _ = viewModel.languageConfirmationDialogLanguages {
+                    isLanguageConfirmPresented = true
+                } else {
+                    await postStatus()
+                }
             }
           } label: {
             if viewModel.isPosting {
@@ -120,6 +121,9 @@ public struct StatusEditorView: View {
           }
           .disabled(!viewModel.canPost)
           .keyboardShortcut(.return, modifiers: .command)
+          .confirmationDialog("", isPresented: $isLanguageConfirmPresented, actions: {
+              languageConfirmationDialog
+          })
         }
         ToolbarItem(placement: .navigationBarLeading) {
           Button {
@@ -155,6 +159,42 @@ public struct StatusEditorView: View {
     }
     .interactiveDismissDisabled(!viewModel.statusText.string.isEmpty)
   }
+
+    @ViewBuilder
+    private var languageConfirmationDialog: some View {
+        if let dialogVals = viewModel.languageConfirmationDialogLanguages,
+           let detected = dialogVals["detected"],
+           let detectedLong = Locale.current.localizedString(forLanguageCode: detected),
+           let selected = dialogVals["selected"],
+           let selectedLong = Locale.current.localizedString(forLanguageCode: selected){
+            Button("status.editor.language-select.confirmation.detected-\(detectedLong)") {
+                viewModel.selectedLanguage = detected
+                Task {
+                    await postStatus()
+                }
+            }
+            Button("status.editor.language-select.confirmation.selected-\(selectedLong)") {
+                viewModel.selectedLanguage = selected
+                Task {
+                    await postStatus()
+                }
+            }
+            Button("action.cancel", role: .cancel) {
+                viewModel.languageConfirmationDialogLanguages = nil
+            }
+        } else {
+            EmptyView()
+        }
+    }
+    
+    private func postStatus() async {
+        let status = await viewModel.postStatus()
+        if status != nil {
+            dismiss()
+            NotificationCenter.default.post(name: NotificationsName.shareSheetClose,
+                                            object: nil)
+        }
+    }
 
   @ViewBuilder
   private var spoilerTextView: some View {

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -14,6 +14,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
   var currentAccount: Account?
   var theme: Theme?
   var preferences: UserPreferences?
+  var languageConfirmationDialogLanguages: [String: String]?
 
   var textView: UITextView? {
     didSet {
@@ -143,6 +144,17 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
     selectedLanguage = selectedLanguage ?? preference ?? currentAccount?.source?.language
   }
 
+    func evaluateLanguages(){
+        if let detectedLang = detectLanguage(text: statusText.string),
+           let selectedLanguage = selectedLanguage,
+           selectedLanguage != detectedLang {
+            languageConfirmationDialogLanguages = ["detected": detectedLang,
+                                                   "selected": selectedLanguage]
+        } else {
+            languageConfirmationDialogLanguages = nil;
+        }
+    }
+
   func postStatus() async -> Status? {
     guard let client else { return nil }
     do {
@@ -153,20 +165,6 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
         pollData = .init(options: pollOptions,
                          multiple: pollVotingFrequency.canVoteMultipleTimes,
                          expires_in: pollDuration.rawValue)
-      }
-
-      if !hasExplicitlySelectedLanguage {
-        // Attempt language resolution using Natural Language
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(statusText.string)
-        // Use languageHypotheses to get the probability with it
-        let hypotheses = recognizer.languageHypotheses(withMaximum: 1)
-        // Assert that 85% probability is enough :)
-        // A one word toot that is en/fr compatible is only ~50% confident, for instance
-        if let (language, probability) = hypotheses.first, probability > 0.85 {
-          // rawValue return the IETF BCP 47 language tag
-          selectedLanguage = language.rawValue
-        }
       }
 
       let data = StatusData(status: statusText.string,

--- a/Packages/Status/Sources/Status/LanguageDetection/LanguageDetection.swift
+++ b/Packages/Status/Sources/Status/LanguageDetection/LanguageDetection.swift
@@ -13,7 +13,7 @@ private func stripToPureLanguage(inText: String) -> String {
         resultStr = splitArray.joined() as String
     }
     
-    return resultStr
+    return resultStr.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
 func detectLanguage(text: String) -> String? {

--- a/Packages/Status/Sources/Status/LanguageDetection/LanguageDetection.swift
+++ b/Packages/Status/Sources/Status/LanguageDetection/LanguageDetection.swift
@@ -1,0 +1,34 @@
+import Foundation
+import NaturalLanguage
+
+private func stripToPureLanguage(inText: String) -> String {
+    let hashtagRegex = try! Regex("#[\\w]*")
+    let emojiRegex = try! Regex(":\\w*:")
+    let atRegex = try! Regex("@\\w*")
+    
+    var resultStr = inText
+    
+    [hashtagRegex, emojiRegex, atRegex].forEach { regex in
+        let splitArray = resultStr.split(separator: regex, omittingEmptySubsequences: true)
+        resultStr = splitArray.joined() as String
+    }
+    
+    return resultStr
+}
+
+func detectLanguage(text: String) -> String? {
+    let recognizer = NLLanguageRecognizer()
+    
+    let strippedText = stripToPureLanguage(inText: text)
+    
+    recognizer.processString(strippedText)
+    
+    let hypotheses = recognizer.languageHypotheses(withMaximum: 1)
+    
+    // Use the detected language only with >= 85 % confidence
+    if let (lang, confidence) = hypotheses.first, confidence >= 0.85 {
+        return lang.rawValue
+    } else {
+        return nil
+    }
+}

--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -76,15 +76,15 @@ struct StatusRowContextMenu: View {
     }
 
     if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier,
-       let statusLanguage = viewModel.getStatusLang(),
-       statusLanguage != lang
+       viewModel.getStatusLang() != lang
     {
       Button {
         Task {
           await viewModel.translate(userLang: lang)
         }
       } label: {
-        if let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage) {
+        if let statusLanguage = viewModel.getStatusLang(),
+           let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage) {
           Label("status.action.translate-from-\(languageName)", systemImage: "captions.bubble")
         } else {
           Label("status.action.translate", systemImage: "captions.bubble")

--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -76,7 +76,7 @@ struct StatusRowContextMenu: View {
     }
 
     if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier,
-       let statusLanguage = viewModel.status.reblog?.language ?? viewModel.status.language,
+       let statusLanguage = viewModel.getStatusLang(),
        statusLanguage != lang
     {
       Button {
@@ -91,6 +91,22 @@ struct StatusRowContextMenu: View {
         }
       }
     }
+
+      if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier,
+         let statusLanguage = viewModel.getSecondaryStatusLang(),
+         statusLanguage != lang {
+          Button {
+              Task {
+                  await viewModel.translateFromSecondaryLang(userLang: lang)
+              }
+          } label: {
+              if let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage) {
+                  Label("status.action.translate-from-\(languageName)", systemImage: "captions.bubble")
+              } else {
+                  Label("status.action.translate-secondary", systemImage: "captions.bubble")
+              }
+          }
+      }
 
     if account.account?.id == viewModel.status.account.id {
       Section("status.action.section.your-post") {

--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -75,8 +75,7 @@ struct StatusRowContextMenu: View {
       Label("status.action.copy-text", systemImage: "doc.on.doc")
     }
 
-    if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier,
-       viewModel.getStatusLang() != lang
+    if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier
     {
       Button {
         Task {

--- a/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowContextMenu.swift
@@ -92,22 +92,6 @@ struct StatusRowContextMenu: View {
       }
     }
 
-      if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier,
-         let statusLanguage = viewModel.getSecondaryStatusLang(),
-         statusLanguage != lang {
-          Button {
-              Task {
-                  await viewModel.translateFromSecondaryLang(userLang: lang)
-              }
-          } label: {
-              if let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage) {
-                  Label("status.action.translate-from-\(languageName)", systemImage: "captions.bubble")
-              } else {
-                  Label("status.action.translate-secondary", systemImage: "captions.bubble")
-              }
-          }
-      }
-
     if account.account?.id == viewModel.status.account.id {
       Section("status.action.section.your-post") {
         Button {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -344,14 +344,24 @@ public struct StatusRowView: View {
     .accessibilityHidden(true)
   }
 
+    private func shouldShowTranslateButton(status: AnyStatus) -> Bool {
+        let statusLang = viewModel.getStatusLang()
+        
+        if let userLang = preferences.serverPreferences?.postLanguage,
+           preferences.showTranslateButton,
+           !status.content.asRawText.isEmpty,
+           viewModel.translationSourceLang != (statusLang ?? "")
+        {
+            return statusLang != nil && userLang != statusLang
+        } else {
+            return false
+        }
+    }
+
   @ViewBuilder
   private func makeTranslateView(status: AnyStatus) -> some View {
-    if let userLang = preferences.serverPreferences?.postLanguage,
-       preferences.showTranslateButton,
-       status.language != nil,
-       userLang != status.language,
-       !status.content.asRawText.isEmpty,
-       viewModel.translation == nil
+      if let userLang = preferences.serverPreferences?.postLanguage,
+       shouldShowTranslateButton(status: status)
     {
       Button {
         Task {
@@ -361,13 +371,13 @@ public struct StatusRowView: View {
         if viewModel.isLoadingTranslation {
           ProgressView()
         } else {
-          if let statusLanguage = status.language,
-             let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage)
-          {
-            Text("status.action.translate-from-\(languageName)")
-          } else {
-            Text("status.action.translate")
-          }
+            if let statusLanguage = viewModel.getStatusLang(),
+               let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage)
+            {
+                Text("status.action.translate-from-\(languageName)")
+            } else {
+                Text("status.action.translate")
+            }
         }
       }
       .buttonStyle(.borderless)
@@ -378,7 +388,13 @@ public struct StatusRowView: View {
         VStack(alignment: .leading, spacing: 4) {
           Text(translation)
             .font(.scaledBody)
-          Text("status.action.translated-label")
+            Group{
+                if let sourceLang =  Locale.current.localizedString(forLanguageCode: viewModel.translationSourceLang ?? "") {
+                    Text("status.action.translated-label-from-\(sourceLang)")
+                } else {
+                    Text("status.action.translated-label")
+                }
+            }
             .font(.footnote)
             .foregroundColor(.gray)
         }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -349,9 +349,9 @@ public struct StatusRowView: View {
         if let userLang = preferences.serverPreferences?.postLanguage,
            preferences.showTranslateButton,
            !status.content.asRawText.isEmpty,
-           viewModel.translationSourceLang != (statusLang ?? "")
+           viewModel.translation?.isEmpty ?? true
         {
-            return statusLang != nil && userLang != statusLang
+            return userLang != statusLang
         } else {
             return false
         }
@@ -387,13 +387,7 @@ public struct StatusRowView: View {
         VStack(alignment: .leading, spacing: 4) {
           Text(translation)
             .font(.scaledBody)
-            Group{
-                if let sourceLang =  Locale.current.localizedString(forLanguageCode: viewModel.translationSourceLang ?? "") {
-                    Text("status.action.translated-label-from-\(sourceLang)")
-                } else {
-                    Text("status.action.translated-label")
-                }
-            }
+          Text("status.action.translated-label")
             .font(.footnote)
             .foregroundColor(.gray)
         }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -349,7 +349,7 @@ public struct StatusRowView: View {
         if let userLang = preferences.serverPreferences?.postLanguage,
            preferences.showTranslateButton,
            !status.content.asRawText.isEmpty,
-           viewModel.translation?.isEmpty ?? true
+           viewModel.translation == nil
         {
             return userLang != statusLang
         } else {

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -28,7 +28,6 @@ public class StatusRowViewModel: ObservableObject {
   @Published var isLoadingRemoteContent: Bool = false
 
   @Published var translation: String?
-    @Published var translationSourceLang: String?
   @Published var isLoadingTranslation: Bool = false
   @Published var showDeleteAlert: Bool = false
 
@@ -36,7 +35,6 @@ public class StatusRowViewModel: ObservableObject {
   @Published var rebloggers: [Account] = []
 
   private let theme = Theme.shared
-  private lazy var detectedLang = firstDetectLanguage()
   
   var seen = false
 
@@ -293,29 +291,14 @@ public class StatusRowViewModel: ObservableObject {
     reblogsCount = status.reblog?.reblogsCount ?? status.reblogsCount
     repliesCount = status.reblog?.repliesCount ?? status.repliesCount
   }
-
-    private func firstDetectLanguage() -> String? {
-        let text = status.reblog?.content.asRawText ?? status.content.asRawText
-        return detectLanguage(text: text)
-    }
     
     func getStatusLang() -> String? {
-        detectedLang ?? status.language
-    }
-    
-    func getSecondaryStatusLang() -> String? {
-        status.language != getStatusLang() ? status.language : nil
+        status.language
     }
     
   func translate(userLang: String) async {
       await translate(userLang: userLang, sourceLang: getStatusLang())
   }
-    
-    func translateFromSecondaryLang(userLang: String) async {
-        if let secondaryLang = getSecondaryStatusLang() {
-            await translate(userLang: userLang, sourceLang: secondaryLang)
-        }
-    }
     
     private func translate(userLang: String, sourceLang: String?) async {
      let client = DeepLClient()
@@ -328,11 +311,6 @@ public class StatusRowViewModel: ObservableObject {
                                                  text: status.reblog?.content.asRawText ?? status.content.asRawText)
       withAnimation {
         self.translation = translation
-          if let sourceLang = sourceLang {
-              translationSourceLang = sourceLang
-          } else {
-              translationSourceLang = ""
-          }
         isLoadingTranslation = false
       }
     } catch {}


### PR DESCRIPTION
The target-language for the translation option is automatically determined via Apple's NaturalLanguage-Library. The detection works similar to the already implemented detection when posting, but hashtags, emojis (*:emoji:*) and "@"-links are filtered out, so that the processed text is cleaner. If the detected language is wrong the user still has the option to translate from the transmitted (*"secondary"*) language in the context menu.
The language-detection when posting is also reworked: The language is always detected, even when the user explicitly selected another one. The user is however always asked in which language he wants to post, since quietly changing the language before posting can confuse.

That should address issue #747 at least to a certain degree.

Optionally I could also see a scenario where the translation from the secondary language is also accessible via a button in main view (not only the context-menu). That might be easier to understand, depending on the accuracy of the language detection.