### PR TITLE
Fixed compact layout for video tip when video autoplay is disabled

### DIFF
--- a/Packages/Status/Sources/Status/Media/VideoPlayerView.swift
+++ b/Packages/Status/Sources/Status/Media/VideoPlayerView.swift
@@ -45,6 +45,7 @@ class VideoPlayerViewModel: ObservableObject {
 
 struct VideoPlayerView: View {
   @Environment(\.scenePhase) private var scenePhase
+  @Environment(\.isCompact) private var isCompact
   @EnvironmentObject private var preferences: UserPreferences
   @EnvironmentObject private var theme: Theme
 
@@ -56,9 +57,9 @@ struct VideoPlayerView: View {
 
       if !preferences.autoPlayVideo {
         Image(systemName: "play.fill")
-          .font(.largeTitle)
+          .font(isCompact ? .body : .largeTitle)
           .foregroundColor(theme.tintColor)
-          .padding()
+          .padding(.all, isCompact ? 6 : nil)
           .background(Circle().fill(.thinMaterial))
           .padding(theme.statusDisplayStyle == .compact ? 0 : 10)
       }


### PR DESCRIPTION
Layout was broken by the too big sized Symbol.

Before - After:

<img alt="before" src="https://user-images.githubusercontent.com/8696821/220466284-6f51edb0-544e-4b17-a97d-83eb83b2f778.jpg" width="320"> - <img alt="after" src="https://user-images.githubusercontent.com/8696821/220466272-20803017-d1e8-4104-bf9b-662645a4513e.jpg" width="320">