### PR TITLE
Move autoPlayVideo setting to content settings view

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -20,6 +20,9 @@ struct ContentSettingsView: View {
       }.listRowBackground(theme.primaryBackgroundColor)
 
       Section("settings.content.media") {
+        Toggle(isOn: $userPreferences.autoPlayVideo) {
+          Text("settings.other.autoplay-video")
+        }
         Toggle(isOn: $userPreferences.showAltTextForMedia) {
           Text("settings.content.media.show.alt")
         }

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -174,9 +174,6 @@ struct SettingsTabs: View {
       Toggle(isOn: $preferences.isSocialKeyboardEnabled) {
         Label("settings.other.social-keyboard", systemImage: "keyboard")
       }
-      Toggle(isOn: $preferences.autoPlayVideo) {
-        Label("settings.other.autoplay-video", systemImage: "play.square.stack")
-      }
     }
     .listRowBackground(theme.primaryBackgroundColor)
   }


### PR DESCRIPTION
The settings 'Auto-Play Video' belongs to the Media section of the Content Settings view, I think. 