### PR TITLE
Change icon for bot profile

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -137,7 +137,7 @@ struct AccountDetailHeaderView: View {
               .font(.scaledHeadline)
               .emojiSize(Font.scaledHeadlinePointSize)
             if account.bot {
-              Text(Image(systemName: "gearshape.fill"))
+              Text(Image(systemName: "poweroutlet.type.b.fill"))
                 .font(.footnote)
             }
             if account.locked {

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowHeaderView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowHeaderView.swift
@@ -76,7 +76,7 @@ struct StatusRowHeaderView: View {
 
   private var accountBadgeView: Text {
     if (viewModel.status.reblogAsAsStatus ?? viewModel.status).account.bot {
-      return Text(Image(systemName: "gearshape.fill")) + Text(" ")
+      return Text(Image(systemName: "poweroutlet.type.b.fill")) + Text(" ")
     } else if (viewModel.status.reblogAsAsStatus ?? viewModel.status).account.locked {
       return Text(Image(systemName: "lock.fill")) + Text(" ")
     }


### PR DESCRIPTION
Had a short conversation on mastodon where a user asked what the gear icon next to the profile name means. One of the comments came up with this one as it looks more like a robot (I never would have thought of using a poweroutlet symbol)

![image](https://user-images.githubusercontent.com/8456476/221371237-7f0b6f79-9a35-4c46-b1ae-1cebe0c03338.png)

I like it better as well, your decision to use it ;-)