### PR TITLE
Fix status actions on boosting posts

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -359,6 +359,7 @@
 "status.action.translated-label-%@" = "Пераклад з дапамогай %@";
 "status.action.bookmark" = "Закладка";
 "status.action.boost" = "Павышэнне";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Капіяваць тэкст";
 "status.action.delete" = "Выдаліць";
 "status.action.delete.confirm.title" = "Пацвердзіць";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -369,6 +369,7 @@
 "status.action.translated-label-%@" = "Traduït amb %@";
 "status.action.bookmark" = "Afegeix als marcadors";
 "status.action.boost" = "Impulsa";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Copia el text";
 "status.action.delete" = "Elimina";
 "status.action.delete.confirm.title" = "Confirm";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -366,6 +366,7 @@
 "status.action.translated-label-%@" = "Übersetzt mit %@";
 "status.action.bookmark" = "Lesezeichen setzen";
 "status.action.boost" = "Boosten";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Text kopieren";
 "status.action.delete" = "Löschen";
 "status.action.delete.confirm.title" = "Bestätigen";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -372,6 +372,7 @@
 "status.action.translated-label-%@" = "Translated using %@";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Copy Text";
 "status.action.delete" = "Delete";
 "status.action.delete.confirm.title" = "Confirm";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -371,6 +371,7 @@
 "status.action.translated-label-%@" = "Translated using %@";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Copy Text";
 "status.action.delete" = "Delete";
 "status.action.delete.confirm.title" = "Confirm";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -371,6 +371,7 @@
 "status.action.translated-label-%@" = "Traducido usando %@";
 "status.action.bookmark" = "Añadir a marcadores";
 "status.action.boost" = "Retootear";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Copiar texto";
 "status.action.delete" = "Borrar";
 "status.action.delete.confirm.title" = "Confirm";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -364,6 +364,7 @@
 "status.action.translated-label-%@" = "%@ erabiliz itzulia";
 "status.action.bookmark" = "Jarri laster-marka";
 "status.action.boost" = "Bultzatu";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Kopiatu testua";
 "status.action.delete" = "Ezabatu";
 "status.action.delete.confirm.title" = "Baieztatu";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -366,6 +366,7 @@
 "status.action.translated-label-%@" = "Traduit avec %@";
 "status.action.bookmark" = "Marquer";
 "status.action.boost" = "Promouvoir";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Copier le texte";
 "status.action.delete" = "Supprimer";
 "status.action.delete.confirm.title" = "Confirmer";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -371,6 +371,7 @@
 "status.action.translated-label-%@" = "Tradotto usando %@";
 "status.action.bookmark" = "Salva nei segnalibri";
 "status.action.boost" = "Condividi";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Copia il testo";
 "status.action.delete" = "Elimina";
 "status.action.delete.confirm.title" = "Richiesta di conferma";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -370,6 +370,7 @@
 "status.action.translated-label-%@" = "%@ を使用して翻訳";
 "status.action.bookmark" = "ブックマーク";
 "status.action.boost" = "ブースト";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "テキストをコピー";
 "status.action.delete" = "削除";
 "status.action.delete.confirm.title" = "確認";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -372,6 +372,7 @@
 "status.action.translated-label-%@" = "번역 제공: %@";
 "status.action.bookmark" = "보관함에 추가";
 "status.action.boost" = "부스트";
