### PR TITLE
Record quote toots that have failed to load so that we don't try and load them again.

### DIFF
--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -95,12 +95,14 @@ public class RouterPath: ObservableObject {
               client.hasConnection(with: url),
               let id = Int(url.lastPathComponent)
     {
-      if url.absoluteString.contains(client.server) {
-        navigate(to: .statusDetail(id: String(id)))
-      } else {
-        navigate(to: .remoteStatusDetail(url: url))
+      if !StatusEmbedCache.shared.badStatusesURLs.contains(url) {
+        if url.absoluteString.contains(client.server) {
+          navigate(to: .statusDetail(id: String(id)))
+        } else {
+          navigate(to: .remoteStatusDetail(url: url))
+        }
+        return .handled
       }
-      return .handled
     }
     return urlHandler?(url) ?? .systemAction
   }

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -68,9 +68,7 @@ public class RouterPath: ObservableObject {
   @Published public var path: [RouterDestination] = []
   @Published public var presentedSheet: SheetDestination?
 
-  
-  public var badStatuses = Set<URL>()
-  
+    
   public init() {}
 
   public func navigate(to: RouterDestination) {
@@ -97,14 +95,12 @@ public class RouterPath: ObservableObject {
               client.hasConnection(with: url),
               let id = Int(url.lastPathComponent)
     {
-      if !badStatuses.contains(url) {
-        if url.absoluteString.contains(client.server) {
-          navigate(to: .statusDetail(id: String(id)))
-        } else {
-          navigate(to: .remoteStatusDetail(url: url))
-        }
-        return .handled
+      if url.absoluteString.contains(client.server) {
+        navigate(to: .statusDetail(id: String(id)))
+      } else {
+        navigate(to: .remoteStatusDetail(url: url))
       }
+      return .handled
     }
     return urlHandler?(url) ?? .systemAction
   }

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -68,6 +68,9 @@ public class RouterPath: ObservableObject {
   @Published public var path: [RouterDestination] = []
   @Published public var presentedSheet: SheetDestination?
 
+  
+  public var badStatuses = Set<URL>()
+  
   public init() {}
 
   public func navigate(to: RouterDestination) {
@@ -94,12 +97,14 @@ public class RouterPath: ObservableObject {
               client.hasConnection(with: url),
               let id = Int(url.lastPathComponent)
     {
-      if url.absoluteString.contains(client.server) {
-        navigate(to: .statusDetail(id: String(id)))
-      } else {
-        navigate(to: .remoteStatusDetail(url: url))
+      if !badStatuses.contains(url) {
+        if url.absoluteString.contains(client.server) {
+          navigate(to: .statusDetail(id: String(id)))
+        } else {
+          navigate(to: .remoteStatusDetail(url: url))
+        }
+        return .handled
       }
-      return .handled
     }
     return urlHandler?(url) ?? .systemAction
   }

--- a/Packages/Env/Sources/Env/StatusEmbedCache.swift
+++ b/Packages/Env/Sources/Env/StatusEmbedCache.swift
@@ -3,8 +3,8 @@ import Models
 import SwiftUI
 
 @MainActor
-class StatusEmbedCache {
-  static let shared = StatusEmbedCache()
+public class StatusEmbedCache {
+  public static let shared = StatusEmbedCache()
 
   private var cache: [URL: Status] = [:]
   
@@ -12,11 +12,11 @@ class StatusEmbedCache {
 
   private init() {}
 
-  func set(url: URL, status: Status) {
+  public func set(url: URL, status: Status) {
     cache[url] = status
   }
 
-  func get(url: URL) -> Status? {
+  public func get(url: URL) -> Status? {
     cache[url]
   }
 }

--- a/Packages/Status/Sources/Status/Embed/StatusEmbedCache.swift
+++ b/Packages/Status/Sources/Status/Embed/StatusEmbedCache.swift
@@ -7,6 +7,8 @@ class StatusEmbedCache {
   static let shared = StatusEmbedCache()
 
   private var cache: [URL: Status] = [:]
+  
+  public var badStatusesURLs = Set<URL>()
 
   private init() {}
 

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -181,8 +181,8 @@ public class StatusRowViewModel: ObservableObject {
     let content = status.reblog?.content ?? status.content
     if !content.statusesURLs.isEmpty,
        let url = content.statusesURLs.first,
-       client.hasConnection(with: url)
-    {
+       !StatusEmbedCache.shared.badStatusesURLs.contains(url),
+       client.hasConnection(with: url) {
       return url
     }
     return nil
@@ -198,13 +198,6 @@ public class StatusRowViewModel: ObservableObject {
       return
     }
     
-    if routerPath.badStatuses.contains(url) {
-      if isEmbedLoading {
-        isEmbedLoading = false
-      }
-      return
-    }
-
     if let embed = StatusEmbedCache.shared.get(url: url) {
       isEmbedLoading = false
       embeddedStatus = embed
@@ -228,7 +221,7 @@ public class StatusRowViewModel: ObservableObject {
         StatusEmbedCache.shared.set(url: url, status: embed)
       }
       else {
-        routerPath.badStatuses.insert(url)
+        StatusEmbedCache.shared.badStatusesURLs.insert(url)
       }
       withAnimation {
         embeddedStatus = embed
@@ -236,6 +229,7 @@ public class StatusRowViewModel: ObservableObject {
       }
     } catch {
       isEmbedLoading = false
+      StatusEmbedCache.shared.badStatusesURLs.insert(url)
     }
   }
 

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -197,6 +197,13 @@ public class StatusRowViewModel: ObservableObject {
       }
       return
     }
+    
+    if routerPath.badStatuses.contains(url) {
+      if isEmbedLoading {
+        isEmbedLoading = false
+      }
+      return
+    }
 
     if let embed = StatusEmbedCache.shared.get(url: url) {
       isEmbedLoading = false
@@ -219,6 +226,9 @@ public class StatusRowViewModel: ObservableObject {
       }
       if let embed {
         StatusEmbedCache.shared.set(url: url, status: embed)
+      }
+      else {
+        routerPath.badStatuses.insert(url)
       }
       withAnimation {
         embeddedStatus = embed


### PR DESCRIPTION

Fixes #1118

1: Stops repeated visible insertion and removal of placeholder quote toot. 
2: Stops link hijacking of inline status viewer allowing links to be followed as regular URLs