### PR TITLE
Fix build error for env package

### DIFF
--- a/Packages/Env/Package.swift
+++ b/Packages/Env/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
   dependencies: [
     .package(name: "Models", path: "../Models"),
     .package(name: "Network", path: "../Network"),
+    .package(url: "https://github.com/evgenyneu/keychain-swift", branch: "master"),
   ],
   targets: [
     .target(
@@ -25,6 +26,7 @@ let package = Package(
       dependencies: [
         .product(name: "Models", package: "Models"),
         .product(name: "Network", package: "Network"),
+        .product(name: "KeychainSwift", package: "keychain-swift"),
       ]
     ),
   ]


### PR DESCRIPTION
`Env` Package does not contain `KeychainSwift` dependency, so it could not be built by itself.
Adding the `KeychainSwift` dependency eliminated the build error.  
This will allow people who are not in the Apple Developer Program to build.