### PR TITLE
Improve swipe actions

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -59,6 +59,9 @@ struct SwipeActionsSettingsView: View {
             }
           }
         }
+        Toggle(isOn: $userPreferences.swipeActionsUseThemeColor) {
+          Label("Use theme colors instead of default colors", systemImage: "paintbrush.pointed")
+        }
       }
       .listRowBackground(theme.primaryBackgroundColor)
     }

--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -62,6 +62,11 @@ struct SwipeActionsSettingsView: View {
         Toggle(isOn: $userPreferences.swipeActionsUseThemeColor) {
           Label("settings.swipeactions.status.use-theme-colors", systemImage: "paintbrush.pointed")
         }
+        Picker(selection: $userPreferences.swipeActionsIconStyle, label: Label("Icon style", systemImage: "text.below.photo")) {
+          ForEach(UserPreferences.SwipeActionsIconStyle.allCases, id: \.rawValue) { style in
+            Text(style.description).tag(style)
+          }
+        }
       }
       .listRowBackground(theme.primaryBackgroundColor)
     }

--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -62,7 +62,7 @@ struct SwipeActionsSettingsView: View {
         Toggle(isOn: $userPreferences.swipeActionsUseThemeColor) {
           Label("settings.swipeactions.status.use-theme-colors", systemImage: "paintbrush.pointed")
         }
-        Picker(selection: $userPreferences.swipeActionsIconStyle, label: Label("Icon style", systemImage: "text.below.photo")) {
+        Picker(selection: $userPreferences.swipeActionsIconStyle, label: Label("settings.swipeactions.status.icon-style", systemImage: "text.below.photo")) {
           ForEach(UserPreferences.SwipeActionsIconStyle.allCases, id: \.rawValue) { style in
             Text(style.description).tag(style)
           }

--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -60,7 +60,7 @@ struct SwipeActionsSettingsView: View {
           }
         }
         Toggle(isOn: $userPreferences.swipeActionsUseThemeColor) {
-          Label("Use theme colors instead of default colors", systemImage: "paintbrush.pointed")
+          Label("settings.swipeactions.status.use-theme-colors", systemImage: "paintbrush.pointed")
         }
       }
       .listRowBackground(theme.primaryBackgroundColor)

--- a/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SwipeActionsSettingsView.swift
@@ -12,24 +12,24 @@ struct SwipeActionsSettingsView: View {
         Label("settings.swipeactions.status.leading", systemImage: "arrow.right.circle")
         Picker(selection: $userPreferences.swipeActionsStatusLeadingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.leading.left")) {
           Section {
-            Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
+            Text(StatusAction.none.displayName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if action != .none {
-                Label(action.displayName(), systemImage: action.iconName()).tag(action)
+                Text(action.displayName()).tag(action)
               }
             }
           }
         }
         Picker(selection: $userPreferences.swipeActionsStatusLeadingRight, label: makeSwipeLabel(left: false, text: "settings.swipeactions.status.leading.right")) {
           Section {
-            Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
+            Text(StatusAction.none.displayName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if action != .none {
-                Label(action.displayName(), systemImage: action.iconName()).tag(action)
+                Text(action.displayName()).tag(action)
               }
             }
           }
@@ -37,24 +37,24 @@ struct SwipeActionsSettingsView: View {
         Label("settings.swipeactions.status.trailing", systemImage: "arrow.left.circle")
         Picker(selection: $userPreferences.swipeActionsStatusTrailingLeft, label: makeSwipeLabel(left: true, text: "settings.swipeactions.status.trailing.left")) {
           Section {
-            Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
+            Text(StatusAction.none.displayName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if action != .none {
-                Label(action.displayName(), systemImage: action.iconName()).tag(action)
+                Text(action.displayName()).tag(action)
               }
             }
           }
         }
         Picker(selection: $userPreferences.swipeActionsStatusTrailingRight, label: makeSwipeLabel(left: false, text: "settings.swipeactions.status.trailing.right")) {
           Section {
-            Label(StatusAction.none.displayName(), systemImage: StatusAction.none.iconName()).tag(StatusAction.none)
+            Text(StatusAction.none.displayName()).tag(StatusAction.none)
           }
           Section {
             ForEach(StatusAction.allCases) { action in
               if action != .none {
-                Label(action.displayName(), systemImage: action.iconName()).tag(action)
+                Text(action.displayName()).tag(action)
               }
             }
           }

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -36,6 +36,8 @@
 "enum.status-actions-display.only-buttons" = "Només els botons";
 "enum.status-display-style.compact" = "Compacte";
 "enum.status-display-style.large" = "Gran";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Dominis";
@@ -176,6 +178,7 @@
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Exploreu";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Exploreu";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "settings.swipeactions.status.trailing.left" = "links";
 "settings.swipeactions.status.trailing.right" = "rechts";
 "settings.swipeactions.status" = "Beitrag";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 "enum.expand-media.show" = "Alle zeigen";
 "enum.expand-media.hide" = "Alle ausblenden";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Nur Buttons";
 "enum.status-display-style.compact" = "Kompakt";
 "enum.status-display-style.large" = "Groß";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domains";
@@ -174,6 +176,7 @@
 "settings.swipeactions.status.trailing.right" = "rechts";
 "settings.swipeactions.status" = "Beitrag";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 "enum.expand-media.show" = "Alle zeigen";
 "enum.expand-media.hide" = "Alle ausblenden";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Only buttons";
 "enum.status-display-style.compact" = "Compact";
 "enum.status-display-style.large" = "Large";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domains";
@@ -180,6 +182,7 @@
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Explore";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -179,6 +179,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Explore";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -177,6 +177,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Explore";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Only buttons";
 "enum.status-display-style.compact" = "Compact";
 "enum.status-display-style.large" = "Large";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domains";
@@ -178,6 +180,7 @@
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Explore";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Sólo botones";
 "enum.status-display-style.compact" = "Compacto";
 "enum.status-display-style.large" = "Grande";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Dominios";
@@ -174,6 +176,7 @@
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 "enum.expand-media.show" = "Siempre";
 "enum.expand-media.hide" = "Nunca";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 "enum.expand-media.show" = "Siempre";
 "enum.expand-media.hide" = "Nunca";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "settings.swipeactions.status.trailing.left" = "ezker";
 "settings.swipeactions.status.trailing.right" = "eskuma";
 "settings.swipeactions.status" = "Argitaratu";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 "enum.expand-media.show" = "Erakutsi guztia";
 "enum.expand-media.hide" = "Ezkutatu guztia";
@@ -238,7 +239,7 @@
 "account.follow-request.accept" = "Onartu";
 "account.follow-request.reject" = "Baztertu";
 "account.follow-requests.pending-requests" = "Erabakitzeko eskaerak";
-"account.follow-requests.instructions" = "Erabiltzaile horiek ez dituzte zure bidalketak ikusiko onartzen ez dituzun arte."; 
+"account.follow-requests.instructions" = "Erabiltzaile horiek ez dituzte zure bidalketak ikusiko onartzen ez dituzun arte.";
 "account.followers" = "Jarraitzaile";
 "account.following" = "Jarraitzen";
 "account.list.create" = "Sortu zerrenda berria";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Botoiak bakarrik";
 "enum.status-display-style.compact" = "Trinkoa";
 "enum.status-display-style.large" = "Handia";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domeinuak";
@@ -174,6 +176,7 @@
 "settings.swipeactions.status.trailing.right" = "eskuma";
 "settings.swipeactions.status" = "Argitaratu";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 "enum.expand-media.show" = "Erakutsi guztia";
 "enum.expand-media.hide" = "Ezkutatu guztia";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Seulement les boutons";
 "enum.status-display-style.compact" = "Compact";
 "enum.status-display-style.large" = "Grand";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domaines";
@@ -177,6 +179,7 @@
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Explorer";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Explorer";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Solo bottoni";
 "enum.status-display-style.compact" = "Compatto";
 "enum.status-display-style.large" = "Completo";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domini";
@@ -177,6 +179,7 @@
 "settings.swipeactions.status.trailing.right" = "destra";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Esplora";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Esplora";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "左";
 "settings.swipeactions.status.trailing.right" = "右";
 "settings.swipeactions.status" = "投稿";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "エクスプローラー";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "ボタンのみ";
 "enum.status-display-style.compact" = "コンパクト";
 "enum.status-display-style.large" = "ラージ";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "ドメイン";
@@ -177,6 +179,7 @@
 "settings.swipeactions.status.trailing.right" = "右";
 "settings.swipeactions.status" = "投稿";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "エクスプローラー";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "버튼만 표시";
 "enum.status-display-style.compact" = "작게";
 "enum.status-display-style.large" = "크게";
+"enum.swipeactions.icon-with-text" = "아이콘과 텍스트";
+"enum.swipeactions.icon-only" = "아이콘만";
 
 // MARK: Instances
 "instance.info.domains" = "도메인";
@@ -175,8 +177,9 @@
 "settings.swipeactions.status.trailing" = "왼쪽으로 쓸어넘길 때";
 "settings.swipeactions.status.trailing.left" = "왼쪽 버튼";
 "settings.swipeactions.status.trailing.right" = "오른쪽 버튼";
-"settings.swipeactions.status" = "글을";
+"settings.swipeactions.status" = "글";
 "settings.swipeactions.status.use-theme-colors" = "기본 색상 대신 테마 색상 사용";
+"settings.swipeactions.status.icon-style" = "아이콘 모양";
 
 // MARK: Tabs
 "tab.explore" = "둘러보기";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "왼쪽 버튼";
 "settings.swipeactions.status.trailing.right" = "오른쪽 버튼";
 "settings.swipeactions.status" = "글을";
+"settings.swipeactions.status.use-theme-colors" = "기본 색상 대신 테마 색상 사용";
 
 // MARK: Tabs
 "tab.explore" = "둘러보기";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Utforsk";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Bare knapper";
 "enum.status-display-style.compact" = "Kompakt";
 "enum.status-display-style.large" = "Stor";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domener";
@@ -177,6 +179,7 @@
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Utforsk";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Zonder tekst";
 "enum.status-display-style.compact" = "Compact";
 "enum.status-display-style.large" = "Groot";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domeinen";
@@ -174,6 +176,7 @@
 "settings.swipeactions.status.trailing.right" = "rechts";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Ontdekken";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Ontdekken";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Tylko przyciski";
 "enum.status-display-style.compact" = "Pomniejszone";
 "enum.status-display-style.large" = "Duże";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domeny";
@@ -177,6 +179,7 @@
 "settings.swipeactions.status.trailing.right" = "prawa";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Odkrywaj";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "lewa";
 "settings.swipeactions.status.trailing.right" = "prawa";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Odkrywaj";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Somente botões";
 "enum.status-display-style.compact" = "Compacto";
 "enum.status-display-style.large" = "Largo";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domínios";
@@ -177,6 +179,7 @@
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Explorar";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Explorar";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "left";
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "Keşfet";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "Sadece Butonlar";
 "enum.status-display-style.compact" = "Kompakt";
 "enum.status-display-style.large" = "Geniş";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "Domainler";
@@ -177,6 +179,7 @@
 "settings.swipeactions.status.trailing.right" = "right";
 "settings.swipeactions.status" = "Post";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "Keşfet";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.swipeactions.status.trailing.left" = "左";
 "settings.swipeactions.status.trailing.right" = "右";
 "settings.swipeactions.status" = "嘟文";
+"settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
 
 // MARK: Tabs
 "tab.explore" = "探索";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "enum.status-actions-display.only-buttons" = "仅图标";
 "enum.status-display-style.compact" = "紧凑";
 "enum.status-display-style.large" = "宽松";
+"enum.swipeactions.icon-with-text" = "Icon with text";
+"enum.swipeactions.icon-only" = "Icon only";
 
 // MARK: Instances
 "instance.info.domains" = "域名";
@@ -177,6 +179,7 @@
 "settings.swipeactions.status.trailing.right" = "右";
 "settings.swipeactions.status" = "嘟文";
 "settings.swipeactions.status.use-theme-colors" = "Use theme colors instead of default colors";
+"settings.swipeactions.status.icon-style" = "Icon style";
 
 // MARK: Tabs
 "tab.explore" = "探索";

--- a/Packages/Env/Sources/Env/StatusAction.swift
+++ b/Packages/Env/Sources/Env/StatusAction.swift
@@ -41,14 +41,18 @@ public enum StatusAction: String, CaseIterable, Identifiable {
     }
   }
 
-  public func color(themeTintColor: Color) -> Color {
+  public func color(themeTintColor: Color, useThemeColor: Bool, outside: Bool) -> Color {
+    if (useThemeColor) {
+      return outside ? themeTintColor : .gray
+    }
+    
     switch self {
     case .none:
       return .gray
     case .reply:
-      return .gray
+      return outside ? .gray : Color(white: 0.45)
     case .quote:
-      return .gray
+      return outside ? .gray : Color(white: 0.45)
     case .boost:
       return themeTintColor
     case .favorite:

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -45,17 +45,17 @@ public class UserPreferences: ObservableObject {
   @AppStorage("swipeactions-status-leading-left") public var swipeActionsStatusLeadingLeft = StatusAction.reply
   @AppStorage("swipeactions-status-leading-right") public var swipeActionsStatusLeadingRight = StatusAction.none
   @AppStorage("swipeactions-use-theme-color") public var swipeActionsUseThemeColor = false
-  @AppStorage("swipeactions-icon-style") public var swipeActionsIconStyle: SwipeActionsIconStyle = .iconsWithText
-  
+  @AppStorage("swipeactions-icon-style") public var swipeActionsIconStyle: SwipeActionsIconStyle = .iconWithText
+
   public enum SwipeActionsIconStyle: String, CaseIterable {
-    case iconsWithText, iconsOnly
-    
+    case iconWithText, iconOnly
+
     public var description: LocalizedStringKey {
       switch self {
-      case .iconsWithText:
-        return "icons with text"
-      case .iconsOnly:
-        return "icons only"
+      case .iconWithText:
+        return "enum.swipeactions.icon-with-text"
+      case .iconOnly:
+        return "enum.swipeactions.icon-only"
       }
     }
   }

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -44,6 +44,7 @@ public class UserPreferences: ObservableObject {
   @AppStorage("swipeactions-status-trailing-left") public var swipeActionsStatusTrailingLeft = StatusAction.boost
   @AppStorage("swipeactions-status-leading-left") public var swipeActionsStatusLeadingLeft = StatusAction.reply
   @AppStorage("swipeactions-status-leading-right") public var swipeActionsStatusLeadingRight = StatusAction.none
+  @AppStorage("swipeactions-use-theme-color") public var swipeActionsUseThemeColor = false
 
   public var postVisibility: Models.Visibility {
     if useInstanceContentSettings {

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -45,6 +45,20 @@ public class UserPreferences: ObservableObject {
   @AppStorage("swipeactions-status-leading-left") public var swipeActionsStatusLeadingLeft = StatusAction.reply
   @AppStorage("swipeactions-status-leading-right") public var swipeActionsStatusLeadingRight = StatusAction.none
   @AppStorage("swipeactions-use-theme-color") public var swipeActionsUseThemeColor = false
+  @AppStorage("swipeactions-icon-style") public var swipeActionsIconStyle: SwipeActionsIconStyle = .iconsWithText
+  
+  public enum SwipeActionsIconStyle: String, CaseIterable {
+    case iconsWithText, iconsOnly
+    
+    public var description: LocalizedStringKey {
+      switch self {
+      case .iconsWithText:
+        return "icons with text"
+      case .iconsOnly:
+        return "icons only"
+      }
+    }
+  }
 
   public var postVisibility: Models.Visibility {
     if useInstanceContentSettings {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -530,9 +530,7 @@ public struct StatusRowView: View {
       HapticManager.shared.fireHaptic(of: .notification(.success))
       routerPath.presentedSheet = destination
     } label: {
-      Text(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
-      Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
-        .environment(\.symbolVariants, .none)
+      makeSwipeLabel(action: action, style: preferences.swipeActionsIconStyle)
     }
   }
 
@@ -544,8 +542,20 @@ public struct StatusRowView: View {
         await task()
       }
     } label: {
-      Text(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
-      Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
+      makeSwipeLabel(action: action, style: preferences.swipeActionsIconStyle)
+    }
+  }
+  
+  @ViewBuilder
+  private func makeSwipeLabel(action: StatusAction, style: UserPreferences.SwipeActionsIconStyle) -> some View {
+    switch (style) {
+    case .iconsOnly:
+      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
+        .labelStyle(.iconOnly)
+        .environment(\.symbolVariants, .none)
+    case .iconsWithText:
+      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
+        .labelStyle(.titleAndIcon)
         .environment(\.symbolVariants, .none)
     }
   }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -467,9 +467,11 @@ public struct StatusRowView: View {
   private var trailingSwipeActions: some View {
     if preferences.swipeActionsStatusTrailingRight != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusTrailingRight)
+        .tint(preferences.swipeActionsStatusTrailingRight.color(themeTintColor: theme.tintColor, useThemeColor: preferences.swipeActionsUseThemeColor, outside: true))
     }
     if preferences.swipeActionsStatusTrailingLeft != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusTrailingLeft)
+        .tint(preferences.swipeActionsStatusTrailingLeft.color(themeTintColor: theme.tintColor, useThemeColor: preferences.swipeActionsUseThemeColor, outside: false))
     }
   }
 
@@ -477,9 +479,11 @@ public struct StatusRowView: View {
   private var leadingSwipeActions: some View {
     if preferences.swipeActionsStatusLeadingLeft != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusLeadingLeft)
+        .tint(preferences.swipeActionsStatusLeadingLeft.color(themeTintColor: theme.tintColor, useThemeColor: preferences.swipeActionsUseThemeColor, outside: true))
     }
     if preferences.swipeActionsStatusLeadingRight != StatusAction.none {
       makeSwipeButton(action: preferences.swipeActionsStatusLeadingRight)
+        .tint(preferences.swipeActionsStatusLeadingRight.color(themeTintColor: theme.tintColor, useThemeColor: preferences.swipeActionsUseThemeColor, outside: false))
     }
   }
 
@@ -530,7 +534,6 @@ public struct StatusRowView: View {
       Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
         .environment(\.symbolVariants, .none)
     }
-    .tint(action.color(themeTintColor: theme.tintColor))
   }
 
   @ViewBuilder
@@ -545,6 +548,5 @@ public struct StatusRowView: View {
       Image(systemName: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
         .environment(\.symbolVariants, .none)
     }
-    .tint(action.color(themeTintColor: theme.tintColor))
   }
 }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -549,11 +549,11 @@ public struct StatusRowView: View {
   @ViewBuilder
   private func makeSwipeLabel(action: StatusAction, style: UserPreferences.SwipeActionsIconStyle) -> some View {
     switch (style) {
-    case .iconsOnly:
+    case .iconOnly:
       Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
         .labelStyle(.iconOnly)
         .environment(\.symbolVariants, .none)
-    case .iconsWithText:
+    case .iconWithText:
       Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
         .labelStyle(.titleAndIcon)
         .environment(\.symbolVariants, .none)


### PR DESCRIPTION
[context](https://github.com/Dimillian/IceCubesApp/pull/808#issuecomment-1427116198)

- Remove icons from menus
- Fix two gray buttons together being difficult to distinguish
- Add a new toggle to use theme tint colors instead of button colors (of boost, favorite, bookmark ones)
  - With the toggle turned off (use default button colors):
  - ![SCR-20230213-hwe](https://user-images.githubusercontent.com/56245920/218366716-6aae79aa-d1c5-4c5d-a3c7-bb2204935e08.png)
  - on (use theme colors):
  - ![SCR-20230213-hw4](https://user-images.githubusercontent.com/56245920/218366760-da288227-5b13-4489-af70-4f7c369a8d9b.png)

What I'm not sure about
- Where should be the toggle at? display settings or swipe actions settings?
- Default value