### PR TITLE
Fix action button counter glitch in most scenarios

### DIFF
--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
@@ -121,6 +121,7 @@ struct StatusRowActionsView: View {
         Text("\(count)")
           .foregroundColor(Color(UIColor.secondaryLabel))
           .font(.scaledFootnote)
+          .monospacedDigit()
       }
     }
   }


### PR DESCRIPTION
Adds monospacedDigit modifier to the counter next to action button counter labels. This fixes the layout glitch that happens when the counter changes, most noticeably when you tap the boost or favorite button except for when the counter gains or loses a digit (9 -> 10, 99 -> 100 etc…) Still greatly improves the actions view experience though.

Thanks to [@gavtron](https://mstdn.social/@gavtron) for the suggestion.