### PR TITLE
Tweak the theme selector view

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/Views/ThemePreviewView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/ThemePreviewView.swift
@@ -47,7 +47,7 @@ struct ThemeBoxView: View {
 
         Text("design.theme.toots-preview")
           .foregroundColor(color.labelColor)
-          .frame(maxWidth: .infinity)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
           .padding()
           .background(color.primaryBackgroundColor)
 


### PR DESCRIPTION
Tweaked theme selector view.

Before: (There is a margin at the bottom of the Neon theme Box.)
![Simulator Screen Shot - iPhone Pro - 2023-02-21 at 14 05 00](https://user-images.githubusercontent.com/108506642/220253333-4abf9bc3-ca8b-4ba4-b706-78479eebdd2a.png)

After:
![Simulator Screen Shot - iPhone Pro - 2023-02-21 at 14 05 10](https://user-images.githubusercontent.com/108506642/220253776-ba3aeee9-1441-4b03-b14c-363afc5419b8.png)