### PR TITLE
Always show buttons on focused status in details view

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -69,7 +69,7 @@ public struct StatusRowView: View {
             .accessibilityAction {
               viewModel.navigateToDetail()
             }
-            if viewModel.showActions, theme.statusActionsDisplay != .none {
+           if viewModel.showActions, (viewModel.isFocused || theme.statusActionsDisplay != .none) {
               StatusRowActionsView(viewModel: viewModel)
                 .padding(.top, 8)
                 .tint(viewModel.isFocused ? theme.tintColor : .gray)

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
@@ -37,7 +37,7 @@ struct StatusRowActionsView: View {
     }
 
     func count(viewModel: StatusRowViewModel, theme: Theme) -> Int? {
-      if theme.statusActionsDisplay == .discret {
+        if theme.statusActionsDisplay == .discret && !viewModel.isFocused {
         return nil
       }
       switch self {


### PR DESCRIPTION
I think it's helpful to have the buttons and their numeric badges visible when showing a status detail view for the focused status, even if the user has opted to hide them in timeline display settings.
