### PR TITLE
Singularize enum type names

### DIFF
--- a/IceCubesApp/App/AppRouter.swift
+++ b/IceCubesApp/App/AppRouter.swift
@@ -13,7 +13,7 @@ import Timeline
 @MainActor
 extension View {
   func withAppRouter() -> some View {
-    navigationDestination(for: RouterDestinations.self) { destination in
+    navigationDestination(for: RouterDestination.self) { destination in
       switch destination {
       case let .accountDetail(id):
         AccountDetailView(accountId: id)
@@ -47,7 +47,7 @@ extension View {
     }
   }
 
-  func withSheetDestinations(sheetDestinations: Binding<SheetDestinations?>) -> some View {
+  func withSheetDestinations(sheetDestinations: Binding<SheetDestination?>) -> some View {
     sheet(item: sheetDestinations) { destination in
       switch destination {
       case let .replyToStatusEditor(status):

--- a/IceCubesApp/App/Tabs/Settings/SupportAppView.swift
+++ b/IceCubesApp/App/Tabs/Settings/SupportAppView.swift
@@ -5,7 +5,7 @@ import Shimmer
 import SwiftUI
 
 struct SupportAppView: View {
-  enum Tips: String, CaseIterable {
+  enum Tip: String, CaseIterable {
     case one, two, three, four
 
     init(productId: String) {
@@ -86,7 +86,7 @@ struct SupportAppView: View {
           .shimmering()
         } else {
           ForEach(products, id: \.productIdentifier) { product in
-            let tip = Tips(productId: product.productIdentifier)
+            let tip = Tip(productId: product.productIdentifier)
             HStack {
               VStack(alignment: .leading) {
                 Text(tip.title)
@@ -141,7 +141,7 @@ struct SupportAppView: View {
     })
     .onAppear {
       loadingProducts = true
-      Purchases.shared.getProducts(Tips.allCases.map { $0.productId }) { products in
+      Purchases.shared.getProducts(Tip.allCases.map { $0.productId }) { products in
         self.products = products.sorted(by: { $0.price < $1.price })
         withAnimation {
           loadingProducts = false

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -218,7 +218,7 @@ public struct AccountDetailView: View {
   private var listsListView: some View {
     Group {
       ForEach(currentAccount.sortedLists) { list in
-        NavigationLink(value: RouterDestinations.list(list: list)) {
+        NavigationLink(value: RouterDestination.list(list: list)) {
           Text(list.title)
             .font(.scaledHeadline)
             .foregroundColor(theme.labelColor)
@@ -346,7 +346,7 @@ public struct AccountDetailView: View {
                 }
               } else {
                 Menu {
-                  ForEach(MutingDurations.allCases, id: \.rawValue) { duration in
+                  ForEach(MutingDuration.allCases, id: \.rawValue) { duration in
                     Button(duration.description) {
                       Task {
                         do {

--- a/Packages/Account/Sources/Account/MutingDuration.swift
+++ b/Packages/Account/Sources/Account/MutingDuration.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum MutingDurations: Int, CaseIterable {
+enum MutingDuration: Int, CaseIterable {
   case infinite = 0
   case fiveMinutes = 300
   case thirtyMinutes = 1800

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -3,7 +3,7 @@ import Models
 import Network
 import SwiftUI
 
-public enum RouterDestinations: Hashable {
+public enum RouterDestination: Hashable {
   case accountDetail(id: String)
   case accountDetailWithAccount(account: Account)
   case accountSettingsWithAccount(account: Account, appAccount: AppAccount)
@@ -20,7 +20,7 @@ public enum RouterDestinations: Hashable {
   case accountsList(accounts: [Account])
 }
 
-public enum SheetDestinations: Identifiable {
+public enum SheetDestination: Identifiable {
   case newStatusEditor(visibility: Models.Visibility)
   case editStatusEditor(status: Status)
   case replyToStatusEditor(status: Status)
@@ -64,12 +64,12 @@ public class RouterPath: ObservableObject {
   public var client: Client?
   public var urlHandler: ((URL) -> OpenURLAction.Result)?
 
-  @Published public var path: [RouterDestinations] = []
-  @Published public var presentedSheet: SheetDestinations?
+  @Published public var path: [RouterDestination] = []
+  @Published public var presentedSheet: SheetDestination?
 
   public init() {}
 
-  public func navigate(to: RouterDestinations) {
+  public func navigate(to: RouterDestination) {
     path.append(to)
   }
 

--- a/Packages/Network/Sources/Network/OpenAIClient.swift
+++ b/Packages/Network/Sources/Network/OpenAIClient.swift
@@ -43,7 +43,7 @@ public struct OpenAIClient {
     }
   }
 
-  public enum Prompts {
+  public enum Prompt {
     case correct(input: String)
     case shorten(input: String)
     case emphasize(input: String)
@@ -89,7 +89,7 @@ public struct OpenAIClient {
 
   public init() {}
 
-  public func request(_ prompt: Prompts) async throws -> Response {
+  public func request(_ prompt: Prompt) async throws -> Response {
     do {
       let jsonData = try encoder.encode(prompt.request)
       var request = URLRequest(url: endpoint)

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAIPrompt.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAIPrompt.swift
@@ -2,7 +2,7 @@ import Foundation
 import Network
 import SwiftUI
 
-enum StatusEditorAIPrompts: CaseIterable {
+enum StatusEditorAIPrompt: CaseIterable {
   case correct, fit, emphasize
 
   @ViewBuilder
@@ -17,7 +17,7 @@ enum StatusEditorAIPrompts: CaseIterable {
     }
   }
 
-  func toRequestPrompt(text: String) -> OpenAIClient.Prompts {
+  func toRequestPrompt(text: String) -> OpenAIClient.Prompt {
     switch self {
     case .correct:
       return .correct(input: text)

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -124,7 +124,7 @@ struct StatusEditorAccessoryView: View {
 
   private var AIMenu: some View {
     Menu {
-      ForEach(StatusEditorAIPrompts.allCases, id: \.self) { prompt in
+      ForEach(StatusEditorAIPrompt.allCases, id: \.self) { prompt in
         Button {
           Task {
             isLoadingAIRequest = true

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -483,7 +483,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
 
   // MARK: - OpenAI Prompt
 
-  func runOpenAI(prompt: OpenAIClient.Prompts) async {
+  func runOpenAI(prompt: OpenAIClient.Prompt) async {
     do {
       let client = OpenAIClient()
       let response = try await client.request(prompt)

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
@@ -14,7 +14,7 @@ struct StatusRowActionsView: View {
   }
 
   @MainActor
-  enum Actions: CaseIterable {
+  enum Action: CaseIterable {
     case respond, boost, favorite, bookmark, share
 
     func iconName(viewModel: StatusRowViewModel, privateBoost: Bool = false) -> String {
@@ -69,7 +69,7 @@ struct StatusRowActionsView: View {
   var body: some View {
     VStack(spacing: 12) {
       HStack {
-        ForEach(Actions.allCases, id: \.self) { action in
+        ForEach(Action.allCases, id: \.self) { action in
           if action == .share {
             if let urlString = viewModel.status.reblog?.url ?? viewModel.status.url,
                let url = URL(string: urlString)
@@ -107,7 +107,7 @@ struct StatusRowActionsView: View {
     }
   }
 
-  private func handleAction(action: Actions) {
+  private func handleAction(action: Action) {
     Task {
       if viewModel.isRemote, viewModel.localStatusId == nil || viewModel.localStatus == nil {
         guard await viewModel.fetchRemoteStatus() else {

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
@@ -85,7 +85,7 @@ struct StatusRowSwipeView: View {
   }
 
   @ViewBuilder
-  private func makeSwipeButtonForRouterPath(action: StatusAction, destination: SheetDestinations) -> some View {
+  private func makeSwipeButtonForRouterPath(action: StatusAction, destination: SheetDestination) -> some View {
     Button {
       HapticManager.shared.fireHaptic(of: .notification(.success))
       viewModel.routerPath.presentedSheet = destination


### PR DESCRIPTION
Just a minor type name renaming suggestion for the sake of bike-shedding:

https://github.com/Dimillian/IceCubesApp/blob/b643dda0834148c5c01be70696691ebddcf3fb73/Packages/Env/Sources/Env/Router.swift#L6-L21

The Swift Programming Language [book](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/enumerations/) recommends using a **singular** name rather than a plural one:

> Each enumeration definition defines a new type. Like other types in Swift, their names (such as CompassPoint and Planet) start with a capital letter. Give enumeration types singular rather than plural names, so that they read as self-evident […]

The benefit of this naming convention can be seen in:

https://github.com/Dimillian/IceCubesApp/blob/b643dda0834148c5c01be70696691ebddcf3fb73/Packages/Env/Sources/Env/Router.swift#L72-L74

This function signature looks like it will navigate to multiple multiple destinations in a single call while it really does is to navigate to a single destination. The clarity benefit of a singular name appears in several other locations such as here where the reader can be confused into thinking that the `presentedSheet` variable will old multiple destinations:

https://github.com/Dimillian/IceCubesApp/blob/b643dda0834148c5c01be70696691ebddcf3fb73/Packages/Env/Sources/Env/Router.swift#L68

Using a singular name will also make call sites such as the following one more consistent by using a singular name both for the type name and the associated variable name `destination`: 

https://github.com/Dimillian/IceCubesApp/blob/b643dda0834148c5c01be70696691ebddcf3fb73/IceCubesApp/App/AppRouter.swift#L16

In this PR, I singularized most enum type names excluding `CodingKeys` enums and `Constants` enums which behave more like namespaces. I also excluded everything conforming to `Endpoint` since I wasn't sure about the semantic of these enums.