### PR TITLE
Add flair to status action buttons

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusActionButtonStyle.swift
+++ b/Packages/Status/Sources/Status/Row/StatusActionButtonStyle.swift
@@ -1,0 +1,128 @@
+import UIKit
+import SwiftUI
+import DesignSystem
+
+extension ButtonStyle where Self == StatusActionButtonStyle {
+  static func statusAction(isOn: Bool = false, tintColor: Color? = nil) -> Self {
+    StatusActionButtonStyle(isOn: isOn, tintColor: tintColor)
+  }
+}
+
+/// A toggle button that slightly scales and sends particle on activation,
+/// changing its foreground color to `tintColor` when toggled on
+struct StatusActionButtonStyle: ButtonStyle {
+  var isOn: Bool
+  var tintColor: Color?
+
+  @State var sparklesCounter: Float = 0
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .foregroundColor(isOn ? tintColor : Color(UIColor.secondaryLabel))
+      .animation(nil, value: isOn)
+      .brightness(brightness(configuration: configuration))
+      .animation(configuration.isPressed ? nil : .default, value: isOn)
+      .scaleEffect(configuration.isPressed && !isOn ? 0.8 : 1.0)
+      .background {
+        if let tint = tintColor {
+          SparklesView(counter: sparklesCounter, tint: tint, size: 5, velocity: 30)
+        }
+      }
+      .onChange(of: configuration.isPressed) { isPressed in
+        guard tintColor != nil && !isPressed && !isOn else { return }
+
+        withAnimation(.spring(response: 1, dampingFraction: 1)) {
+          sparklesCounter += 1
+        }
+      }
+  }
+
+  func brightness(configuration: Configuration) -> Double {
+    switch (configuration.isPressed, isOn) {
+    case (true, true): return 0.6
+    case (true, false): return 0.2
+    default: return 0
+    }
+  }
+
+  struct SparklesView: View, Animatable {
+    var counter: Float
+    var tint: Color
+    var size: CGFloat
+    var velocity: CGFloat
+
+    var animatableData: Float {
+      get { counter }
+      set { counter = newValue }
+    }
+
+    struct Cell: Identifiable {
+      var id: Int
+      var angle: CGFloat
+      var velocity: CGFloat
+      var scale: CGFloat
+      var alpha: CGFloat
+    }
+
+    @State var cells: [Cell] = []
+
+    var progress: CGFloat {
+      CGFloat(counter - counter.rounded(.down))
+    }
+
+    public var body: some View {
+      if progress > 0.0 {
+        ZStack(alignment: .center) {
+          ForEach(cells) { cell in
+            Circle()
+              .frame(width: size, height: size)
+              .foregroundColor(tint)
+              .opacity(cell.alpha - (progress * cell.alpha) / 3)
+              .scaleEffect(cell.scale - progress * cell.scale)
+              .offset(
+                x: cos(cell.angle) * progress * cell.velocity * velocity,
+                y: sin(cell.angle) * progress * cell.velocity * velocity
+              )
+          }
+        }
+        .onAppear {
+          cells = Self.generateCells()
+        }
+        .onChange(of: counter) { [counter] newCounter in
+          if floor(counter) != floor(newCounter) {
+            cells = Self.generateCells()
+          }
+        }
+      }
+    }
+
+    static func generateCells() -> [Cell] {
+      let cellCount = 16
+      let velocityRange = 0.6...1.0
+      let scaleRange = 0.5...1.0
+      let alphaRange = 0.6...1.0
+
+      let spacing = 2 * .pi/(1.618 + Double(arc4random() % 200) / 10000)
+      let initialSpacing = deg2rad(Double(arc4random() % 360))
+      return (0..<cellCount).map { index in
+        return Cell(
+          id: index,
+          angle: initialSpacing + spacing * Double(index),
+          velocity: random(within: velocityRange),
+          scale: random(within: scaleRange),
+          alpha: random(within: alphaRange)
+        )
+      }
+    }
+
+    static func random(within range: ClosedRange<Double>) -> Double {
+      Double(arc4random()) / 0xFFFFFFFF * (range.upperBound - range.lowerBound) + range.lowerBound
+    }
+
+    static func deg2rad(_ number: Double) -> Double {
+        return number * .pi / 180
+    }
+  }
+}
+
+

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
@@ -107,7 +107,7 @@ struct StatusRowActionsView: View {
       Button {
         handleAction(action: action)
       } label: {
-        Image(systemName: action.iconName(viewModel: viewModel))
+        Image(systemName: action.iconName(viewModel: viewModel, privateBoost: privateBoost()))
       }
       .buttonStyle(
         .statusAction(


### PR DESCRIPTION
- makes tintColor viewModel independent in Action
- adds isOn function to Action
- moves actionButton to its own function for clarity (and help compilo)
- moves the counter outside the button
- creates StatusActionButtonStyle that defines how an action button behaves when tapped and toggled
- adds nested SparklesView that animates sparkles when the action button is tapped

Sidenote : couldn't get the "bouncy" scale effect I wanted. It wouldn't work on an iOS device, but did on the simulator.


https://user-images.githubusercontent.com/520924/220598379-c6f5f831-8edf-4b05-85b1-b229d5fd07c1.mov

