### PR TITLE
Fix building on Xcode 14.3 beta

### DIFF
--- a/IceCubesApp.xcodeproj/project.pbxproj
+++ b/IceCubesApp.xcodeproj/project.pbxproj
@@ -1369,8 +1369,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				branch = main;
+				kind = branch;
 			};
 		};
 		9FAE4ACC29379A5A00772766 /* XCRemoteSwiftPackageReference "keychain-swift" */ = {

--- a/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios.git",
       "state" : {
-        "revision" : "9cfb6adb41dc40d80c104b2ef6e9a84bca03ea48",
-        "version" : "4.16.0"
+        "branch" : "main",
+        "revision" : "3cc302bc83e0e33ad8f3d12b84cec225a865f1eb"
       }
     },
     {

--- a/IceCubesApp/App/SideBarView.swift
+++ b/IceCubesApp/App/SideBarView.swift
@@ -27,10 +27,11 @@ struct SideBarView<Content: View>: View {
   }
   
   private func makeIconForTab(tab: Tab) -> some View {
-    ZStack(alignment: .topTrailing) {
+    let badge = badgeFor(tab: tab)
+    return ZStack(alignment: .topTrailing) {
       SideBarIcon(systemIconName: tab.iconName,
                   isSelected: tab == selectedTab)
-      if let badge = badgeFor(tab: tab), badge > 0 {
+      if badge > 0 {
         makeBadgeView(count: badge)
       }
     }

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -179,18 +179,17 @@ struct SettingsTabs: View {
   }
 
   private var appSection: some View {
-    Section {
+    let icon = IconSelectorView.Icon(string: UIApplication.shared.alternateIconName ?? "AppIcon")
+    return Section {
       if !ProcessInfo.processInfo.isiOSAppOnMac {
         NavigationLink(destination: IconSelectorView()) {
           Label {
             Text("settings.app.icon")
           } icon: {
-            if let icon = IconSelectorView.Icon(string: UIApplication.shared.alternateIconName ?? "AppIcon") {
-              Image(uiImage: .init(named: icon.iconName)!)
-                .resizable()
-                .frame(width: 25, height: 25)
-                .cornerRadius(4)
-            }
+            Image(uiImage: .init(named: icon.iconName)!)
+                          .resizable()
+                          .frame(width: 25, height: 25)
+                          .cornerRadius(4)
           }
         }
       }


### PR DESCRIPTION
Two optional bindings without optionals are now removed. Xcode 14.2 allowed this, but it's a compiler-error in the new beta. Additionally, Xcode complained about @MainActor being only allowed since iOS 13 in RevenueCat, so RevenueCat is updated to the current HEAD of main, where this problem doesn't persist.
I've also added a feature request to revenue-cat/purchases-ios to bump the version-number, so we should later be able to revert to using that version-number instead of the branch.