+"status.action.boost-to-followers" = "팔로워에게 부스트";
 "status.action.copy-text" = "복사";
 "status.action.delete" = "삭제";
 "status.action.delete.confirm.title" = "삭제 확인";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -370,6 +370,7 @@
 "status.action.translated-label-%@" = "Oversatt ved hjelp av %@";
 "status.action.bookmark" = "Bokmerk";
 "status.action.boost" = "Forsterk";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Kopier tekst";
 "status.action.delete" = "Slett";
 "status.action.delete.confirm.title" = "Confirm";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -364,6 +364,7 @@
 "status.action.translated-label-%@" = "Vertaald met behulp van %@";
 "status.action.bookmark" = "Voeg bladwijzer toe";
 "status.action.boost" = "Boosten";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Kopieer tekst";
 "status.action.delete" = "Verwijder";
 "status.action.delete.confirm.title" = "Bevestigen";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -366,6 +366,7 @@
 "status.action.translated-label-%@" = "Przetłumaczono za pomocą %@";
 "status.action.bookmark" = "Dodaj zakładkę";
 "status.action.boost" = "Podbij";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Kopiuj tekst";
 "status.action.delete" = "Usuń";
 "status.action.delete.confirm.title" = "Potwierdź";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -370,6 +370,7 @@
 "status.action.translated-label-%@" = "Traduzir usando %@";
 "status.action.bookmark" = "Salvar";
 "status.action.boost" = "Boost";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Copiar Texto";
 "status.action.delete" = "Deletar";
 "status.action.delete.confirm.title" = "Confirm";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -366,6 +366,7 @@
 "status.action.translated-label-%@" = "%@ tarafından tercüme edildi";
 "status.action.bookmark" = "Yer İmi Ekle";
 "status.action.boost" = "Yükselt";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "Yazıyı Kopyala";
 "status.action.delete" = "Sil";
 "status.action.delete.confirm.title" = "Confirm";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -369,6 +369,7 @@
 "status.action.translated-label-%@" = "由 %@ 翻译";
 "status.action.bookmark" = "书签";
 "status.action.boost" = "转发";
