### PR TITLE
Update to Nuke 12 (Beta 1)

### DIFF
--- a/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "67bd45931180f652159e3342575277a7f197b3ab",
-        "version" : "11.6.2"
+        "branch" : "nuke-12",
+        "revision" : "1e3098adc210edb4b93f62d89c4687301e371a9a"
       }
     },
     {

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -42,7 +42,8 @@ struct AccountDetailHeaderView: View {
         LazyImage(url: account.header) { state in
           if let image = state.image {
             image
-              .resizingMode(.aspectFill)
+              .resizable()
+              .aspectRatio(contentMode: .fill)
               .overlay(account.haveHeader ? .black.opacity(0.50) : .clear)
           } else if state.isLoading {
             theme.secondaryBackgroundColor

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -45,6 +45,8 @@ struct AccountDetailHeaderView: View {
               .resizable()
               .aspectRatio(contentMode: .fill)
               .overlay(account.haveHeader ? .black.opacity(0.50) : .clear)
+              .frame(height: Constants.headerHeight)
+              .clipped()
           } else if state.isLoading {
             theme.secondaryBackgroundColor
               .frame(height: Constants.headerHeight)

--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
@@ -128,7 +128,8 @@ struct ConversationMessageView: View {
     LazyImage(url: attachement.url) { state in
       if let image = state.image {
         image
-          .resizingMode(.aspectFill)
+          .resizable()
+          .aspectRatio(contentMode: .fill)
           .cornerRadius(8)
           .padding(8)
       } else if state.isLoading {

--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
@@ -125,17 +125,22 @@ struct ConversationMessageView: View {
   }
 
   private func makeMediaView(_ attachement: MediaAttachment) -> some View {
-    LazyImage(url: attachement.url) { state in
-      if let image = state.image {
-        image
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .cornerRadius(8)
-          .padding(8)
-      } else if state.isLoading {
-        RoundedRectangle(cornerRadius: 8)
-          .fill(Color.gray)
-          .frame(height: 200)
+    GeometryReader { proxy in
+      LazyImage(url: attachement.url) { state in
+        if let image = state.image {
+          image
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(height: 200)
+            .frame(maxWidth: proxy.frame(in: .local).width)
+            .clipped()
+            .cornerRadius(8)
+            .padding(8)
+        } else if state.isLoading {
+          RoundedRectangle(cornerRadius: 8)
+            .fill(Color.gray)
+            .frame(height: 200)
+        }
       }
     }
     .frame(height: 200)

--- a/Packages/DesignSystem/Package.swift
+++ b/Packages/DesignSystem/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .package(name: "Models", path: "../Models"),
     .package(name: "Env", path: "../Env"),
     .package(url: "https://github.com/markiv/SwiftUI-Shimmer", exact: "1.1.0"),
-    .package(url: "https://github.com/kean/Nuke", from: "11.6.0"),
+    .package(url: "https://github.com/kean/Nuke", branch: "nuke-12"),
     .package(url: "https://github.com/divadretlaw/EmojiText", from: "1.1.0"),
   ],
   targets: [

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -243,7 +243,8 @@ struct StatusEditorAccessoryView: View {
             LazyImage(url: emoji.url) { state in
               if let image = state.image {
                 image
-                  .resizingMode(.aspectFit)
+                  .resizable()
+                  .aspectRatio(contentMode: .fill)
                   .frame(width: 40, height: 40)
               } else if state.isLoading {
                 Rectangle()

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
@@ -100,7 +100,8 @@ struct StatusEditorMediaView: View {
         LazyImage(url: url) { state in
           if let image = state.image {
             image
-              .resizingMode(.aspectFill)
+              .resizable()
+              .aspectRatio(contentMode: .fill)
               .frame(width: 150, height: 150)
           } else {
             placeholderView


### PR DESCRIPTION
It contains a couple of performance improvements:

- Use native `SwiftUI.Image` for all rendering
- Reduce the amount of fields in `LazyImage`
- Reduce the number of `body` reload of `LazyImage` by extracting progress updates to a separate observable object

More info here: https://github.com/kean/Nuke/releases/tag/12.0.0-beta.1

**Warning**: I haven't tested some screens. It says beta 1, but it's a (relatively) safe change that only affects `LazyImage` and for the most part it's only code removal.