### PR TITLE
add icons for muted and blocked profiles

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -144,6 +144,14 @@ struct AccountDetailHeaderView: View {
               Text(Image(systemName: "lock.fill"))
                 .font(.footnote)
             }
+            if viewModel.relationship?.blocking == true {
+              Text(Image(systemName: "person.crop.circle.badge.xmark.fill"))
+                .font(.footnote)
+            }
+            if viewModel.relationship?.muting == true {
+              Text(Image(systemName: "speaker.slash.fill"))
+                .font(.footnote)
+            }
           }
           Text("@\(account.acct)")
             .font(.scaledCallout)


### PR DESCRIPTION
In the profile view adding icons for profiles that are muted or blocked or both (the lock in the screenshot comes from the fact that my other account is private)

muted
![image](https://user-images.githubusercontent.com/8456476/221432068-ed70a460-1769-4839-be23-eb0d640140bd.png)

blocked
![image](https://user-images.githubusercontent.com/8456476/221432076-68bbcbdc-a2ba-4bf9-a38f-5f49f28e3f6b.png)

blocked and muted
![image](https://user-images.githubusercontent.com/8456476/221432079-2928c238-9c5c-44bf-ae7a-e4c076b39726.png)

Closes #1076 