### PR TITLE
Use previously unused LocalizedStringKey in language selector

### DIFF
--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -157,7 +157,7 @@ struct StatusEditorAccessoryView: View {
       List {
         if languageSearch.isEmpty {
           if !recentlyUsedLanguages.isEmpty {
-            Section("Recently Used") {
+            Section("status.editor.language-select.recently-used") {
               languageSheetSection(languages: recentlyUsedLanguages)
             }
           }


### PR DESCRIPTION
The string "Recently Used" was not replaced by a `LocalizedStringKey` yet. 

![image](https://user-images.githubusercontent.com/5955957/218509792-be906bc8-5068-4975-8d83-2eb09305c066.jpeg)

I checked and the string "status.editor.language-select.recently-used" is available in all the present localizations.

