### PR TITLE
Status as class (performance improvement)

### DIFF
--- a/Packages/Models/Sources/Models/Account.swift
+++ b/Packages/Models/Sources/Models/Account.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-public struct Account: Codable, Identifiable, Equatable, Hashable {
+public final class Account: Codable, Identifiable, Equatable, Hashable {
+  public static func == (lhs: Account, rhs: Account) -> Bool {
+    lhs.id == rhs.id
+  }
+  
   public func hash(into hasher: inout Hasher) {
     hasher.combine(id)
   }
@@ -51,6 +55,29 @@ public struct Account: Codable, Identifiable, Equatable, Hashable {
     return header.lastPathComponent != "missing.png"
   }
 
+  
+  public init(id: String, username: String, displayName: String, avatar: URL, header: URL, acct: String, note: HTMLString, createdAt: ServerDate, followersCount: Int, followingCount: Int, statusesCount: Int, lastStatusAt: String? = nil, fields: [Account.Field], locked: Bool, emojis: [Emoji], url: URL? = nil, source: Account.Source? = nil, bot: Bool, discoverable: Bool? = nil) {
+    self.id = id
+    self.username = username
+    self.displayName = displayName
+    self.avatar = avatar
+    self.header = header
+    self.acct = acct
+    self.note = note
+    self.createdAt = createdAt
+    self.followersCount = followersCount
+    self.followingCount = followingCount
+    self.statusesCount = statusesCount
+    self.lastStatusAt = lastStatusAt
+    self.fields = fields
+    self.locked = locked
+    self.emojis = emojis
+    self.url = url
+    self.source = source
+    self.bot = bot
+    self.discoverable = discoverable
+  }
+  
   public static func placeholder() -> Account {
     .init(id: UUID().uuidString,
           username: "Username",

--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -68,7 +68,7 @@ protocol StatusUI {
   var userMentioned: Bool? { get set }
 }
 
-public struct Status: AnyStatus, Codable, Identifiable, Equatable, Hashable, StatusUI {
+public final class Status: AnyStatus, Codable, Identifiable, Equatable, Hashable, StatusUI {
   public var userMentioned: Bool?
 
   public static func == (lhs: Status, rhs: Status) -> Bool {
@@ -106,6 +106,37 @@ public struct Status: AnyStatus, Codable, Identifiable, Equatable, Hashable, Sta
   public let filtered: [Filtered]?
   public let sensitive: Bool
   public let language: String?
+
+  public init(userMentioned: Bool? = nil, id: String, content: HTMLString, account: Account, createdAt: ServerDate, editedAt: ServerDate?, reblog: ReblogStatus?, mediaAttachments: [MediaAttachment], mentions: [Mention], repliesCount: Int, reblogsCount: Int, favouritesCount: Int, card: Card?, favourited: Bool?, reblogged: Bool?, pinned: Bool?, bookmarked: Bool?, emojis: [Emoji], url: String?, application: Application?, inReplyToId: String?, inReplyToAccountId: String?, visibility: Visibility, poll: Poll?, spoilerText: HTMLString, filtered: [Filtered]?, sensitive: Bool, language: String?) {
+    self.userMentioned = userMentioned
+    self.id = id
+    self.content = content
+    self.account = account
+    self.createdAt = createdAt
+    self.editedAt = editedAt
+    self.reblog = reblog
+    self.mediaAttachments = mediaAttachments
+    self.mentions = mentions
+    self.repliesCount = repliesCount
+    self.reblogsCount = reblogsCount
+    self.favouritesCount = favouritesCount
+    self.card = card
+    self.favourited = favourited
+    self.reblogged = reblogged
+    self.pinned = pinned
+    self.bookmarked = bookmarked
+    self.emojis = emojis
+    self.url = url
+    self.application = application
+    self.inReplyToId = inReplyToId
+    self.inReplyToAccountId = inReplyToAccountId
+    self.visibility = visibility
+    self.poll = poll
+    self.spoilerText = spoilerText
+    self.filtered = filtered
+    self.sensitive = sensitive
+    self.language = language
+  }
 
   public static func placeholder(forSettings: Bool = false, language: String? = nil) -> Status {
     .init(id: UUID().uuidString,
@@ -176,7 +207,7 @@ public struct Status: AnyStatus, Codable, Identifiable, Equatable, Hashable, Sta
   }
 }
 
-public struct ReblogStatus: AnyStatus, Codable, Identifiable, Equatable, Hashable {
+public final class ReblogStatus: AnyStatus, Codable, Identifiable, Equatable, Hashable {
   public static func == (lhs: ReblogStatus, rhs: ReblogStatus) -> Bool {
     lhs.id == rhs.id
   }
@@ -211,4 +242,33 @@ public struct ReblogStatus: AnyStatus, Codable, Identifiable, Equatable, Hashabl
   public let filtered: [Filtered]?
   public let sensitive: Bool
   public let language: String?
+
+  public init(id: String, content: HTMLString, account: Account, createdAt: ServerDate, editedAt: ServerDate?, mediaAttachments: [MediaAttachment], mentions: [Mention], repliesCount: Int, reblogsCount: Int, favouritesCount: Int, card: Card?, favourited: Bool?, reblogged: Bool?, pinned: Bool?, bookmarked: Bool?, emojis: [Emoji], url: String?, application: Application? = nil, inReplyToId: String?, inReplyToAccountId: String?, visibility: Visibility, poll: Poll?, spoilerText: HTMLString, filtered: [Filtered]?, sensitive: Bool, language: String?) {
+    self.id = id
+    self.content = content
+    self.account = account
+    self.createdAt = createdAt
+    self.editedAt = editedAt
+    self.mediaAttachments = mediaAttachments
+    self.mentions = mentions
+    self.repliesCount = repliesCount
+    self.reblogsCount = reblogsCount
+    self.favouritesCount = favouritesCount
+    self.card = card
+    self.favourited = favourited
+    self.reblogged = reblogged
+    self.pinned = pinned
+    self.bookmarked = bookmarked
+    self.emojis = emojis
+    self.url = url
+    self.application = application
+    self.inReplyToId = inReplyToId
+    self.inReplyToAccountId = inReplyToAccountId
+    self.visibility = visibility
+    self.poll = poll
+    self.spoilerText = spoilerText
+    self.filtered = filtered
+    self.sensitive = sensitive
+    self.language = language
+  }
 }


### PR DESCRIPTION
It's inefficient to use structs for types that contain a lot of fields, especially if they are either reference types or structs that use references internally (e.g. String and its underlying CoW representation). Every time you pass a struct around, it performs a retain/release for every property. By changing it to a class, there is only one retain/release call needed. And there is much less memory needed to copy these values around – only the pointer itself. Reference: https://developer.apple.com/videos/play/wwdc2016/416/

**Before**

![Screenshot 2023-02-17 at 8 38 45 PM](https://user-images.githubusercontent.com/1567433/219825151-fc1fe7c5-3b0c-413c-ba60-a633387ff4c3.png)

**After**

![Screenshot 2023-02-17 at 8 42 37 PM](https://user-images.githubusercontent.com/1567433/219825152-46d675b8-20f7-402a-b3ea-2ef45a38a7fb.png)
