### PR TITLE
Don't show the source-language before translating

### DIFF
--- a/IceCubesApp/Resources/Localization/Plurals/en.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/en.lproj/Localizable.stringsdict
@@ -2,37 +2,37 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>timeline-new-posts %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@timelineNewPosts@</string>
-        <key>timelineNewPosts</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string>%lld new post</string>
-            <key>other</key>
-            <string>%lld new posts</string>
-        </dict>
-    </dict>
-    <key>notifications-others-count %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@noficationsOthersCount@</string>
-        <key>noficationsOthersCount</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string> and %lld other </string>
-            <key>other</key>
-            <string> and %lld others </string>
-        </dict>
-    </dict>
+	<key>timeline-new-posts %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@timelineNewPosts@</string>
+		<key>timelineNewPosts</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld new post</string>
+			<key>other</key>
+			<string>%lld new posts</string>
+		</dict>
+	</dict>
+	<key>notifications-others-count %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@noficationsOthersCount@</string>
+		<key>noficationsOthersCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string> and %lld other </string>
+			<key>other</key>
+			<string> and %lld others </string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -357,6 +357,7 @@
 "status.action.translate" = "Перакласці";
 "status.action.translate-from-%@" = "Перакласці з %@";
 "status.action.translated-label-%@" = "Пераклад з дапамогай %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Закладка";
 "status.action.boost" = "Павышэнне";
 "status.action.copy-text" = "Капіяваць тэкст";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -372,7 +372,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Перакласці";
-"status.action.translate-from-%@" = "Перакласці з %@";
 "status.action.translated-label-%@" = "Пераклад з дапамогай %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Закладка";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -367,6 +367,7 @@
 "status.action.translate" = "Tradueix";
 "status.action.translate-from-%@" = "Tradueix del %@";
 "status.action.translated-label-%@" = "Traduït amb %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Afegeix als marcadors";
 "status.action.boost" = "Impulsa";
 "status.action.copy-text" = "Copia el text";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -366,7 +366,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tradueix";
-"status.action.translate-from-%@" = "Tradueix del %@";
 "status.action.translated-label-%@" = "Traduït amb %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Afegeix als marcadors";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -363,7 +363,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Übersetzen";
-"status.action.translate-from-%@" = "Aus %@ übersetzen";
 "status.action.translated-label-%@" = "Übersetzt mit %@";
 "status.action.translated-label-from-%@-%@" = "Aus %@ mit %@ übersetzt";
 "status.action.bookmark" = "Lesezeichen setzen";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -364,6 +364,7 @@
 "status.action.translate" = "Übersetzen";
 "status.action.translate-from-%@" = "Aus %@ übersetzen";
 "status.action.translated-label-%@" = "Übersetzt mit %@";
+"status.action.translated-label-from-%@-%@" = "Aus %@ mit %@ übersetzt";
 "status.action.bookmark" = "Lesezeichen setzen";
 "status.action.boost" = "Boosten";
 "status.action.copy-text" = "Text kopieren";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -369,7 +369,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
-"status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label-%@" = "Translated using %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Bookmark";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -370,6 +370,7 @@
 "status.action.translate" = "Translate";
 "status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label-%@" = "Translated using %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copy Text";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -368,7 +368,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
-"status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label-%@" = "Translated using %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Bookmark";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -369,6 +369,7 @@
 "status.action.translate" = "Translate";
 "status.action.translate-from-%@" = "Translate from %@";
 "status.action.translated-label-%@" = "Translated using %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Bookmark";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copy Text";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -368,7 +368,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traducir";
-"status.action.translate-from-%@" = "Traducir desde %@";
 "status.action.translated-label-%@" = "Traducido usando %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Añadir a marcadores";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -369,6 +369,7 @@
 "status.action.translate" = "Traducir";
 "status.action.translate-from-%@" = "Traducir desde %@";
 "status.action.translated-label-%@" = "Traducido usando %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Añadir a marcadores";
 "status.action.boost" = "Retootear";
 "status.action.copy-text" = "Copiar texto";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -361,7 +361,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Itzuli";
