### PR TITLE
Added a tip that it's a video, and not an image when autoplay is off

### DIFF
--- a/Packages/Status/Sources/Status/Media/VideoPlayerView.swift
+++ b/Packages/Status/Sources/Status/Media/VideoPlayerView.swift
@@ -1,4 +1,5 @@
 import AVKit
+import DesignSystem
 import Env
 import SwiftUI
 
@@ -45,12 +46,22 @@ class VideoPlayerViewModel: ObservableObject {
 struct VideoPlayerView: View {
   @Environment(\.scenePhase) private var scenePhase
   @EnvironmentObject private var preferences: UserPreferences
+  @EnvironmentObject private var theme: Theme
 
   @StateObject var viewModel: VideoPlayerViewModel
 
   var body: some View {
-    VStack {
+    ZStack(alignment: .bottomLeading) {
       VideoPlayer(player: viewModel.player)
+
+      if !preferences.autoPlayVideo {
+        Image(systemName: "play.fill")
+          .foregroundColor(theme.tintColor)
+          .padding(4)
+          .background(.thinMaterial)
+          .cornerRadius(4)
+          .padding(theme.statusDisplayStyle == .compact ? 0 : 10)
+      }
     }.onAppear {
       viewModel.preparePlayer(autoPlay: preferences.autoPlayVideo)
     }

--- a/Packages/Status/Sources/Status/Media/VideoPlayerView.swift
+++ b/Packages/Status/Sources/Status/Media/VideoPlayerView.swift
@@ -51,15 +51,15 @@ struct VideoPlayerView: View {
   @StateObject var viewModel: VideoPlayerViewModel
 
   var body: some View {
-    ZStack(alignment: .bottomLeading) {
+    ZStack {
       VideoPlayer(player: viewModel.player)
 
       if !preferences.autoPlayVideo {
         Image(systemName: "play.fill")
+          .font(.largeTitle)
           .foregroundColor(theme.tintColor)
-          .padding(4)
-          .background(.thinMaterial)
-          .cornerRadius(4)
+          .padding()
+          .background(Circle().fill(.thinMaterial))
           .padding(theme.statusDisplayStyle == .compact ? 0 : 10)
       }
     }.onAppear {


### PR DESCRIPTION
**Motivation**:
When autoplay is off in the settings, images are not distinguishable from videos. To prevent missing fun or info from videos, we need tip them

**Proposed solution**:
Adding a "play" tip at the bottom left ; with the same stylish than "ALT"
The play tip only shows when autoplay is off.
The position have been chosen to not overlay with VideoPlayer standard controls that might appear sometime.

<img src="https://user-images.githubusercontent.com/8696821/219901544-b2ea924d-8e69-491d-a894-fc53b5b361b9.jpg" alt="Screenshot of the actual look of the video tip" width="320">
