### PR TITLE
Optimize avatar view

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/Views/AvatarView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/AvatarView.swift
@@ -56,19 +56,19 @@ public struct AvatarView: View {
           .fill(.gray)
           .frame(width: size.size.width, height: size.size.height)
       } else {
-        if isInCaptureMode, let image = Nuke.ImagePipeline.shared.cache.cachedImage(for: .init(url: url))?.image {
+        if isInCaptureMode, let url = url, let image = Nuke.ImagePipeline.shared.cache.cachedImage(for: makeImageRequest(for: url))?.image {
           Image(uiImage: image)
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: size.size.width, height: size.size.height)
         } else {
-          LazyImage(url: url) { state in
+          LazyImage(request: url.map(makeImageRequest)) { state in
             if let image = state.image {
               image
                 .resizable()
                 .aspectRatio(contentMode: .fit)
             } else {
-                AvatarPlaceholderView(size: size)
+              AvatarPlaceholderView(size: size)
             }
           }
           .animation(nil)
@@ -80,6 +80,10 @@ public struct AvatarView: View {
     .overlay(
       clipShape.stroke(Color.primary.opacity(0.25), lineWidth: 1)
     )
+  }
+
+  private func makeImageRequest(for url: URL) -> ImageRequest {
+    ImageRequest(url: url, processors: [.resize(size: size.size)])
   }
 
   private var clipShape: some Shape {

--- a/Packages/DesignSystem/Sources/DesignSystem/Views/AvatarView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/AvatarView.swift
@@ -68,7 +68,7 @@ public struct AvatarView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
             } else {
-              placeholderView
+                AvatarPlaceholderView(size: size)
             }
           }
           .animation(nil)
@@ -90,17 +90,20 @@ public struct AvatarView: View {
       return AnyShape(RoundedRectangle(cornerRadius: size.cornerRadius))
     }
   }
+}
 
-  @ViewBuilder
-  private var placeholderView: some View {
-    if size == .badge {
-      Circle()
-        .fill(.gray)
-        .frame(width: size.size.width, height: size.size.height)
-    } else {
-      RoundedRectangle(cornerRadius: size.cornerRadius)
-        .fill(.gray)
-        .frame(width: size.size.width, height: size.size.height)
+private struct AvatarPlaceholderView: View {
+    let size: AvatarView.Size
+
+    var body: some View {
+        if size == .badge {
+          Circle()
+            .fill(.gray)
+            .frame(width: size.size.width, height: size.size.height)
+        } else {
+          RoundedRectangle(cornerRadius: size.cornerRadius)
+            .fill(.gray)
+            .frame(width: size.size.width, height: size.size.height)
+        }
     }
-  }
 }


### PR DESCRIPTION
The avatars in Mastodon seem to be standardized to 400x400px size, e.g. https://files.mastodon.social/accounts/avatars/108/194/113/520/602/290/original/a05c41565ddbe779.jpeg. The default display size in the feed is 40x40pt. With this change, the resizing is performed in the background and the bitmapped image exactly matches the display size.

The placeholder is currently called at least twice: one one the first body calculation and the second time on `onAppear` when the `LazyImage` starts loading. By extracting  `AvatarPlaceholderView`, its body is calculated only once – fewer reloads.

> **Warning**:  I smoke-tested the timeline and not much else