### PR TITLE
Improve swipe actions and settings

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -10,10 +10,7 @@ struct SwipeActionsSettingsView: View {
     
     Form {
       Section("settings.swipeactions.status") {
-        HStack {
-          Text("settings.swipeactions.status.leading")
-          Image(systemName: "arrow.right")
-        }
+        Label("settings.swipeactions.status.leading", systemImage: "arrow.left.circle")
         Picker(selection: $userPreferences.swipeActionsStatusLeadingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.leading.left")) {
           ForEach(StatusAction.allCases) { action in
             Text(action.displayName).tag(action)
@@ -24,10 +21,7 @@ struct SwipeActionsSettingsView: View {
             Text(action.displayName).tag(action)
           }
         }
-        HStack {
-          Text("settings.swipeactions.status.trailing")
-          Image(systemName: "arrow.left")
-        }
+        Label("settings.swipeactions.status.trailing", systemImage: "arrow.right.circle")
         Picker(selection: $userPreferences.swipeActionsStatusTrailingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.trailing.left"))  {
           ForEach(StatusAction.allCases) { action in
             Text(action.displayName).tag(action)
@@ -47,9 +41,7 @@ struct SwipeActionsSettingsView: View {
   }
   
   private func makeSwipeLabel(left: Bool, text: LocalizedStringKey) -> some View {
-    return HStack {
-      Image(systemName: left ? "rectangle.lefthalf.filled" : "rectangle.righthalf.filled")
-      Text(text)
-    }.padding(.leading, 16)
+    return Label(text, systemImage: left ? "rectangle.lefthalf.filled" : "rectangle.righthalf.filled")
+           .padding(.leading, 16)
   }
 }

--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -12,24 +12,52 @@ struct SwipeActionsSettingsView: View {
       Section("settings.swipeactions.status") {
         Label("settings.swipeactions.status.leading", systemImage: "arrow.left.circle")
         Picker(selection: $userPreferences.swipeActionsStatusLeadingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.leading.left")) {
-          ForEach(StatusAction.allCases) { action in
-            Text(action.displayName).tag(action)
+          Section {
+            Text(StatusAction.none.displayName).tag(StatusAction.none)
+          }
+          Section {
+            ForEach(StatusAction.allCases) { action in
+              if (action != .none) {
+                Text(action.displayName).tag(action)
+              }
+            }
           }
         }
         Picker(selection: $userPreferences.swipeActionsStatusLeadingRight, label: makeSwipeLabel(left: false, text: "settings.swipeactions.status.leading.right")) {
-          ForEach(StatusAction.allCases) { action in
-            Text(action.displayName).tag(action)
+          Section {
+            Text(StatusAction.none.displayName).tag(StatusAction.none)
+          }
+          Section {
+            ForEach(StatusAction.allCases) { action in
+              if (action != .none) {
+                Text(action.displayName).tag(action)
+              }
+            }
           }
         }
         Label("settings.swipeactions.status.trailing", systemImage: "arrow.right.circle")
         Picker(selection: $userPreferences.swipeActionsStatusTrailingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.trailing.left"))  {
-          ForEach(StatusAction.allCases) { action in
-            Text(action.displayName).tag(action)
+          Section {
+            Text(StatusAction.none.displayName).tag(StatusAction.none)
+          }
+          Section {
+            ForEach(StatusAction.allCases) { action in
+              if (action != .none) {
+                Text(action.displayName).tag(action)
+              }
+            }
           }
         }
         Picker(selection: $userPreferences.swipeActionsStatusTrailingRight, label: makeSwipeLabel(left: false, text: "settings.swipeactions.status.trailing.right")) {
-          ForEach(StatusAction.allCases) { action in
-            Text(action.displayName).tag(action)
+          Section {
+            Text(StatusAction.none.displayName).tag(StatusAction.none)
+          }
+          Section {
+            ForEach(StatusAction.allCases) { action in
+              if (action != .none) {
+                Text(action.displayName).tag(action)
+              }
+            }
           }
         }
       }

--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -12,24 +12,24 @@ struct SwipeActionsSettingsView: View {
         Label("settings.swipeactions.status.leading", systemImage: "arrow.left.circle")
         Picker(selection: $userPreferences.swipeActionsStatusLeadingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.leading.left")) {
           Section {
-            Label(StatusAction.none.displayName, systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
+            Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if (action != .none) {
-                Label(action.displayName, systemImage: action.iconName()).tag(action)
+                Label(action.displayName(), systemImage: action.iconName()).tag(action)
               }
             }
           }
         }
         Picker(selection: $userPreferences.swipeActionsStatusLeadingRight, label: makeSwipeLabel(left: false, text: "settings.swipeactions.status.leading.right")) {
           Section {
-            Label(StatusAction.none.displayName, systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
+            Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if (action != .none) {
-                Label(action.displayName, systemImage: action.iconName()).tag(action)
+                Label(action.displayName(), systemImage: action.iconName()).tag(action)
               }
             }
           }
@@ -37,24 +37,24 @@ struct SwipeActionsSettingsView: View {
         Label("settings.swipeactions.status.trailing", systemImage: "arrow.right.circle")
         Picker(selection: $userPreferences.swipeActionsStatusTrailingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.trailing.left"))  {
           Section {
-            Label(StatusAction.none.displayName, systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
+            Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if (action != .none) {
-                Label(action.displayName, systemImage: action.iconName()).tag(action)
+                Label(action.displayName(), systemImage: action.iconName()).tag(action)
               }
             }
           }
         }
         Picker(selection: $userPreferences.swipeActionsStatusTrailingRight, label: makeSwipeLabel(left: false, text: "settings.swipeactions.status.trailing.right")) {
           Section {
-            Label(StatusAction.none.displayName, systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
+            Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if (action != .none) {
-                Label(action.displayName, systemImage: action.iconName()).tag(action)
+                Label(action.displayName(), systemImage: action.iconName()).tag(action)
               }
             }
           }

--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -7,30 +7,29 @@ struct SwipeActionsSettingsView: View {
   @EnvironmentObject private var userPreferences: UserPreferences
   
   var body: some View {
-    
     Form {
       Section("settings.swipeactions.status") {
         Label("settings.swipeactions.status.leading", systemImage: "arrow.left.circle")
         Picker(selection: $userPreferences.swipeActionsStatusLeadingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.leading.left")) {
           Section {
-            Text(StatusAction.none.displayName).tag(StatusAction.none)
+            Label(StatusAction.none.displayName, systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if (action != .none) {
-                Text(action.displayName).tag(action)
+                Label(action.displayName, systemImage: action.iconName()).tag(action)
               }
             }
           }
         }
         Picker(selection: $userPreferences.swipeActionsStatusLeadingRight, label: makeSwipeLabel(left: false, text: "settings.swipeactions.status.leading.right")) {
           Section {
-            Text(StatusAction.none.displayName).tag(StatusAction.none)
+            Label(StatusAction.none.displayName, systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if (action != .none) {
-                Text(action.displayName).tag(action)
+                Label(action.displayName, systemImage: action.iconName()).tag(action)
               }
             }
           }
@@ -38,24 +37,24 @@ struct SwipeActionsSettingsView: View {
         Label("settings.swipeactions.status.trailing", systemImage: "arrow.right.circle")
         Picker(selection: $userPreferences.swipeActionsStatusTrailingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.trailing.left"))  {
           Section {
-            Text(StatusAction.none.displayName).tag(StatusAction.none)
+            Label(StatusAction.none.displayName, systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if (action != .none) {
-                Text(action.displayName).tag(action)
+                Label(action.displayName, systemImage: action.iconName()).tag(action)
               }
             }
           }
         }
         Picker(selection: $userPreferences.swipeActionsStatusTrailingRight, label: makeSwipeLabel(left: false, text: "settings.swipeactions.status.trailing.right")) {
           Section {
-            Text(StatusAction.none.displayName).tag(StatusAction.none)
+            Label(StatusAction.none.displayName, systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if (action != .none) {
-                Text(action.displayName).tag(action)
+                Label(action.displayName, systemImage: action.iconName()).tag(action)
               }
             }
           }

--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -9,7 +9,7 @@ struct SwipeActionsSettingsView: View {
   var body: some View {
     Form {
       Section("settings.swipeactions.status") {
-        Label("settings.swipeactions.status.leading", systemImage: "arrow.left.circle")
+        Label("settings.swipeactions.status.leading", systemImage: "arrow.right.circle")
         Picker(selection: $userPreferences.swipeActionsStatusLeadingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.leading.left")) {
           Section {
             Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
@@ -34,7 +34,7 @@ struct SwipeActionsSettingsView: View {
             }
           }
         }
-        Label("settings.swipeactions.status.trailing", systemImage: "arrow.right.circle")
+        Label("settings.swipeactions.status.trailing", systemImage: "arrow.left.circle")
         Picker(selection: $userPreferences.swipeActionsStatusTrailingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.trailing.left"))  {
           Section {
             Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -171,7 +171,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -169,7 +169,7 @@
 "settings.swipeactions.status.leading" = "Nach rechts wischen";
 "settings.swipeactions.status.leading.left" = "links";
 "settings.swipeactions.status.leading.right" = "links";
-"settings.swipeactions.status.trailing" = " Nach links wischen";
+"settings.swipeactions.status.trailing" = "Nach links wischen";
 "settings.swipeactions.status.trailing.left" = "links";
 "settings.swipeactions.status.trailing.right" = "rechts";
 "settings.swipeactions.status" = "Beitrag";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -175,7 +175,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -173,7 +173,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -169,7 +169,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -169,7 +169,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "settings.swipeactions.status.leading" = "Swipe right";
 "settings.swipeactions.status.leading.left" = "left";
 "settings.swipeactions.status.leading.right" = "right";
-"settings.swipeactions.status.trailing" = " Swipe left";
+"settings.swipeactions.status.trailing" = "Swipe left";
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";

--- a/Packages/Env/Sources/Env/StatusAction.swift
+++ b/Packages/Env/Sources/Env/StatusAction.swift
@@ -40,4 +40,21 @@ public enum StatusAction : String, CaseIterable, Identifiable {
       return isBookmarked ? "bookmark.fill" : "bookmark"
     }
   }
+  
+  public func color(themeTintColor: Color) -> Color {
+    switch self {
+    case .none:
+      return .gray
+    case .reply:
+      return .gray
+    case .quote:
+      return .gray
+    case .boost:
+      return themeTintColor
+    case .favorite:
+      return .yellow
+    case .bookmark:
+      return .pink
+    }
+  }
 }

--- a/Packages/Env/Sources/Env/StatusAction.swift
+++ b/Packages/Env/Sources/Env/StatusAction.swift
@@ -4,9 +4,10 @@ public enum StatusAction : String, CaseIterable, Identifiable {
   public var id: String {
     "\(rawValue)"
   }
-  case none, boost, reply, quote, favorite, bookmark
   
-  public var displayName: LocalizedStringKey {
+  case none, reply, boost, favorite, bookmark, quote
+  
+  public func displayName(isReblogged: Bool = false, isFavorited: Bool = false, isBookmarked: Bool = false) -> LocalizedStringKey {
     switch self {
     case .none:
       return "settings.swipeactions.status.action.none"
@@ -15,11 +16,11 @@ public enum StatusAction : String, CaseIterable, Identifiable {
     case .quote:
       return "settings.swipeactions.status.action.quote"
     case .boost:
-      return "settings.swipeactions.status.action.boost"
+      return isReblogged ? "status.action.unboost" : "settings.swipeactions.status.action.boost"
     case .favorite:
-      return "settings.swipeactions.status.action.favorite"
+      return isFavorited ? "status.action.unfavorite" : "settings.swipeactions.status.action.favorite"
     case .bookmark:
-      return "settings.swipeactions.status.action.bookmark"
+      return isBookmarked ? "status.action.unbookmark" : "settings.swipeactions.status.action.bookmark"
     }
   }
     

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -520,7 +520,7 @@ public struct StatusRowView: View {
     } label: {
       Text(action.displayName)
       Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
-        .foregroundColor(.red)
+        .environment(\.symbolVariants, .none)
     }
   }
   
@@ -534,6 +534,7 @@ public struct StatusRowView: View {
     } label: {
       Text(action.displayName)
       Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
+        .environment(\.symbolVariants, .none)
     }
   }
 }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -455,17 +455,9 @@ public struct StatusRowView: View {
   private var trailingSwipeActions: some View {
     if preferences.swipeActionsStatusTrailingRight != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusTrailingRight)
-        .tint(
-          preferences.swipeActionsStatusTrailingRight == .boost ? theme.tintColor :
-            preferences.swipeActionsStatusTrailingRight == .favorite ? .yellow : preferences.swipeActionsStatusTrailingRight == .bookmark ? .pink : .gray
-        )
     }
     if preferences.swipeActionsStatusTrailingLeft != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusTrailingLeft)
-        .tint(
-          preferences.swipeActionsStatusTrailingLeft == .boost ? theme.tintColor :
-            preferences.swipeActionsStatusTrailingLeft == .favorite ? .yellow : preferences.swipeActionsStatusTrailingLeft == .bookmark ? .pink : .gray
-        )
     }
   }
 
@@ -473,17 +465,9 @@ public struct StatusRowView: View {
   private var leadingSwipeActions: some View {
     if preferences.swipeActionsStatusLeadingLeft != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusLeadingLeft)
-        .tint(
-          preferences.swipeActionsStatusLeadingLeft == .boost ? theme.tintColor :
-            preferences.swipeActionsStatusLeadingLeft == .favorite ? .yellow : preferences.swipeActionsStatusLeadingLeft == .bookmark ? .pink : .gray
-        )
     }
     if preferences.swipeActionsStatusLeadingRight != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusLeadingRight)
-        .tint(
-          preferences.swipeActionsStatusLeadingRight == .boost ? theme.tintColor :
-            preferences.swipeActionsStatusLeadingRight == .favorite ? .yellow : preferences.swipeActionsStatusLeadingRight == .bookmark ? .pink : .gray
-        )
     }
   }
   
@@ -534,6 +518,7 @@ public struct StatusRowView: View {
       Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
         .environment(\.symbolVariants, .none)
     }
+    .tint(action.color(themeTintColor: theme.tintColor))
   }
   
   @ViewBuilder
@@ -548,5 +533,6 @@ public struct StatusRowView: View {
       Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
         .environment(\.symbolVariants, .none)
     }
+    .tint(action.color(themeTintColor: theme.tintColor))
   }
 }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -518,7 +518,7 @@ public struct StatusRowView: View {
       HapticManager.shared.fireHaptic(of: .notification(.success))
       routerPath.presentedSheet = destination
     } label: {
-      Text(action.displayName)
+      Text(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
       Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
         .environment(\.symbolVariants, .none)
     }
@@ -532,7 +532,7 @@ public struct StatusRowView: View {
         await task()
       }
     } label: {
-      Text(action.displayName)
+      Text(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
       Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
         .environment(\.symbolVariants, .none)
     }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -455,11 +455,17 @@ public struct StatusRowView: View {
   private var trailingSwipeActions: some View {
     if preferences.swipeActionsStatusTrailingRight != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusTrailingRight)
-        .tint(theme.tintColor)
+        .tint(
+          preferences.swipeActionsStatusTrailingRight == .boost ? theme.tintColor :
+            preferences.swipeActionsStatusTrailingRight == .favorite ? .yellow : preferences.swipeActionsStatusTrailingRight == .bookmark ? .pink : .gray
+        )
     }
     if preferences.swipeActionsStatusTrailingLeft != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusTrailingLeft)
-        .tint(.gray)
+        .tint(
+          preferences.swipeActionsStatusTrailingLeft == .boost ? theme.tintColor :
+            preferences.swipeActionsStatusTrailingLeft == .favorite ? .yellow : preferences.swipeActionsStatusTrailingLeft == .bookmark ? .pink : .gray
+        )
     }
   }
 
@@ -467,11 +473,17 @@ public struct StatusRowView: View {
   private var leadingSwipeActions: some View {
     if preferences.swipeActionsStatusLeadingLeft != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusLeadingLeft)
-        .tint(theme.tintColor)
+        .tint(
+          preferences.swipeActionsStatusLeadingLeft == .boost ? theme.tintColor :
+            preferences.swipeActionsStatusLeadingLeft == .favorite ? .yellow : preferences.swipeActionsStatusLeadingLeft == .bookmark ? .pink : .gray
+        )
     }
     if preferences.swipeActionsStatusLeadingRight != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusLeadingRight)
-        .tint(.gray)
+        .tint(
+          preferences.swipeActionsStatusLeadingRight == .boost ? theme.tintColor :
+            preferences.swipeActionsStatusLeadingRight == .favorite ? .yellow : preferences.swipeActionsStatusLeadingRight == .bookmark ? .pink : .gray
+        )
     }
   }
   


### PR DESCRIPTION
This removes an unnecessary leading space from `settings.swipeactions.status.trailing`.
Definitely not a big deal, but details matter 🙂

With a space:
<img width="370" alt="SCR-20230212-it5" src="https://user-images.githubusercontent.com/56245920/218293165-400c6125-7d7a-4ea9-91a8-f26bab1bc10c.png">

Removed:
<img width="368" alt="SCR-20230212-iuc" src="https://user-images.githubusercontent.com/56245920/218293177-ecbdb3cd-3ad2-4f5a-a9c1-fd0f3e5fe4cf.png">