-"status.action.translate-from-%@" = "Itzuli %@(e)tik";
 "status.action.translated-label-%@" = "%@ erabiliz itzulia";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Jarri laster-marka";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -362,6 +362,7 @@
 "status.action.translate" = "Itzuli";
 "status.action.translate-from-%@" = "Itzuli %@(e)tik";
 "status.action.translated-label-%@" = "%@ erabiliz itzulia";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Jarri laster-marka";
 "status.action.boost" = "Bultzatu";
 "status.action.copy-text" = "Kopiatu testua";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -363,7 +363,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduire";
-"status.action.translate-from-%@" = "Traduire de %@";
 "status.action.translated-label-%@" = "Traduit avec %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Marquer";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -364,6 +364,7 @@
 "status.action.translate" = "Traduire";
 "status.action.translate-from-%@" = "Traduire de %@";
 "status.action.translated-label-%@" = "Traduit avec %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Marquer";
 "status.action.boost" = "Promouvoir";
 "status.action.copy-text" = "Copier le texte";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -368,7 +368,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduci";
-"status.action.translate-from-%@" = "Traduci da %@";
 "status.action.translated-label-%@" = "Tradotto usando %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Salva nei segnalibri";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -369,6 +369,7 @@
 "status.action.translate" = "Traduci";
 "status.action.translate-from-%@" = "Traduci da %@";
 "status.action.translated-label-%@" = "Tradotto usando %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Salva nei segnalibri";
 "status.action.boost" = "Condividi";
 "status.action.copy-text" = "Copia il testo";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -367,7 +367,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻訳";
-"status.action.translate-from-%@" = "%@ から翻訳";
 "status.action.translated-label-%@" = "%@ を使用して翻訳";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "ブックマーク";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -368,6 +368,7 @@
 "status.action.translate" = "翻訳";
 "status.action.translate-from-%@" = "%@ から翻訳";
 "status.action.translated-label-%@" = "%@ を使用して翻訳";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "ブックマーク";
 "status.action.boost" = "ブースト";
 "status.action.copy-text" = "テキストをコピー";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -370,6 +370,7 @@
 "status.action.translate" = "번역";
 "status.action.translate-from-%@" = "%@에서 번역";
 "status.action.translated-label-%@" = "번역 제공: %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "보관함에 추가";
 "status.action.boost" = "부스트";
 "status.action.copy-text" = "복사";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -369,7 +369,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "번역";
-"status.action.translate-from-%@" = "%@에서 번역";
 "status.action.translated-label-%@" = "번역 제공: %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "보관함에 추가";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -367,7 +367,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Oversett";
-"status.action.translate-from-%@" = "Oversett fra %@";
 "status.action.translated-label-%@" = "Oversatt ved hjelp av %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Bokmerk";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -368,6 +368,7 @@
 "status.action.translate" = "Oversett";
 "status.action.translate-from-%@" = "Oversett fra %@";
 "status.action.translated-label-%@" = "Oversatt ved hjelp av %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Bokmerk";
 "status.action.boost" = "Forsterk";
 "status.action.copy-text" = "Kopier tekst";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -362,7 +362,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Vertaal";
-"status.action.translate-from-%@" = "Vertaal uit het %@";
 "status.action.translated-label-%@" = "Vertaald met behulp van %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Voeg bladwijzer toe";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -362,6 +362,7 @@
 "status.action.translate" = "Vertaal";
 "status.action.translate-from-%@" = "Vertaal uit het %@";
 "status.action.translated-label-%@" = "Vertaald met behulp van %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Voeg bladwijzer toe";
 "status.action.boost" = "Boosten";
 "status.action.copy-text" = "Kopieer tekst";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -363,7 +363,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Przetłumacz";
-"status.action.translate-from-%@" = "Przetłumacz tekst %@";
 "status.action.translated-label-%@" = "Przetłumaczono za pomocą %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Dodaj zakładkę";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -364,6 +364,7 @@
 "status.action.translate" = "Przetłumacz";
 "status.action.translate-from-%@" = "Przetłumacz tekst %@";
 "status.action.translated-label-%@" = "Przetłumaczono za pomocą %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Dodaj zakładkę";
 "status.action.boost" = "Podbij";
 "status.action.copy-text" = "Kopiuj tekst";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -368,6 +368,7 @@
 "status.action.translate" = "Traduzir";
 "status.action.translate-from-%@" = "Traduzir do %@";
 "status.action.translated-label-%@" = "Traduzir usando %@";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Salvar";
 "status.action.boost" = "Boost";
 "status.action.copy-text" = "Copiar Texto";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -367,7 +367,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduzir";
