### PR TITLE
Trim whitespace and newlines in instance rules list

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/InstanceInfoView.swift
+++ b/IceCubesApp/App/Tabs/Settings/InstanceInfoView.swift
@@ -38,7 +38,7 @@ public struct InstanceInfoSection: View {
     if let rules = instance.rules {
       Section("instance.info.section.rules") {
         ForEach(rules) { rule in
-          Text(rule.text)
+          Text(rule.text.trimmingCharacters(in: .whitespacesAndNewlines))
         }
       }
       .listRowBackground(theme.primaryBackgroundColor)


### PR DESCRIPTION
It has bothered me that the first of the https://ruby.social rules has a trailing newline, which makes it render inconsistently.

<img width="659" alt="Screenshot 2023-02-19 at 21 23 23" src="https://user-images.githubusercontent.com/216/219976021-2b1f60df-a574-4699-bb76-0fff90f17c07.png">

This should fix it – though I didn't set up and build the project locally for this tiny fix, so please do confirm 😅 

To be clear, this intentionally removes leading and trailing whitespace and newlines but not internal such: https://swiftfiddle.com/ykulagxc5bhsto52qqpcelztty