### PR TITLE
Update ReblogCache.swift

### DIFF
--- a/Packages/Status/Sources/Status/List/ReblogCache.swift
+++ b/Packages/Status/Sources/Status/List/ReblogCache.swift
@@ -16,7 +16,7 @@ public class ReblogCache {
   private var needsWrite = false
 
   init() {
-    statusCache.countLimit = 100 // can tune the cache here, 100 is super conservative
+    statusCache.countLimit = 300 // can tune the cache here, 100 is super conservative
 
     // read any existing cache from disk
     if FileManager.default.fileExists(atPath: cacheFile.path()) {


### PR DESCRIPTION
Increase cache size to 300, since 100 was too small and I was still seeing many duplicate boosts. This seems to be more effective.