-"status.action.translate-from-%@" = "Traduzir do %@";
 "status.action.translated-label-%@" = "Traduzir usando %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Salvar";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -363,7 +363,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tercüme et";
-"status.action.translate-from-%@" = "Tercüme et %@";
 "status.action.translated-label-%@" = "%@ tarafından tercüme edildi";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Yer İmi Ekle";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -364,6 +364,7 @@
 "status.action.translate" = "Tercüme et";
 "status.action.translate-from-%@" = "Tercüme et %@";
 "status.action.translated-label-%@" = "%@ tarafından tercüme edildi";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Yer İmi Ekle";
 "status.action.boost" = "Yükselt";
 "status.action.copy-text" = "Yazıyı Kopyala";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -367,6 +367,7 @@
 "status.action.translate" = "翻译";
 "status.action.translate-from-%@" = "翻译 %@";
 "status.action.translated-label-%@" = "由 %@ 翻译";
+"status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "书签";
 "status.action.boost" = "转发";
 "status.action.copy-text" = "拷贝文本";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -366,7 +366,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻译";
-"status.action.translate-from-%@" = "翻译 %@";
 "status.action.translated-label-%@" = "由 %@ 翻译";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "书签";

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -312,10 +312,6 @@ public class StatusRowViewModel: ObservableObject {
   }
 
   func translate(userLang: String) async {
-    await translate(userLang: userLang, sourceLang: getStatusLang())
-  }
-
-  private func translate(userLang: String, sourceLang _: String?) async {
     do {
       withAnimation {
         isLoadingTranslation = true

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -123,13 +123,7 @@ struct StatusRowContextMenu: View {
           await viewModel.translate(userLang: lang)
         }
       } label: {
-        if let statusLang = viewModel.getStatusLang(),
-           let languageName = Locale.current.localizedString(forLanguageCode: statusLang)
-        {
-          Label("status.action.translate-from-\(languageName)", systemImage: "captions.bubble")
-        } else {
           Label("status.action.translate", systemImage: "captions.bubble")
-        }
       }
     }
 

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowTranslateView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowTranslateView.swift
@@ -25,6 +25,15 @@ struct StatusRowTranslateView: View {
     }
   }
 
+    private func getLocalizedString(langCode: String, provider: String) -> String {
+        if let localizedLanguage = Locale.current.localizedString(forLanguageCode: langCode) {
+            let format = NSLocalizedString("status.action.translated-label-from-%@-%@", comment: "")
+            return String.localizedStringWithFormat(format, localizedLanguage, provider)
+        } else {
+            return "status.action.translated-label-\(provider)"
+        }
+    }
+    
   var body: some View {
     if !isInCaptureMode,
         let userLang = preferences.serverPreferences?.postLanguage,
@@ -49,7 +58,7 @@ struct StatusRowTranslateView: View {
         VStack(alignment: .leading, spacing: 4) {
           Text(translation.content.asSafeMarkdownAttributedString)
             .font(.scaledBody)
-          Text("status.action.translated-label-\(translation.provider)")
+            Text(getLocalizedString(langCode: translation.detectedSourceLanguage, provider: translation.provider))
             .font(.footnote)
             .foregroundColor(.gray)
         }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowTranslateView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowTranslateView.swift
@@ -38,13 +38,7 @@ struct StatusRowTranslateView: View {
         if viewModel.isLoadingTranslation {
           ProgressView()
         } else {
-          if let statusLanguage = viewModel.getStatusLang(),
-             let languageName = Locale.current.localizedString(forLanguageCode: statusLanguage)
-          {
-            Text("status.action.translate-from-\(languageName)")
-          } else {
             Text("status.action.translate")
-          }
         }
       }
       .buttonStyle(.borderless)


### PR DESCRIPTION
I've removed the source language from the translate buttons to more accurately show what is done (The transition service automatically detects the language) and to not confuse the user if the poster sets the wrong source language.
This set language is now only used to determine if the button is shown in the main view in addition to the context menu. Furthermore, the detected source language is now visible in the box with the translated text and the translation service.