### PR TITLE
Fix an empty dialog would appear if the selected language was empty

### DIFF
--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -145,6 +145,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
   func evaluateLanguages() {
     if let detectedLang = detectLanguage(text: statusText.string),
        let selectedLanguage = selectedLanguage,
+       selectedLanguage != "",
        selectedLanguage != detectedLang
     {
       languageConfirmationDialogLanguages = ["detected": detectedLang,


### PR DESCRIPTION
The language in the server settings is empty in my instance.

In that case, we dealt with the problem that the language setting dialog was empty when posting.

![IMG_9922](https://user-images.githubusercontent.com/108506642/218950112-2285b579-f798-4e0b-8e7e-97e49b412511.PNG)