### PR TITLE
Make boost swipe buttons consistent with ones from inline & context menu

### DIFF
--- a/Packages/Env/Sources/Env/StatusAction.swift
+++ b/Packages/Env/Sources/Env/StatusAction.swift
@@ -7,7 +7,7 @@ public enum StatusAction: String, CaseIterable, Identifiable {
 
   case none, reply, boost, favorite, bookmark, quote
 
-  public func displayName(isReblogged: Bool = false, isFavorited: Bool = false, isBookmarked: Bool = false) -> LocalizedStringKey {
+  public func displayName(isReblogged: Bool = false, isFavorited: Bool = false, isBookmarked: Bool = false, privateBoost: Bool = false) -> LocalizedStringKey {
     switch self {
     case .none:
       return "settings.swipeactions.status.action.none"
@@ -16,6 +16,10 @@ public enum StatusAction: String, CaseIterable, Identifiable {
     case .quote:
       return "settings.swipeactions.status.action.quote"
     case .boost:
+      if privateBoost {
+        return isReblogged ? "status.action.unboost" : "status.action.boost-to-followers"
+      }
+      
       return isReblogged ? "status.action.unboost" : "settings.swipeactions.status.action.boost"
     case .favorite:
       return isFavorited ? "status.action.unfavorite" : "settings.swipeactions.status.action.favorite"
@@ -24,7 +28,7 @@ public enum StatusAction: String, CaseIterable, Identifiable {
     }
   }
 
-  public func iconName(isReblogged: Bool = false, isFavorited: Bool = false, isBookmarked: Bool = false) -> String {
+  public func iconName(isReblogged: Bool = false, isFavorited: Bool = false, isBookmarked: Bool = false, privateBoost: Bool = false) -> String {
     switch self {
     case .none:
       return "slash.circle"
@@ -33,6 +37,10 @@ public enum StatusAction: String, CaseIterable, Identifiable {
     case .quote:
       return "quote.bubble"
     case .boost:
+      if privateBoost {
+        return isReblogged ? "arrow.left.arrow.right.circle.fill" : "lock.rotation"
+      }
+      
       return isReblogged ? "arrow.left.arrow.right.circle.fill" : "arrow.left.arrow.right.circle"
     case .favorite:
       return isFavorited ? "star.fill" : "star"

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
@@ -6,9 +6,14 @@ import SwiftUI
 struct StatusRowSwipeView: View {
   @EnvironmentObject private var theme: Theme
   @EnvironmentObject private var preferences: UserPreferences
+  @EnvironmentObject private var currentAccount: CurrentAccount
 
   enum Mode {
     case leading, trailing
+  }
+  
+  func privateBoost() -> Bool {
+    return viewModel.status.visibility == .priv && viewModel.status.account.id == currentAccount.account?.id
   }
 
   let viewModel: StatusRowViewModel
@@ -110,11 +115,11 @@ struct StatusRowSwipeView: View {
   private func makeSwipeLabel(action: StatusAction, style: UserPreferences.SwipeActionsIconStyle) -> some View {
     switch style {
     case .iconOnly:
-      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
+      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost()), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost()))
         .labelStyle(.iconOnly)
         .environment(\.symbolVariants, .none)
     case .iconWithText:
-      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked))
+      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost()), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost()))
         .labelStyle(.titleAndIcon)
         .environment(\.symbolVariants, .none)
     }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
@@ -68,7 +68,7 @@ struct StatusRowSwipeView: View {
         }
       }
     case .boost:
-      makeSwipeButtonForTask(action: action) {
+      makeSwipeButtonForTask(action: action, privateBoost: privateBoost()) {
         if viewModel.isReblogged {
           await viewModel.unReblog()
         } else {
@@ -101,26 +101,26 @@ struct StatusRowSwipeView: View {
   }
 
   @ViewBuilder
-  private func makeSwipeButtonForTask(action: StatusAction, task: @escaping () async -> Void) -> some View {
+  private func makeSwipeButtonForTask(action: StatusAction, privateBoost: Bool = false, task: @escaping () async -> Void) -> some View {
     Button {
       Task {
         HapticManager.shared.fireHaptic(of: .notification(.success))
         await task()
       }
     } label: {
-      makeSwipeLabel(action: action, style: preferences.swipeActionsIconStyle)
+      makeSwipeLabel(action: action, style: preferences.swipeActionsIconStyle, privateBoost: privateBoost)
     }
   }
 
   @ViewBuilder
-  private func makeSwipeLabel(action: StatusAction, style: UserPreferences.SwipeActionsIconStyle) -> some View {
+  private func makeSwipeLabel(action: StatusAction, style: UserPreferences.SwipeActionsIconStyle, privateBoost: Bool = false) -> some View {
     switch style {
     case .iconOnly:
-      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost()), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost()))
+      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost))
         .labelStyle(.iconOnly)
         .environment(\.symbolVariants, .none)
     case .iconWithText:
-      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost()), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost()))
+      Label(action.displayName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost), systemImage: action.iconName(isReblogged: viewModel.isReblogged, isFavorited: viewModel.isFavorited, isBookmarked: viewModel.isBookmarked, privateBoost: privateBoost))
         .labelStyle(.titleAndIcon)
         .environment(\.symbolVariants, .none)
     }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
@@ -75,6 +75,7 @@ struct StatusRowSwipeView: View {
           await viewModel.reblog()
         }
       }
+      .disabled(viewModel.status.visibility == .direct || viewModel.status.visibility == .priv && viewModel.status.account.id != currentAccount.account?.id)
     case .bookmark:
       makeSwipeButtonForTask(action: action) {
         if viewModel.isBookmarked {


### PR DESCRIPTION
- Show different labels and icons in boost swipe buttons when boosting my followers-only posts
- Disable boost swipe buttons on posts that can't be boosted