### PR TITLE
Add setting to disable display of alt texts for media

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -19,6 +19,12 @@ struct ContentSettingsView: View {
         }
       }.listRowBackground(theme.primaryBackgroundColor)
 
+      Section("settings.content.media") {
+        Toggle(isOn: $userPreferences.showAltTextForMedia) {
+         Text("settings.content.media.show.alt")
+        }
+      }
+
       Section("settings.content.instance-settings") {
         Toggle(isOn: $userPreferences.useInstanceContentSettings) {
           Text("settings.content.use-instance-settings")
@@ -61,7 +67,9 @@ struct ContentSettingsView: View {
         }
         .disabled(userPreferences.useInstanceContentSettings)
       }
+
       .listRowBackground(theme.primaryBackgroundColor)
+      
     }
     .navigationTitle("settings.content.navigation-title")
     .scrollContentBackground(.hidden)

--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -23,7 +23,7 @@ struct ContentSettingsView: View {
         Toggle(isOn: $userPreferences.showAltTextForMedia) {
          Text("settings.content.media.show.alt")
         }
-      }
+      }.listRowBackground(theme.primaryBackgroundColor)
 
       Section("settings.content.instance-settings") {
         Toggle(isOn: $userPreferences.useInstanceContentSettings) {

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -112,6 +112,8 @@
 "settings.content.expand-media" = "Visibilitat del contingut multimèdia";
 "settings.content.default-sensitive" = "Marca sempre el contingut com a sensible";
 "settings.content.default-visibility" = "Visibilitat de les publicacions";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Llegint";
 "settings.content.posting" = "Publicant";
 "enum.expand-media.show" = "Mostra-ho tot";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -137,6 +137,8 @@
 "settings.content.expand-media" = "Medienansicht";
 "settings.content.default-sensitive" = "Medien immer als sensibel kennzeichnen";
 "settings.content.default-visibility" = "Sichtbarkeit Beiträge";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Lesen";
 "settings.content.posting" = "Schreiben";
 "settings.push.duplicate.title" = "Doppelte-Mitteilungen-Korrigierer";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -118,6 +118,8 @@
 "settings.content.expand-media" = "Media display";
 "settings.content.default-sensitive" = "Always mark media as sensitive";
 "settings.content.default-visibility" = "Posting visibility";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Reading";
 "settings.content.posting" = "Posting";
 "enum.expand-media.show" = "Show All";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -117,6 +117,8 @@
 "settings.content.expand-media" = "Media display";
 "settings.content.default-sensitive" = "Always mark media as sensitive";
 "settings.content.default-visibility" = "Posting visibility";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Reading";
 "settings.content.posting" = "Posting";
 "enum.expand-media.show" = "Show All";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -137,6 +137,8 @@
 "settings.content.expand-media" = "Mostrar el contenido multimedia";
 "settings.content.default-sensitive" = "Marcar siempre el contenido multimedia como sensible";
 "settings.content.default-visibility" = "Publicar visibilidad";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Leyendo";
 "settings.content.posting" = "Publicando";
 "settings.push.duplicate.title" = "Arreglar notificaciones duplicadas";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -137,6 +137,8 @@
 "settings.content.expand-media" = "Multimedia erakusteko hobespenak";
 "settings.content.default-sensitive" = "Markatu eduki guztia hunkigarri gisa";
 "settings.content.default-visibility" = "Edukiaren irismena";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Irakurtzean";
 "settings.content.posting" = "Bidaltzean";
 "settings.push.duplicate.title" = "Bikoiztutako jakinarazpenen konpontzailea";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "settings.content.expand-media" = "Affichage des médias";
 "settings.content.default-sensitive" = "Toujours marquer les médias comme sensibles";
 "settings.content.default-visibility" = "Visibilité des publications";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Lecture";
 "settings.content.posting" = "Publication";
 "enum.expand-media.show" = "Afficher tout";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -137,6 +137,8 @@
 "settings.content.expand-media" = "Visualizzazione dei media";
 "settings.content.default-sensitive" = "Segnala sempre i contenuti come sensibili";
 "settings.content.default-visibility" = "Visibilità del post";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Lettura";
 "settings.content.posting" = "Composizione";
 "enum.expand-media.show" = "Mostra tutti";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -117,6 +117,8 @@
 "settings.content.expand-media" = "メディア表示";
 "settings.content.default-sensitive" = "常にメディアをセンシティブなものとしてマークする";
 "settings.content.default-visibility" = "投稿の可視化";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "リーディング";
 "settings.content.posting" = "ポスティング";
 "enum.expand-media.show" = "全て表示";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "settings.content.expand-media" = "표시할 미디어";
 "settings.content.default-sensitive" = "내 미디어 항상 민감함으로 표시";
 "settings.content.default-visibility" = "글 기본 공개 범위";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "읽을 때";
 "settings.content.posting" = "올릴 때";
 "enum.expand-media.show" = "모두 표시하기";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -117,6 +117,8 @@
 "settings.content.expand-media" = "Medievisning";
 "settings.content.default-sensitive" = "Marker alltid medier som sensitive";
 "settings.content.default-visibility" = "Innleggssynlighet";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Lesing";
 "settings.content.posting" = "Innlegg";
 "enum.expand-media.show" = "Vis alle";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -137,6 +137,8 @@
 "settings.content.expand-media" = "Mediaweergave";
 "settings.content.default-sensitive" = "Markeer media standaard als gevoelig";
 "settings.content.default-visibility" = "Standaard postzichtbaarheid";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Lezen";
 "settings.content.posting" = "Posten";
 "settings.push.duplicate.title" = "Dubbele meldingen";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "settings.content.expand-media" = "Multimedia";
 "settings.content.default-sensitive" = "Oznaczaj media jako wrażliwe";
 "settings.content.default-visibility" = "Widoczność postów";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Czytanie postów";
 "settings.content.posting" = "Wysyłanie postów";
 "enum.expand-media.show" = "Pokazuj wszystkie";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "settings.content.expand-media" = "Exibição de mídia";
 "settings.content.default-sensitive" = "Sempre marcar mídias como sensíveis";
 "settings.content.default-visibility" = "Visibilidade da postagem";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Lendo";
 "settings.content.posting" = "Postagem";
 "enum.expand-media.show" = "Exibir Todas";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "settings.content.expand-media" = "Media display";
 "settings.content.default-sensitive" = "Always mark media as sensitive";
 "settings.content.default-visibility" = "Posting visibility";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Reading";
 "settings.content.posting" = "Posting";
 "enum.expand-media.show" = "Show All";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -138,6 +138,8 @@
 "settings.content.expand-media" = "媒体显示";
 "settings.content.default-sensitive" = "始终将媒体标为敏感内容";
 "settings.content.default-visibility" = "默认发布内容可见性";
+"settings.content.media" = "Media";
+"settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "阅读设置";
 "settings.content.posting" = "发布设置";
 

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -37,7 +37,8 @@ public class UserPreferences: ObservableObject {
   @AppStorage("haptic_button_press") public var hapticButtonPressEnabled = true
 
   @AppStorage("show_tab_label_iphone") public var showiPhoneTabLabel = true
-
+  @AppStorage("show_alt_text_for_media") public var showAltTextForMedia = true
+  
   @AppStorage("show_second_column_ipad") public var showiPadSecondaryColumn = true
 
   @AppStorage("swipeactions-status-trailing-right") public var swipeActionsStatusTrailingRight = StatusAction.favorite

--- a/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusMediaPreviewView.swift
@@ -175,7 +175,7 @@ public struct StatusMediaPreviewView: View {
       if sensitive {
         cornerSensitiveButton
       }
-      if let alt = attachment.description, !alt.isEmpty, !isNotifications {
+      if let alt = attachment.description, !alt.isEmpty, !isNotifications, preferences.showAltTextForMedia {
         Group {
           Button {
             altTextDisplayed = alt
@@ -220,7 +220,7 @@ public struct StatusMediaPreviewView: View {
               if sensitive {
                 cornerSensitiveButton
               }
-              if let alt = attachment.description, !alt.isEmpty, !isNotifications {
+              if let alt = attachment.description, !alt.isEmpty, !isNotifications, preferences.showAltTextForMedia {
                 Button {
                   altTextDisplayed = alt
                   isAltAlertDisplayed = true


### PR DESCRIPTION
Users can now disable the display of the `ALT` button on media if they don't need it so it won't cover the image.

Closes #850