### PR TITLE
Workaround for macOS 13.3 SFSafariViewController issue (Fix for #1069)

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/AddAccountsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AddAccountsView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct AddAccountView: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(\.scenePhase) private var scenePhase
+  @Environment(\.openURL) var openURL
 
   @EnvironmentObject private var appAccountsManager: AppAccountsManager
   @EnvironmentObject private var currentAccount: CurrentAccount
@@ -125,7 +126,30 @@ struct AddAccountView: View {
         }
       })
       .sheet(item: $oauthURL, content: { url in
-        SafariView(url: url)
+		  if ProcessInfo.processInfo.isiOSAppOnMac && ProcessInfo.processInfo.isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 13, minorVersion: 3, patchVersion: 0)) {  // Workaround for macOS 13.3 seemingly breaking SFSafariViewController, can be removed if this issue is resolved
+			  NavigationView {
+			  VStack {
+				  Text("account.add.link-account")
+				  Button {
+					  withAnimation {
+						  openURL(url)
+					  }
+				  } label: {
+					  HStack {
+						  Text("account.add.sign-in")
+							  .font(.scaledHeadline)
+					  }
+				  }
+				  .buttonStyle(.borderedProminent)
+			  }
+			  .toolbar {
+				  ToolbarItem(placement: .navigationBarLeading) {
+					  Button("action.cancel", action: { dismiss() })
+				  }}
+		  }
+		  } else {
+			  SafariView(url: url)
+		  }
       })
     }
   }

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -18,6 +18,7 @@
 "account.add.error.instance-not-supported" = "This instance is not currently supported.";
 "account.add.navigation-title" = "Add account";
 "account.add.sign-in" = "Sign in";
+"account.add.link-account" = "Click below to login with your Mastodon account";
 
 // MARK: Enums
 "enum.avatar-position.leading" = "Leading";


### PR DESCRIPTION
macOS 13.3 breaks SFSafariViewController, leading to a crash as described in [#1069](https://github.com/Dimillian/IceCubesApp/issues/1069).

It's unclear if this is an intended change by Apple, release notes make no mention of anything that could cause this issue and today's 13.3 developer beta (22E5230e) hasn't resolved the issue. Public release 13.2.1 doesn't have this issue. 

For now I've created a workaround in this commit and will submit a feedback report with Apple. Issue  [#1069](https://github.com/Dimillian/IceCubesApp/issues/1069) will be updated with more information on this feedback report.

Workaround could use some polish if this is going to be a long term solution.