### PR TITLE
Remove capture mode for images

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/Views/AvatarView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/AvatarView.swift
@@ -4,7 +4,6 @@ import Shimmer
 import SwiftUI
 
 public struct AvatarView: View {
-  @Environment(\.isInCaptureMode) private var isInCaptureMode: Bool
   @Environment(\.redactionReasons) private var reasons
   @EnvironmentObject private var theme: Theme
 
@@ -56,24 +55,17 @@ public struct AvatarView: View {
           .fill(.gray)
           .frame(width: size.size.width, height: size.size.height)
       } else {
-        if isInCaptureMode, let url = url, let image = Nuke.ImagePipeline.shared.cache.cachedImage(for: makeImageRequest(for: url))?.image {
-          Image(uiImage: image)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: size.size.width, height: size.size.height)
-        } else {
-          LazyImage(request: url.map(makeImageRequest)) { state in
-            if let image = state.image {
-              image
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-            } else {
-              AvatarPlaceholderView(size: size)
-            }
+        LazyImage(request: url.map(makeImageRequest)) { state in
+          if let image = state.image {
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+          } else {
+            AvatarPlaceholderView(size: size)
           }
-          .animation(nil)
-          .frame(width: size.size.width, height: size.size.height)
         }
+        .animation(nil)
+        .frame(width: size.size.width, height: size.size.height)
       }
     }
     .clipShape(clipShape)

--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -57,12 +57,12 @@ public protocol AnyStatus {
 
 public struct StatusViewId: Hashable {
   let id: String
-  let editedAt: ServerDate?
+  let editedAt: Date?
 }
 
 public extension AnyStatus {
   var viewId: StatusViewId {
-    StatusViewId(id: id, editedAt: editedAt)
+    StatusViewId(id: id, editedAt: editedAt?.asDate)
   }
 }
 

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -171,7 +171,7 @@ public struct StatusRowMediaPreviewView: View {
               .frame(width: newSize.width, height: newSize.height)
           }
         }
-        .processors([.resize(size: .init(width: newSize.width, height: newSize.height))])
+        .processors([.resize(size: newSize)])
         .frame(width: newSize.width, height: newSize.height)
 
       case .gifv, .video, .audio:

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -21,7 +21,6 @@ public struct StatusRowMediaPreviewView: View {
   public let isNotifications: Bool
 
   @State private var isQuickLookLoading: Bool = false
-  @State private var width: CGFloat = 0
   @State private var altTextDisplayed: String?
   @State private var isAltAlertDisplayed: Bool = false
   @State private var isHidingMedia: Bool = false
@@ -155,39 +154,25 @@ public struct StatusRowMediaPreviewView: View {
   private func makeFeaturedImagePreview(attachment: MediaAttachment) -> some View {
     ZStack(alignment: .bottomTrailing) {
       let size: CGSize = size(for: attachment) ?? .init(width: imageMaxHeight, height: imageMaxHeight)
-      let newSize = imageSize(from: size,
-                              newWidth: availableWidth - appLayoutWidth)
-      let processors: [ImageProcessing] = [.resize(size: .init(width: newSize.width, height: newSize.height))]
+      let newSize = imageSize(from: size, newWidth: availableWidth - appLayoutWidth)
       switch attachment.supportedType {
       case .image:
-        if isInCaptureMode,
-           let image = Nuke.ImagePipeline.shared.cache.cachedImage(for: .init(url: attachment.url,
-                                                                              processors: processors))?.image
-        {
-          Image(uiImage: image)
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: newSize.width, height: newSize.height)
-            .clipped()
-            .cornerRadius(4)
-        } else {
-          LazyImage(url: attachment.url) { state in
-            if let image = state.image {
-              image
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: newSize.width, height: newSize.height)
-                .clipped()
-                .cornerRadius(4)
-            } else {
-              RoundedRectangle(cornerRadius: 4)
-                .fill(Color.gray)
-                .frame(width: newSize.width, height: newSize.height)
-            }
+        LazyImage(url: attachment.url) { state in
+          if let image = state.image {
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+              .frame(width: newSize.width, height: newSize.height)
+              .clipped()
+              .cornerRadius(4)
+          } else {
+            RoundedRectangle(cornerRadius: 4)
+              .fill(Color.gray)
+              .frame(width: newSize.width, height: newSize.height)
           }
-          .processors([.resize(size: .init(width: newSize.width, height: newSize.height))])
-          .frame(width: newSize.width, height: newSize.height)
         }
+        .processors([.resize(size: .init(width: newSize.width, height: newSize.height))])
+        .frame(width: newSize.width, height: newSize.height)
 
       case .gifv, .video, .audio:
         if let url = attachment.url {


### PR DESCRIPTION
The `isInCaptureMode` option appears to be unnecessary for avatars and images. `ImageRender` takes a screenshot after `onAppear` is called, so `LazyImage` is given a chance to fetch the image from the memory cache, which happens synchronously.

Prior to Nuke 12, `LazyImage` was using `UIImageView` for rendering. I suspect `isInCaptureMode` was added as a workaround for the following issue:

> ImageRenderer output only includes views that SwiftUI renders, such as text, images, shapes, and composite views of these types. It does not render views provided by native platform frameworks (AppKit and UIKit) such as web views, media players, and some controls. For these views, ImageRenderer displays a placeholder image, similar to the behavior of [drawingGroup(opaque:colorMode:)](doc://com.apple.documentation/documentation/swiftui/view/drawinggroup(opaque:colormode:)?language=swift).
> 
> From [`ImageRenderer`](https://developer.apple.com/documentation/swiftui/imagerenderer) docs.

Btw, starting with [Nuke 12.0 Beta 5](https://github.com/kean/Nuke/releases/tag/12.0.0-beta.5), `LazyImage` no longer even requires `onAppear` to be called to fetch the memcached images; it happens on the first `body` compute, so there is now even fewer `body` redraw cycles.

### How I tested it

- Select a post and tap "Share / Share post as image"
- Verify that the saved images has both the avatars and the content media (images)