### PR TITLE
Updated EmojiText to 2.x

### DIFF
--- a/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/divadretlaw/EmojiText",
       "state" : {
-        "revision" : "3d8f6196de59634352ed317cf6ab4e292eeaaf44",
-        "version" : "1.2.0"
+        "revision" : "b52cfb8278425c28771bee4cc9e87453a52f3f4d",
+        "version" : "2.0.2"
       }
     },
     {

--- a/Packages/DesignSystem/Package.swift
+++ b/Packages/DesignSystem/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     .package(name: "Env", path: "../Env"),
     .package(url: "https://github.com/markiv/SwiftUI-Shimmer", exact: "1.1.0"),
     .package(url: "https://github.com/kean/Nuke", branch: "nuke-12"),
-    .package(url: "https://github.com/divadretlaw/EmojiText", from: "1.1.0"),
+    .package(url: "https://github.com/divadretlaw/EmojiText", from: "2.0.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Interface used by IceCubeApp has not changed from 1.x to 2.x 

Looking at the library diff shows new features like SFSymbol powered emojis. 

Not like we're going to make use of that https://github.com/divadretlaw/EmojiText/compare/v1.2.0...2.0.2