### PR TITLE
Removed Boutique, using Bogeda directly

### DIFF
--- a/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "boutique",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mergesort/Boutique",
-      "state" : {
-        "revision" : "b5b697de67100edc4b2d5c74724f3c1068b49d4e",
-        "version" : "2.1.1"
-      }
-    },
-    {
       "identity" : "emojitext",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/divadretlaw/EmojiText",
@@ -70,15 +61,6 @@
       "state" : {
         "revision" : "4d543d811ee644fa4cc4bfa0be996b4dd6ba0f54",
         "version" : "0.13.3"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
-      "state" : {
-        "revision" : "48254824bb4248676bf7ce56014ff57b142b77eb",
-        "version" : "1.0.2"
       }
     },
     {

--- a/IceCubesApp/App/Tabs/Settings/AboutView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AboutView.swift
@@ -65,7 +65,7 @@ struct AboutView: View {
 
         • [LRUCache](https://github.com/nicklockwood/LRUCache)
 
-        • [Boutique](https://github.com/mergesort/Boutique)
+        • [Bodega](https://github.com/mergesort/Bodega)
 
         • [Nuke](https://github.com/kean/Nuke)
 

--- a/Packages/Timeline/Package.swift
+++ b/Packages/Timeline/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     .package(name: "Status", path: "../Status"),
     .package(name: "DesignSystem", path: "../DesignSystem"),
     .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "0.1.4"),
-    .package(url: "https://github.com/mergesort/Boutique", from: "2.1.1"),
+    .package(url: "https://github.com/mergesort/Bodega", from: "2.0.2"),
   ],
   targets: [
     .target(
@@ -34,7 +34,7 @@ let package = Package(
         .product(name: "Status", package: "Status"),
         .product(name: "DesignSystem", package: "DesignSystem"),
         .product(name: "Introspect", package: "SwiftUI-Introspect"),
-        .product(name: "Boutique", package: "Boutique"),
+        .product(name: "Bodega", package: "Bodega"),
       ]
     ),
     .testTarget(

--- a/Packages/Timeline/Sources/Timeline/TimelineCache.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineCache.swift
@@ -1,4 +1,4 @@
-import Boutique
+import Bodega
 import Models
 import Network
 import SwiftUI


### PR DESCRIPTION
Turns out IceCubesApp is not using Boutique at all, but is using a dependency of Boutique: Bogeda.
This PR remove Boutique in favor of Bogeda directly

Motivations : less dependencies (removing Boutique & Swift-Collection) leads to:
- Faster build
- Less dependency management
- Reduced build size? (not sure, depends on swift compiler optimizations)