### PR TITLE
Fix crash when opening account details

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -40,15 +40,13 @@ public struct AccountDetailView: View {
   public var body: some View {
     ScrollViewReader { proxy in
       List {
-        Group {
-          makeHeaderView(proxy: proxy)
-            .padding(.bottom, -20)
-          familiarFollowers
-          featuredTagsView
-        }
-        .listRowInsets(.init())
-        .listRowSeparator(.hidden)
-        .listRowBackground(theme.primaryBackgroundColor)
+        makeHeaderView(proxy: proxy)
+          .applyAccountDetailsRowStyle(theme: theme)
+          .padding(.bottom, -20)
+        familiarFollowers
+          .applyAccountDetailsRowStyle(theme: theme)
+        featuredTagsView
+          .applyAccountDetailsRowStyle(theme: theme)
 
         Picker("", selection: $viewModel.selectedTab) {
           ForEach(isCurrentUser ? AccountDetailViewModel.Tab.currentAccountTabs : AccountDetailViewModel.Tab.accountTabs,
@@ -59,9 +57,7 @@ public struct AccountDetailView: View {
         }
         .pickerStyle(.segmented)
         .padding(.layoutPadding)
-        .listRowSeparator(.hidden)
-        .listRowBackground(theme.primaryBackgroundColor)
-        .listRowInsets(.init())
+        .applyAccountDetailsRowStyle(theme: theme)
         .id("status")
 
         switch viewModel.tabState {
@@ -484,6 +480,15 @@ public struct AccountDetailView: View {
         Image(systemName: "ellipsis.circle")
       }
     }
+  }
+}
+
+private extension View {
+  func applyAccountDetailsRowStyle(theme: Theme) -> some View {
+    self
+      .listRowInsets(.init())
+      .listRowSeparator(.hidden)
+      .listRowBackground(theme.primaryBackgroundColor)
   }
 }
 


### PR DESCRIPTION
For me, the app consistently crashes on a device (iOS 16.1.1) when I open account details from notifications where "also followed by" section isn't empty. It crashes with the following issue:

<img width="452" alt="Screenshot 2023-02-20 at 9 06 57 PM" src="https://user-images.githubusercontent.com/1567433/220229773-1d060267-068c-4c44-b0de-65503b81fa21.png">

I started reviewing the code and noticed `Group`. I had issue with it before, so I decided to remove it, and, sure enough, the crash was gone.  It looks like it's the combination of `Group` and these three `listRow` modifiers that leads to a crash:

```swift
        Group {
          makeHeaderView(proxy: proxy)
            .padding(.bottom, -20)
          familiarFollowers
          featuredTagsView
        }
          .listRowInsets(.init())
          .listRowSeparator(.hidden)
          .listRowBackground(theme.primaryBackgroundColor)
```

It doesn't crash on iOS 16.2 simulator, so presumably this issue with `Group` is fixed. But it's prone to issues and I personally avoid using it, especially directly inside `List` or other containers.

**Update:** I upgraded to iOS 16.3.1 and confirm that it no longer crashes.