+"status.action.boost-to-followers" = "Boost to Followers";
 "status.action.copy-text" = "拷贝文本";
 "status.action.delete" = "删除";
 "status.action.delete.confirm.title" = "确认删除";

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
@@ -6,17 +6,26 @@ import SwiftUI
 
 struct StatusRowActionsView: View {
   @EnvironmentObject private var theme: Theme
+  @EnvironmentObject private var currentAccount: CurrentAccount
   @ObservedObject var viewModel: StatusRowViewModel
-
+    
+  func privateBoost() -> Bool {
+    return self.viewModel.status.visibility == .priv && self.viewModel.status.account.id == self.currentAccount.account?.id
+  }
+  
   @MainActor
   enum Actions: CaseIterable {
     case respond, boost, favorite, bookmark, share
 
-    func iconName(viewModel: StatusRowViewModel) -> String {
+    func iconName(viewModel: StatusRowViewModel, privateBoost: Bool = false) -> String {
       switch self {
       case .respond:
         return "arrowshape.turn.up.left"
       case .boost:
+        if (privateBoost) {
+          return viewModel.isReblogged ? "arrow.left.arrow.right.circle.fill" : "lock.rotation"
+        }
+        
         return viewModel.isReblogged ? "arrow.left.arrow.right.circle.fill" : "arrow.left.arrow.right.circle"
       case .favorite:
         return viewModel.isFavorited ? "star.fill" : "star"
@@ -77,7 +86,7 @@ struct StatusRowActionsView: View {
               handleAction(action: action)
             } label: {
               HStack(spacing: 2) {
-                Image(systemName: action.iconName(viewModel: viewModel))
+                Image(systemName: action.iconName(viewModel: viewModel, privateBoost: privateBoost()))
                   .foregroundColor(action.tintColor(viewModel: viewModel, theme: theme))
                 if let count = action.count(viewModel: viewModel, theme: theme), !viewModel.isRemote {
                   Text("\(count)")
@@ -87,7 +96,7 @@ struct StatusRowActionsView: View {
             }
             .buttonStyle(.borderless)
             .disabled(action == .boost &&
-              (viewModel.status.visibility == .direct || viewModel.status.visibility == .priv))
+                      (viewModel.status.visibility == .direct || viewModel.status.visibility == .priv && viewModel.status.account.id != currentAccount.account?.id))
             Spacer()
           }
         }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -14,19 +14,17 @@ struct StatusRowContextMenu: View {
 
   @ObservedObject var viewModel: StatusRowViewModel
   
-  func getBoostLabel() -> some View {
-    if (self.viewModel.status.visibility == .priv && self.viewModel.status.account.id == self.account.account?.id) {
-      if (self.viewModel.isReblogged) {
+  var boostLabel: some View {
+    if self.viewModel.status.visibility == .priv && self.viewModel.status.account.id == self.account.account?.id {
+      if self.viewModel.isReblogged {
         return Label("status.action.unboost", systemImage: "lock.rotation")
       }
-      
       return Label("status.action.boost-to-followers", systemImage: "lock.rotation")
     }
     
-    if (self.viewModel.isReblogged) {
+    if self.viewModel.isReblogged {
       return Label("status.action.unboost", systemImage: "arrow.left.arrow.right.circle")
     }
-    
     return Label("status.action.boost", systemImage: "arrow.left.arrow.right.circle")
   }
   
@@ -48,7 +46,7 @@ struct StatusRowContextMenu: View {
           await viewModel.reblog()
         }
       } } label: {
-        getBoostLabel()
+        boostLabel
       }
       .disabled(viewModel.status.visibility == .direct || viewModel.status.visibility == .priv && viewModel.status.account.id != account.account?.id)
       Button { Task {

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -133,7 +133,7 @@ struct StatusRowContextMenu: View {
       }
     }
 
-    if account.account?.id == viewModel.status.account.id {
+    if account.account?.id == viewModel.status.reblog?.account.id ?? viewModel.status.account.id {
       Section("status.action.section.your-post") {
         Button {
           Task {

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -14,6 +14,22 @@ struct StatusRowContextMenu: View {
 
   @ObservedObject var viewModel: StatusRowViewModel
   
+  func getBoostLabel() -> some View {
+    if (self.viewModel.status.visibility == .priv && self.viewModel.status.account.id == self.account.account?.id) {
+      if (self.viewModel.isReblogged) {
+        return Label("status.action.unboost", systemImage: "lock.rotation")
+      }
+      
+      return Label("Boost to followers", systemImage: "lock.rotation")
+    }
+    
+    if (self.viewModel.isReblogged) {
+      return Label("status.action.unboost", systemImage: "arrow.left.arrow.right.circle")
+    }
+    
+    return Label("status.action.boost", systemImage: "arrow.left.arrow.right.circle")
+  }
+  
   var body: some View {
     if !viewModel.isRemote {
       Button { Task {
@@ -32,8 +48,9 @@ struct StatusRowContextMenu: View {
           await viewModel.reblog()
         }
       } } label: {
-        Label(viewModel.isReblogged ? "status.action.unboost" : "status.action.boost", systemImage: "arrow.left.arrow.right.circle")
+        getBoostLabel()
       }
+      .disabled(viewModel.status.visibility == .direct || viewModel.status.visibility == .priv && viewModel.status.account.id != account.account?.id)
       Button { Task {
         if viewModel.isBookmarked {
           await viewModel.unbookmark()

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -20,7 +20,7 @@ struct StatusRowContextMenu: View {
         return Label("status.action.unboost", systemImage: "lock.rotation")
       }
       
-      return Label("Boost to followers", systemImage: "lock.rotation")
+      return Label("status.action.boost-to-followers", systemImage: "lock.rotation")
     }
     
     if (self.viewModel.isReblogged) {


### PR DESCRIPTION
- Fix the context menu showing edit, pin, and delete buttons on posts that I boosted but didn't post
- Fix the context menu ***not*** showing edit, pin, and delete buttons on posts that I posted and someone else boosted.
- Allow boosting my followers-only posts (which is available on Mastodon web)
  - Show `Boost to Followers` instead of `Boost` on context menus
  - Enable the inline boost button for my followers-only posts
  - But I'm not sure about the icon. Maybe there's something better than `lock.rotation`
- Disable the boost context menu from posts that can't be boosted (mentioned-only posts or others' followers-only posts)

I think the same mechanism should be applied to the swipe actions. But this is all for now.