### PR TITLE
add 12 hour duration to poll duration menu

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -289,6 +289,7 @@
 "env.poll-duration.30m" = "30 хвілін";
 "env.poll-duration.1h" = "1 гадзіна";
 "env.poll-duration.6h" = "6 гадзін";
+"env.poll-duration.12h" = "12 гадзін";
 "env.poll-duration.1d" = "1 дзень";
 "env.poll-duration.3d" = "3 дні";
 "env.poll-duration.7d" = "7 дзён";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -296,6 +296,7 @@
 "env.poll-duration.30m" = "30 minuts";
 "env.poll-duration.1h" = "1 hora";
 "env.poll-duration.6h" = "6 hores";
+"env.poll-duration.12h" = "12 hores";
 "env.poll-duration.1d" = "1 dia";
 "env.poll-duration.3d" = "3 dies";
 "env.poll-duration.7d" = "7 dies";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -298,6 +298,7 @@
 "env.poll-duration.30m" = "30 Minuten";
 "env.poll-duration.1h" = "1 Stunde";
 "env.poll-duration.6h" = "6 Stunden";
+"env.poll-duration.12h" = "12 Stunden";
 "env.poll-duration.1d" = "1 Tag";
 "env.poll-duration.3d" = "3 Tage";
 "env.poll-duration.7d" = "7 Tage";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -299,6 +299,7 @@
 "env.poll-duration.30m" = "30 minutes";
 "env.poll-duration.1h" = "1 hour";
 "env.poll-duration.6h" = "6 hours";
+"env.poll-duration.12h" = "12 hours";
 "env.poll-duration.1d" = "1 day";
 "env.poll-duration.3d" = "3 days";
 "env.poll-duration.7d" = "7 days";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -298,6 +298,7 @@
 "env.poll-duration.30m" = "30 minutes";
 "env.poll-duration.1h" = "1 hour";
 "env.poll-duration.6h" = "6 hours";
+"env.poll-duration.12h" = "12 hours";
 "env.poll-duration.1d" = "1 day";
 "env.poll-duration.3d" = "3 days";
 "env.poll-duration.7d" = "7 days";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -298,6 +298,7 @@
 "env.poll-duration.30m" = "30 minutos";
 "env.poll-duration.1h" = "1 hora";
 "env.poll-duration.6h" = "6 horas";
+"env.poll-duration.12h" = "12 horas";
 "env.poll-duration.1d" = "1 día";
 "env.poll-duration.3d" = "3 dias";
 "env.poll-duration.7d" = "7 dias";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -297,6 +297,7 @@
 "env.poll-duration.30m" = "30 minutu";
 "env.poll-duration.1h" = "Ordubete";
 "env.poll-duration.6h" = "6 ordu";
+"env.poll-duration.12h" = "12 ordu";
 "env.poll-duration.1d" = "Egun 1";
 "env.poll-duration.3d" = "3 egun";
 "env.poll-duration.7d" = "7 egun";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -297,6 +297,7 @@
 "env.poll-duration.30m" = "30 minutes";
 "env.poll-duration.1h" = "1 heure";
 "env.poll-duration.6h" = "6 heures";
+"env.poll-duration.12h" = "12 heures";
 "env.poll-duration.1d" = "1 jour";
 "env.poll-duration.3d" = "3 jours";
 "env.poll-duration.7d" = "7 jours";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -298,6 +298,7 @@
 "env.poll-duration.30m" = "30 minuti";
 "env.poll-duration.1h" = "1 ora";
 "env.poll-duration.6h" = "6 ore";
+"env.poll-duration.12h" = "12 ore";
 "env.poll-duration.1d" = "1 giorno";
 "env.poll-duration.3d" = "3 giorni";
 "env.poll-duration.7d" = "7 giorni";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -297,6 +297,7 @@
 "env.poll-duration.30m" = "30分間";
 "env.poll-duration.1h" = "1時間";
 "env.poll-duration.6h" = "6時間";
