### PR TITLE
Fix AppAccountView touch area

### DIFF
--- a/Packages/AppAccount/Sources/AppAccount/AppAccountView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountView.swift
@@ -68,6 +68,7 @@ public struct AppAccountView: View {
       Image(systemName: "chevron.right")
         .foregroundColor(.gray)
     }
+    .contentShape(Rectangle())
     .onTapGesture {
       if appAccounts.currentAccount.id == viewModel.appAccount.id,
          let account = viewModel.account


### PR DESCRIPTION
This fixes the spacer not being tappable in `AppAccountView`.

<img width="345" alt="SCR-20230212-jxm" src="https://user-images.githubusercontent.com/56245920/218294420-905b958a-5cec-4fcd-98c7-596e04d09270.png">