### PR TITLE
Mark the active account in the account switcher

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Дадаць уліковы запіс";
 "account.add.sign-in" = "Увайсці";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Вядучы";
 "enum.avatar-position.top" = "Наверсе";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -18,6 +18,8 @@
 "account.add.navigation-title" = "Afegeix un compte";
 "account.add.sign-in" = "Inicia sessió";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Davant";
 "enum.avatar-position.top" = "Dalt";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Konto hinzufügen";
 "account.add.sign-in" = "Anmelden";
 
+"account.active" = "Aktives Konto";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Vorne";
 "enum.avatar-position.top" = "Oben";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Add account";
 "account.add.sign-in" = "Sign in";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Leading";
 "enum.avatar-position.top" = "Top";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Add account";
 "account.add.sign-in" = "Sign in";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Leading";
 "enum.avatar-position.top" = "Top";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Añadir cuenta";
 "account.add.sign-in" = "Iniciar sesión";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Delante";
 "enum.avatar-position.top" = "Arriba";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Gehitu kontua";
 "account.add.sign-in" = "Hasi saioa";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Alboan";
 "enum.avatar-position.top" = "Corpusean";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Ajouter un compte";
 "account.add.sign-in" = "Se connecter";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "En tête";
 "enum.avatar-position.top" = "En haut";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Aggiungi account";
 "account.add.sign-in" = "Accedi";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "A fianco";
 "enum.avatar-position.top" = "In alto";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "アカウントの追加";
 "account.add.sign-in" = "サインイン";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "水平方向に先頭";
 "enum.avatar-position.top" = "垂直方向に先頭";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "계정 추가";
 "account.add.sign-in" = "로그인";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "본문 옆";
 "enum.avatar-position.top" = "본문 위";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Legg til konto";
 "account.add.sign-in" = "Logg inn";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Ledende";
 "enum.avatar-position.top" = "Topp";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Account toevoegen";
 "account.add.sign-in" = "Log in";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Leidend";
 "enum.avatar-position.top" = "Boven";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Dodaj konto";
 "account.add.sign-in" = "Zaloguj się";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Z lewej";
 "enum.avatar-position.top" = "Na górze";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Adicionar conta";
 "account.add.sign-in" = "Entrar";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Principal";
 "enum.avatar-position.top" = "Topo";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Hesap Ekle";
 "account.add.sign-in" = "Giriş Yap";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Önde";
 "enum.avatar-position.top" = "Üstte";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "Додати підключення";
 "account.add.sign-in" = "Зареєструватися";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "Поряд";
 "enum.avatar-position.top" = "Зверху";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "account.add.navigation-title" = "添加账户";
 "account.add.sign-in" = "登录";
 
+"account.active" = "Active Account";
+
 // MARK: Enums
 "enum.avatar-position.leading" = "居首";
 "enum.avatar-position.top" = "顶部";

--- a/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
@@ -76,10 +76,20 @@ public struct AppAccountsSelectorView: View {
     .accessibilityLabel("accessibility.app-account.selector.accounts")
   }
 
+    private func getCurrentAccountStr(viewModel: AppAccountViewModel) -> String {
+        if let current = currentAccount.account?.id,
+           let object = viewModel.account?.id,
+           current == object {
+            return "\(String(localized: "account.active"))\n"
+        } else {
+            return ""
+        }
+    }
+
   @ViewBuilder
   private var menuView: some View {
     ForEach(accountsViewModel, id: \.appAccount.id) { viewModel in
-      Section(viewModel.acct) {
+      Section("\(getCurrentAccountStr(viewModel: viewModel))\(viewModel.acct)") {
         Button {
           if let account = currentAccount.account,
              viewModel.account?.id == account.id


### PR DESCRIPTION
The active account is marked with the string "Active Account" in front of the account name in the title of the section.
Requested in #1068 