### PR TITLE
A cancel button has been placed on the custom emoji selection screen on the post screen

### DIFF
--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -261,6 +261,11 @@ struct StatusEditorAccessoryView: View {
           }
         }.padding(.horizontal)
       }
+      .toolbar {
+        ToolbarItem(placement: .navigationBarLeading) {
+          Button("action.cancel", action: { isCustomEmojisSheetDisplay = false })
+        }
+      }
       .scrollContentBackground(.hidden)
       .background(theme.primaryBackgroundColor)
       .navigationTitle("status.editor.emojis.navigation-title")


### PR DESCRIPTION
Currently, the post screen has a cancel button only on the screen for selecting drafts, so we placed a cancel button for consistency and UX improvement. Related: #1073