### PR TITLE
Adjusted how to hide the voting screen

### DIFF
--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -39,6 +39,7 @@ struct StatusEditorAccessoryView: View {
             Button {
               withAnimation {
                 viewModel.showPoll.toggle()
+                viewModel.resetPollDefaults()
               }
             } label: {
               Image(systemName: "chart.bar")

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -99,7 +99,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
   }
 
   var shouldDisablePollButton: Bool {
-    showPoll || !selectedMedias.isEmpty
+    !selectedMedias.isEmpty
   }
 
   var shouldDisplayDismissWarning: Bool {


### PR DESCRIPTION
Like other submission item selection screens, the voting screen can now be shown/hidden with a button toggle.