### PR TITLE
fix: some Localization.strings in Japanese

### DIFF
--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -186,7 +186,7 @@
 "settings.swipeactions.status.icon-style" = "アイコンスタイル";
 
 // MARK: Tabs
-"tab.explore" = "エクスプローラー";
+"tab.explore" = "検索";
 "tab.federated" = "連合";
 "tab.local" = "ローカル";
 "tab.messages" = "メッセージ";
@@ -278,7 +278,7 @@
 "design.theme.toots-preview" = "トゥートプレビュー";
 
 // MARK: Package: Explore
-"explore.navigation-title" = "エクスプローラー";
+"explore.navigation-title" = "検索";
 "explore.search.message-%@" = "ここからあらゆるものを検索することができます %@";
 "explore.search.prompt" = "ユーザー、投稿、タグの検索";
 "explore.search.title" = "インスタンスの検索";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -241,14 +241,14 @@
 "account.edit.post-settings.sensitive" = "センシティブな内容";
 "account.favorited-by" = "お気に入りされた";
 "account.follow.follow" = "フォロー";
-"account.follow.following" = "フォローしている";
+"account.follow.following" = "フォロー中";
 "account.follow.requested" = "リクエストしました";
 "account.follow-request.accept" = "承認";
 "account.follow-request.reject" = "拒否";
 "account.follow-requests.pending-requests" = "リクエスト申請中";
 "account.follow-requests.instructions" = "これらのユーザーはあなたが承認するまで、あなたの投稿を見ることはできません";
 "account.followers" = "フォロワー";
-"account.following" = "フォローしている";
+"account.following" = "フォロー中";
 "account.list.create" = "新しいリストを作成";
 "account.list.create.confirm" = "リストを作成";
 "account.list.create.description" = "リストの名前を入力";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -256,7 +256,7 @@
 "account.list.name" = "リストの名前";
 "account.post.pinned" = "固定した投稿";
 "account.posts" = "投稿";
-"account.relation.follows-you" = "あなたをフォローしている";
+"account.relation.follows-you" = "フォローされています";
 "account.joined" = "登録日";
 "account.action.logout" = "アカウントをログアウトする";
 


### PR DESCRIPTION
# Overview
I felt uncomfortable with some of the Japanese and have corrected them.
Basically, I made the text similar to Twitter as follows.

|Before|After|Twitter|
|--|--|--|
|![IMG_DEDC509DF775-1](https://user-images.githubusercontent.com/39183069/219041066-a73bbe7f-d89f-4ebc-a4f8-e1fea61b585e.jpeg)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-15 at 22 22 54](https://user-images.githubusercontent.com/39183069/219041187-04ad6cbe-f19d-45b6-adea-365d2bfda3c3.jpg)|![IMG_D3881F883852-1](https://user-images.githubusercontent.com/39183069/219041266-644f2043-7236-44f1-9929-c79bbe85358a.jpeg)|