+"env.poll-duration.12h" = "12時間";
 "env.poll-duration.1d" = "1日間";
 "env.poll-duration.3d" = "3日間";
 "env.poll-duration.7d" = "7日間";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -298,6 +298,7 @@
 "env.poll-duration.30m" = "30분";
 "env.poll-duration.1h" = "1시간";
 "env.poll-duration.6h" = "6시간";
+"env.poll-duration.12h" = "12시간";
 "env.poll-duration.1d" = "1일";
 "env.poll-duration.3d" = "3일";
 "env.poll-duration.7d" = "7일";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -297,6 +297,7 @@
 "env.poll-duration.30m" = "30 minutter";
 "env.poll-duration.1h" = "1 time";
 "env.poll-duration.6h" = "6 timer";
+"env.poll-duration.12h" = "12 timer";
 "env.poll-duration.1d" = "1 dag";
 "env.poll-duration.3d" = "3 dager";
 "env.poll-duration.7d" = "7 dager";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -295,6 +295,7 @@
 "env.poll-duration.30m" = "30 minuten";
 "env.poll-duration.1h" = "1 uur";
 "env.poll-duration.6h" = "6 uur";
+"env.poll-duration.12h" = "12 uur";
 "env.poll-duration.1d" = "1 dag";
 "env.poll-duration.3d" = "3 dagen";
 "env.poll-duration.7d" = "7 dagen";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -294,6 +294,7 @@
 "env.poll-duration.30m" = "30 minut";
 "env.poll-duration.1h" = "1 godzina";
 "env.poll-duration.6h" = "6 godzin";
+"env.poll-duration.12h" = "12 godzin";
 "env.poll-duration.1d" = "1 dzień";
 "env.poll-duration.3d" = "3 dni";
 "env.poll-duration.7d" = "7 dni";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -297,6 +297,7 @@
 "env.poll-duration.30m" = "30 minutos";
 "env.poll-duration.1h" = "1 hora";
 "env.poll-duration.6h" = "6 horas";
+"env.poll-duration.12h" = "12 horas";
 "env.poll-duration.1d" = "1 dia";
 "env.poll-duration.3d" = "3 dias";
 "env.poll-duration.7d" = "7 dias";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -293,6 +293,7 @@
 "env.poll-duration.30m" = "30 dakika";
 "env.poll-duration.1h" = "1 saat";
 "env.poll-duration.6h" = "6 saat";
+"env.poll-duration.12h" = "12 saat";
 "env.poll-duration.1d" = "1 gün";
 "env.poll-duration.3d" = "3 gün";
 "env.poll-duration.7d" = "7 gün";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -298,6 +298,7 @@
 "env.poll-duration.30m" = "30 分钟";
 "env.poll-duration.1h" = "1 小时";
 "env.poll-duration.6h" = "6 小时";
+"env.poll-duration.12h" = "12 小时";
 "env.poll-duration.1d" = "1 天";
 "env.poll-duration.3d" = "3 天";
 "env.poll-duration.7d" = "7 天";

--- a/Packages/Env/Sources/Env/PollPreferences.swift
+++ b/Packages/Env/Sources/Env/PollPreferences.swift
@@ -7,6 +7,7 @@ public enum PollDuration: Int, CaseIterable {
   case halfAnHour = 1800
   case oneHour = 3600
   case sixHours = 21600
+  case twelveHours = 43200
   case oneDay = 86400
   case threeDays = 259_200
   case sevenDays = 604_800
@@ -17,6 +18,7 @@ public enum PollDuration: Int, CaseIterable {
     case .halfAnHour: return "env.poll-duration.30m"
     case .oneHour: return "env.poll-duration.1h"
     case .sixHours: return "env.poll-duration.6h"
+    case .twelveHours: return "env.poll-duration.12h"
     case .oneDay: return "env.poll-duration.1d"
     case .threeDays: return "env.poll-duration.3d"
     case .sevenDays: return "env.poll-duration.7d"


### PR DESCRIPTION
Mastodon 4.1 added the option "12 hours" to its Web UI. This PR adds the same option to icecubes to stay consistent