### PR TITLE
Display and edit filter expirations

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Кола";
 "enum.avatar-shape.rounded" = "Акруглены";
 "enum.durations.infinite" = "бясконцасць";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 хвілін";
 "enum.durations.thirtyMinutes" = "30 хвілін";
 "enum.durations.oneHour" = "1 гадзіна";
 "enum.durations.sixHours" = "6 гадзін";
+"enum.durations.twelveHours" = "12 гадзін";
 "enum.durations.oneDay" = "1 дзень";
 "enum.durations.threeDays" = "3 дні";
 "enum.durations.sevenDays" = "7 дзён";
@@ -330,14 +332,6 @@
 "explore.section.users" = "Карыстальнікі";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 хвілін";
-"env.poll-duration.30m" = "30 хвілін";
-"env.poll-duration.1h" = "1 гадзіна";
-"env.poll-duration.6h" = "6 гадзін";
-"env.poll-duration.12h" = "12 гадзін";
-"env.poll-duration.1d" = "1 дзень";
-"env.poll-duration.3d" = "3 дні";
-"env.poll-duration.7d" = "7 дзён";
 "env.poll-vote-frequency.one" = "Адзін голас";
 "env.poll-vote-frequency.multiple" = "Некалькі галасоў";
 
@@ -491,6 +485,9 @@
 "filter.edit.keywords.add" = "Дадаць новае ключавое слова";
 "filter.edit.contexts" = "Кантэксты фільтра";
 "filter.edit.action" = "Дзеянне фільтра";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Рэдагаваць фільтры";
 "filter.contexts.home" = "Галоўная старонка і спісы";
 "filter.contexts.notifications" = "Апавяшчэнні";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -24,10 +24,12 @@
 "enum.avatar-shape.circle" = "Cercle";
 "enum.avatar-shape.rounded" = "Arrodonida";
 "enum.durations.infinite" = "infinite";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutes";
 "enum.durations.thirtyMinutes" = "30 minutes";
 "enum.durations.oneHour" = "1 hora";
 "enum.durations.sixHours" = "6 hores";
+"enum.durations.twelveHours" = "12 hores";
 "enum.durations.oneDay" = "1 dia";
 "enum.durations.threeDays" = "3 dies";
 "enum.durations.sevenDays" = "7 dies";
@@ -324,14 +326,6 @@
 "explore.section.users" = "Usuaris";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minuts";
-"env.poll-duration.30m" = "30 minuts";
-"env.poll-duration.1h" = "1 hora";
-"env.poll-duration.6h" = "6 hores";
-"env.poll-duration.12h" = "12 hores";
-"env.poll-duration.1d" = "1 dia";
-"env.poll-duration.3d" = "3 dies";
-"env.poll-duration.7d" = "7 dies";
 "env.poll-vote-frequency.one" = "Vot únic";
 "env.poll-vote-frequency.multiple" = "Vot múltiple";
 
@@ -485,6 +479,9 @@
 "filter.edit.keywords.add" = "Afegeix una paraula clau";
 "filter.edit.contexts" = "Filtra els contextos";
 "filter.edit.action" = "Acció del filtre";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Edita els filtres";
 "filter.contexts.home" = "Inici i llistes";
 "filter.contexts.notifications" = "Notificacions";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Kreis";
 "enum.avatar-shape.rounded" = "Abgerundet";
 "enum.durations.infinite" = "Unbegrenzt";
+"enum.durations.custom" = "Individuelle Einstellung";
 "enum.durations.fiveMinutes" = "5 Minuten";
 "enum.durations.thirtyMinutes" = "30 Minuten";
 "enum.durations.oneHour" = "1 Stunde";
 "enum.durations.sixHours" = "6 Stunden";
+"enum.durations.twelveHours" = "12 Stunden";
 "enum.durations.oneDay" = "1 Tag";
 "enum.durations.threeDays" = "3 Tage";
 "enum.durations.sevenDays" = "7 Tage";
@@ -326,14 +328,6 @@
 "explore.section.users" = "Profile";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 Minuten";
-"env.poll-duration.30m" = "30 Minuten";
-"env.poll-duration.1h" = "1 Stunde";
-"env.poll-duration.6h" = "6 Stunden";
-"env.poll-duration.12h" = "12 Stunden";
-"env.poll-duration.1d" = "1 Tag";
-"env.poll-duration.3d" = "3 Tage";
-"env.poll-duration.7d" = "7 Tage";
 "env.poll-vote-frequency.one" = "Einfache Auswahl";
 "env.poll-vote-frequency.multiple" = "Mehrfachauswahl";
 
@@ -482,6 +476,9 @@
 "filter.edit.keywords.add" = "Neues Wort hinzufügen";
 "filter.edit.contexts" = "Filterkontext";
 "filter.edit.action" = "Filteraktion";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "filter.contexts.home" = "Startseite und Listen";
 "filter.contexts.notifications" = "Mitteilungen";
 "filter.contexts.public" = "Öffentliche Timelines";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Circle";
 "enum.avatar-shape.rounded" = "Rounded";
 "enum.durations.infinite" = "infinite";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutes";
 "enum.durations.thirtyMinutes" = "30 minutes";
 "enum.durations.oneHour" = "1 hour";
 "enum.durations.sixHours" = "6 hours";
+"enum.durations.twelveHours" = "12 hours";
 "enum.durations.oneDay" = "1 day";
 "enum.durations.threeDays" = "3 days";
 "enum.durations.sevenDays" = "7 days";
@@ -327,14 +329,6 @@
 "explore.section.users" = "Users";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minutes";
-"env.poll-duration.30m" = "30 minutes";
-"env.poll-duration.1h" = "1 hour";
-"env.poll-duration.6h" = "6 hours";
-"env.poll-duration.12h" = "12 hours";
-"env.poll-duration.1d" = "1 day";
-"env.poll-duration.3d" = "3 days";
-"env.poll-duration.7d" = "7 days";
 "env.poll-vote-frequency.one" = "One Vote";
 "env.poll-vote-frequency.multiple" = "Multiple Votes";
 
@@ -486,6 +480,9 @@
 "filter.edit.keywords.add" = "Add a new keyword";
 "filter.edit.contexts" = "Filter Contexts";
 "filter.edit.action" = "Filter Action";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Edit Filters";
 "filter.contexts.home" = "Home and lists";
 "filter.contexts.notifications" = "Notifications";
@@ -494,6 +491,8 @@
 "filter.contexts.profiles" = "Profiles";
 "filter.action.warning" = "Hide with a warning";
 "filter.action.hide" = "Hide completely";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Attach photo";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Circle";
 "enum.avatar-shape.rounded" = "Rounded";
 "enum.durations.infinite" = "infinite";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutes";
 "enum.durations.thirtyMinutes" = "30 minutes";
 "enum.durations.oneHour" = "1 hour";
 "enum.durations.sixHours" = "6 hours";
+"enum.durations.twelveHours" = "12 hours";
 "enum.durations.oneDay" = "1 day";
 "enum.durations.threeDays" = "3 days";
 "enum.durations.sevenDays" = "7 days";
@@ -326,14 +328,6 @@
 "explore.section.users" = "Users";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minutes";
-"env.poll-duration.30m" = "30 minutes";
-"env.poll-duration.1h" = "1 hour";
-"env.poll-duration.6h" = "6 hours";
-"env.poll-duration.12h" = "12 hours";
-"env.poll-duration.1d" = "1 day";
-"env.poll-duration.3d" = "3 days";
-"env.poll-duration.7d" = "7 days";
 "env.poll-vote-frequency.one" = "One Vote";
 "env.poll-vote-frequency.multiple" = "Multiple Votes";
 
@@ -487,6 +481,9 @@
 "filter.edit.keywords.add" = "Add a new keyword";
 "filter.edit.contexts" = "Filter Contexts";
 "filter.edit.action" = "Filter Action";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Edit Filters";
 "filter.contexts.home" = "Home and lists";
 "filter.contexts.notifications" = "Notifications";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Círculo";
 "enum.avatar-shape.rounded" = "Redondeado";
 "enum.durations.infinite" = "infinito";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutos";
 "enum.durations.thirtyMinutes" = "30 minutos";
 "enum.durations.oneHour" = "1 hora";
 "enum.durations.sixHours" = "6 horas";
+"enum.durations.twelveHours" = "12 horas";
 "enum.durations.oneDay" = "1 día";
 "enum.durations.threeDays" = "3 días";
 "enum.durations.sevenDays" = "7 días";
@@ -326,14 +328,6 @@
 "explore.section.users" = "Usuarios";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minutos";
-"env.poll-duration.30m" = "30 minutos";
-"env.poll-duration.1h" = "1 hora";
-"env.poll-duration.6h" = "6 horas";
-"env.poll-duration.12h" = "12 horas";
-"env.poll-duration.1d" = "1 día";
-"env.poll-duration.3d" = "3 dias";
-"env.poll-duration.7d" = "7 dias";
 "env.poll-vote-frequency.one" = "Un voto";
 "env.poll-vote-frequency.multiple" = "Varios votos";
 
@@ -487,6 +481,9 @@
 "filter.edit.keywords.add" = "Añadir una nueva palabra clave";
 "filter.edit.contexts" = "Contextos del filtro";
 "filter.edit.action" = "Acción del filtro";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Editar filtros";
 "filter.contexts.home" = "Inicio y listas";
 "filter.contexts.notifications" = "Notificaciones";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Biribila";
 "enum.avatar-shape.rounded" = "Biribildutako ertzak";
 "enum.durations.infinite" = "Betiko";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutuz";
 "enum.durations.thirtyMinutes" = "30 minutuz";
 "enum.durations.oneHour" = "Ordubetez";
 "enum.durations.sixHours" = "6 orduz";
+"enum.durations.twelveHours" = "12 orduz";
 "enum.durations.oneDay" = "Egun batez";
 "enum.durations.threeDays" = "3 egunez";
 "enum.durations.sevenDays" = "7 egunez";
@@ -325,14 +327,6 @@
 "explore.section.users" = "Erabiltzaileak";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minutu";
-"env.poll-duration.30m" = "30 minutu";
-"env.poll-duration.1h" = "Ordubete";
-"env.poll-duration.6h" = "6 ordu";
-"env.poll-duration.12h" = "12 ordu";
-"env.poll-duration.1d" = "Egun 1";
-"env.poll-duration.3d" = "3 egun";
-"env.poll-duration.7d" = "7 egun";
 "env.poll-vote-frequency.one" = "Boto bakarra";
 "env.poll-vote-frequency.multiple" = "Boto bat baino gehiago";
 
@@ -477,6 +471,9 @@
 "filter.edit.keywords.add" = "Gehitu hitz gako berria";
 "filter.edit.contexts" = "Iragazkiaren testuinguruak";
 "filter.edit.action" = "Iragazkiaren ekintzak";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "filter.contexts.home" = "Hasiera eta zerrendak";
 "filter.contexts.notifications" = "Jakinarazpenak";
 "filter.contexts.public" = "Denbora-lerro lokalak";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -25,13 +25,15 @@
 "enum.avatar-shape.circle" = "Rond";
 "enum.avatar-shape.rounded" = "Arrondi";
 "enum.durations.infinite" = "infinite";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutes";
 "enum.durations.thirtyMinutes" = "30 minutes";
-"enum.durations.oneHour" = "1 hour";
-"enum.durations.sixHours" = "6 hours";
-"enum.durations.oneDay" = "1 day";
-"enum.durations.threeDays" = "3 days";
-"enum.durations.sevenDays" = "7 days";
+"enum.durations.oneHour" = "1 heure";
+"enum.durations.sixHours" = "6 heures";
+"enum.durations.twelveHours" = "12 heures";
+"enum.durations.oneDay" = "1 jour";
+"enum.durations.threeDays" = "3 jours";
+"enum.durations.sevenDays" = "7 jours";
 "enum.status-actions-display.all" = "Tout";
 "enum.status-actions-display.no-buttons" = "Pas de boutons";
 "enum.status-actions-display.only-buttons" = "Seulement les boutons";
@@ -325,14 +327,6 @@
 "explore.section.users" = "Utilisateurs";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minutes";
-"env.poll-duration.30m" = "30 minutes";
-"env.poll-duration.1h" = "1 heure";
-"env.poll-duration.6h" = "6 heures";
-"env.poll-duration.12h" = "12 heures";
-"env.poll-duration.1d" = "1 jour";
-"env.poll-duration.3d" = "3 jours";
-"env.poll-duration.7d" = "7 jours";
 "env.poll-vote-frequency.one" = "Un vote";
 "env.poll-vote-frequency.multiple" = "Plusieurs votes";
 
@@ -482,6 +476,9 @@
 "filter.edit.keywords.add" = "Ajouter un nouveau mot-clé";
 "filter.edit.contexts" = "Contextes du filtre";
 "filter.edit.action" = "Action du filtre";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Éditer les filtres";
 "filter.contexts.home" = "Accueil et listes";
 "filter.contexts.notifications" = "Notifications";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Cerchio";
 "enum.avatar-shape.rounded" = "Arrotondata";
 "enum.durations.infinite" = "Infinito";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minuti";
 "enum.durations.thirtyMinutes" = "30 minuti";
 "enum.durations.oneHour" = "1 ora";
 "enum.durations.sixHours" = "6 ore";
+"enum.durations.twelveHours" = "12 ore";
 "enum.durations.oneDay" = "1 giorno";
 "enum.durations.threeDays" = "3 giorni";
 "enum.durations.sevenDays" = "7 giorni";
@@ -326,14 +328,6 @@
 "explore.section.users" = "Utenti";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minuti";
-"env.poll-duration.30m" = "30 minuti";
-"env.poll-duration.1h" = "1 ora";
-"env.poll-duration.6h" = "6 ore";
-"env.poll-duration.12h" = "12 ore";
-"env.poll-duration.1d" = "1 giorno";
-"env.poll-duration.3d" = "3 giorni";
-"env.poll-duration.7d" = "7 giorni";
 "env.poll-vote-frequency.one" = "Voto singolo";
 "env.poll-vote-frequency.multiple" = "Voto multiplo";
 
@@ -487,6 +481,9 @@
 "filter.edit.keywords.add" = "Aggiungi una nuova parola chiave";
 "filter.edit.contexts" = "Dove applicare il filtro";
 "filter.edit.action" = "Azione del filtro";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Modifica filtri";
 "filter.contexts.home" = "Nella Home e nelle liste";
 "filter.contexts.notifications" = "Nelle notifiche";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "円形";
 "enum.avatar-shape.rounded" = "角丸";
 "enum.durations.infinite" = "無期限";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5分間";
 "enum.durations.thirtyMinutes" = "30分間";
 "enum.durations.oneHour" = "1時間";
 "enum.durations.sixHours" = "6時間";
+"enum.durations.twelveHours" = "12時間";
 "enum.durations.oneDay" = "1日間";
 "enum.durations.threeDays" = "3日間";
 "enum.durations.sevenDays" = "7日間";
@@ -325,14 +327,6 @@
 "explore.section.users" = "ユーザー";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5分間";
-"env.poll-duration.30m" = "30分間";
-"env.poll-duration.1h" = "1時間";
-"env.poll-duration.6h" = "6時間";
-"env.poll-duration.12h" = "12時間";
-"env.poll-duration.1d" = "1日間";
-"env.poll-duration.3d" = "3日間";
-"env.poll-duration.7d" = "7日間";
 "env.poll-vote-frequency.one" = "単一投票";
 "env.poll-vote-frequency.multiple" = "複数投票可";
 
@@ -486,6 +480,9 @@
 "filter.edit.keywords.add" = "新しいキーワードを追加する";
 "filter.edit.contexts" = "フィルターする文章";
 "filter.edit.action" = "フィルターする";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "フィルターを編集する";
 "filter.contexts.home" = "ホームとリスト";
 "filter.contexts.notifications" = "通知";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "원";
 "enum.avatar-shape.rounded" = "둥근 사각형";
 "enum.durations.infinite" = "해제할 때까지";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5분";
 "enum.durations.thirtyMinutes" = "30분";
 "enum.durations.oneHour" = "1시간";
 "enum.durations.sixHours" = "6시간";
+"enum.durations.twelveHours" = "12시간";
 "enum.durations.oneDay" = "1일";
 "enum.durations.threeDays" = "3일";
 "enum.durations.sevenDays" = "7일";
@@ -326,14 +328,6 @@
 "explore.section.users" = "사용자";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5분";
-"env.poll-duration.30m" = "30분";
-"env.poll-duration.1h" = "1시간";
-"env.poll-duration.6h" = "6시간";
-"env.poll-duration.12h" = "12시간";
-"env.poll-duration.1d" = "1일";
-"env.poll-duration.3d" = "3일";
-"env.poll-duration.7d" = "7일";
 "env.poll-vote-frequency.one" = "하나만 선택 가능";
 "env.poll-vote-frequency.multiple" = "여러 개 선택 가능";
 
@@ -488,6 +482,9 @@
 "filter.edit.keywords.add" = "새 단어 추가";
 "filter.edit.contexts" = "필터를 적용할 곳";
 "filter.edit.action" = "가릴 방식";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "필터 편집";
 "filter.contexts.home" = "홈 및 리스트";
 "filter.contexts.notifications" = "알림";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Sirkel";
 "enum.avatar-shape.rounded" = "Avrundet";
 "enum.durations.infinite" = "infinite";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutes";
 "enum.durations.thirtyMinutes" = "30 minutes";
 "enum.durations.oneHour" = "1 hour";
 "enum.durations.sixHours" = "6 hours";
+"enum.durations.twelveHours" = "12 hours";
 "enum.durations.oneDay" = "1 day";
 "enum.durations.threeDays" = "3 days";
 "enum.durations.sevenDays" = "7 days";
@@ -325,14 +327,6 @@
 "explore.section.users" = "Brukere";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minutter";
-"env.poll-duration.30m" = "30 minutter";
-"env.poll-duration.1h" = "1 time";
-"env.poll-duration.6h" = "6 timer";
-"env.poll-duration.12h" = "12 timer";
-"env.poll-duration.1d" = "1 dag";
-"env.poll-duration.3d" = "3 dager";
-"env.poll-duration.7d" = "7 dager";
 "env.poll-vote-frequency.one" = "Én stemme";
 "env.poll-vote-frequency.multiple" = "Flere stemmer";
 
@@ -486,6 +480,9 @@
 "filter.edit.keywords.add" = "Legg til nytt nøkkelord";
 "filter.edit.contexts" = "Filtrer kontekster";
 "filter.edit.action" = "Filterhandling";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Rediger filtre";
 "filter.contexts.home" = "Hjem og lister";
 "filter.contexts.notifications" = "Varsler";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Cirkel";
 "enum.avatar-shape.rounded" = "Afgerond";
 "enum.durations.infinite" = "Onbepaald";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minuten";
 "enum.durations.thirtyMinutes" = "30 minuten";
 "enum.durations.oneHour" = "1 uur";
 "enum.durations.sixHours" = "6 uur";
+"enum.durations.twelveHours" = "12 uur";
 "enum.durations.oneDay" = "1 dag";
 "enum.durations.threeDays" = "3 dagen";
 "enum.durations.sevenDays" = "7 dagen";
@@ -323,14 +325,6 @@
 "explore.section.users" = "Gebruikers";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minuten";
-"env.poll-duration.30m" = "30 minuten";
-"env.poll-duration.1h" = "1 uur";
-"env.poll-duration.6h" = "6 uur";
-"env.poll-duration.12h" = "12 uur";
-"env.poll-duration.1d" = "1 dag";
-"env.poll-duration.3d" = "3 dagen";
-"env.poll-duration.7d" = "7 dagen";
 "env.poll-vote-frequency.one" = "Eén stem";
 "env.poll-vote-frequency.multiple" = "Meerdere stemmen";
 
@@ -480,6 +474,9 @@
 "filter.edit.keywords.add" = "Voeg een nieuw sleutelwoord toe";
 "filter.edit.contexts" = "Filtercontext";
 "filter.edit.action" = "Filteractie";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "filter.contexts.home" = "Start en lijsten";
 "filter.contexts.notifications" = "Meldingen";
 "filter.contexts.public" = "Openbare tijdlijnen";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Okrągły";
 "enum.avatar-shape.rounded" = "Zaokrąglony";
 "enum.durations.infinite" = "czas nieokreślony";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minut";
 "enum.durations.thirtyMinutes" = "30 minut";
 "enum.durations.oneHour" = "1 godzina";
 "enum.durations.sixHours" = "6 godzin";
+"enum.durations.twelveHours" = "12 godzin";
 "enum.durations.oneDay" = "1 dzień";
 "enum.durations.threeDays" = "3 dni";
 "enum.durations.sevenDays" = "7 dni";
@@ -322,14 +324,6 @@
 "explore.section.users" = "Osoby";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minut";
-"env.poll-duration.30m" = "30 minut";
-"env.poll-duration.1h" = "1 godzina";
-"env.poll-duration.6h" = "6 godzin";
-"env.poll-duration.12h" = "12 godzin";
-"env.poll-duration.1d" = "1 dzień";
-"env.poll-duration.3d" = "3 dni";
-"env.poll-duration.7d" = "7 dni";
 "env.poll-vote-frequency.one" = "Jeden głos";
 "env.poll-vote-frequency.multiple" = "Głosowanie wielokrotne";
 
@@ -478,6 +472,9 @@
 "filter.edit.keywords.add" = "Dodaj nowe słowo kluczowe";
 "filter.edit.contexts" = "Kontekst filtra";
 "filter.edit.action" = "Działanie filtra";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Edytuj filtry";
 "filter.contexts.home" = "Strona główna i listy";
 "filter.contexts.notifications" = "Powiadomienia";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Círculo";
 "enum.avatar-shape.rounded" = "Arredondado";
 "enum.durations.infinite" = "infinito";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutos";
 "enum.durations.thirtyMinutes" = "30 minutos";
 "enum.durations.oneHour" = "1 hora";
 "enum.durations.sixHours" = "6 horas";
+"enum.durations.twelveHours" = "12 horas";
 "enum.durations.oneDay" = "1 dia";
 "enum.durations.threeDays" = "3 dias";
 "enum.durations.sevenDays" = "7 dias";
@@ -325,14 +327,6 @@
 "explore.section.users" = "Usuários";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 minutos";
-"env.poll-duration.30m" = "30 minutos";
-"env.poll-duration.1h" = "1 hora";
-"env.poll-duration.6h" = "6 horas";
-"env.poll-duration.12h" = "12 horas";
-"env.poll-duration.1d" = "1 dia";
-"env.poll-duration.3d" = "3 dias";
-"env.poll-duration.7d" = "7 dias";
 "env.poll-vote-frequency.one" = "Um Voto";
 "env.poll-vote-frequency.multiple" = "Múltiplos Votos";
 
@@ -486,6 +480,9 @@
 "filter.edit.keywords.add" = "Aidicionar uma palavra chave";
 "filter.edit.contexts" = "Filtrar Contextos";
 "filter.edit.action" = "Filtrar Ação";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Editar Filtros";
 "filter.contexts.home" = "Início e listas";
 "filter.contexts.notifications" = "Notificações";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Çember";
 "enum.avatar-shape.rounded" = "Yuvarlak";
 "enum.durations.infinite" = "infinite";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 minutes";
 "enum.durations.thirtyMinutes" = "30 minutes";
 "enum.durations.oneHour" = "1 hour";
 "enum.durations.sixHours" = "6 hours";
+"enum.durations.twelveHours" = "12 saat";
 "enum.durations.oneDay" = "1 day";
 "enum.durations.threeDays" = "3 days";
 "enum.durations.sevenDays" = "7 days";
@@ -321,14 +323,6 @@
 "explore.section.users" = "Kullanıcılar";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 dakika";
-"env.poll-duration.30m" = "30 dakika";
-"env.poll-duration.1h" = "1 saat";
-"env.poll-duration.6h" = "6 saat";
-"env.poll-duration.12h" = "12 saat";
-"env.poll-duration.1d" = "1 gün";
-"env.poll-duration.3d" = "3 gün";
-"env.poll-duration.7d" = "7 gün";
 "env.poll-vote-frequency.one" = "Bir oy";
 "env.poll-vote-frequency.multiple" = "Birden fazla oy";
 
@@ -482,6 +476,9 @@
 "filter.edit.keywords.add" = "Add a new keyword";
 "filter.edit.contexts" = "Filter Contexts";
 "filter.edit.action" = "Filter Action";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Edit Filters";
 "filter.contexts.home" = "Home and lists";
 "filter.contexts.notifications" = "Notifications";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "Круг";
 "enum.avatar-shape.rounded" = "Закруглені";
 "enum.durations.infinite" = "без обмеження";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 хвилин";
 "enum.durations.thirtyMinutes" = "30 хвилин";
 "enum.durations.oneHour" = "1 година";
 "enum.durations.sixHours" = "6 годин";
+"enum.durations.twelveHours" = "12 годин";
 "enum.durations.oneDay" = "1 день";
 "enum.durations.threeDays" = "3 дні";
 "enum.durations.sevenDays" = "7 днів";
@@ -326,14 +328,6 @@
 "explore.section.users" = "Користувачі";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 хвилин";
-"env.poll-duration.30m" = "30 хвилин";
-"env.poll-duration.1h" = "1 година";
-"env.poll-duration.6h" = "6 годин";
-"env.poll-duration.12h" = "12 годин";
-"env.poll-duration.1d" = "1 день";
-"env.poll-duration.3d" = "3 дні";
-"env.poll-duration.7d" = "7 днів";
 "env.poll-vote-frequency.one" = "Лише один варіант";
 "env.poll-vote-frequency.multiple" = "Вибір декількох варіантів";
 
@@ -487,6 +481,9 @@
 "filter.edit.keywords.add" = "Додати нове слово";
 "filter.edit.contexts" = "Фільтрувати вміст";
 "filter.edit.action" = "Виконати";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "account.action.edit-filters" = "Редагувати фільтри";
 "filter.contexts.home" = "Домівка та список";
 "filter.contexts.notifications" = "Сповіщення";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -25,10 +25,12 @@
 "enum.avatar-shape.circle" = "圆形";
 "enum.avatar-shape.rounded" = "圆角";
 "enum.durations.infinite" = "永久";
+"enum.durations.custom" = "custom";
 "enum.durations.fiveMinutes" = "5 分钟";
 "enum.durations.thirtyMinutes" = "30 分钟";
 "enum.durations.oneHour" = "1 小时";
 "enum.durations.sixHours" = "6 小时";
+"enum.durations.twelveHours" = "12 小时";
 "enum.durations.oneDay" = "1 天";
 "enum.durations.threeDays" = "3 天";
 "enum.durations.sevenDays" = "7 天";
@@ -324,14 +326,6 @@
 "explore.section.users" = "用户";
 
 // MARK: Package: Env
-"env.poll-duration.5m" = "5 分钟";
-"env.poll-duration.30m" = "30 分钟";
-"env.poll-duration.1h" = "1 小时";
-"env.poll-duration.6h" = "6 小时";
-"env.poll-duration.12h" = "12 小时";
-"env.poll-duration.1d" = "1 天";
-"env.poll-duration.3d" = "3 天";
-"env.poll-duration.7d" = "7 天";
 "env.poll-vote-frequency.one" = "单个投票";
 "env.poll-vote-frequency.multiple" = "多个投票";
 
@@ -485,6 +479,9 @@
 "filter.edit.keywords.add" = "添加关键词";
 "filter.edit.contexts" = "过滤范围";
 "filter.edit.action" = "过滤器行为";
+"filter.edit.expiry" = "Expiry";
+"filter.edit.expiry.date-time" = "Date/Time";
+"filter.edit.expiry.duration" = "Duration";
 "filter.contexts.home" = "主页和列表";
 "filter.contexts.notifications" = "通知";
 "filter.contexts.public" = "公共时间线";

--- a/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
+++ b/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
@@ -68,7 +68,7 @@ public struct AccountDetailContextMenu: View {
             }
           } else {
             Menu {
-              ForEach(MutingDuration.allCases, id: \.rawValue) { duration in
+              ForEach(Duration.mutingDurations(), id: \.rawValue) { duration in
                 Button(duration.description) {
                   Task {
                     do {

--- a/Packages/Account/Sources/Account/Filters/FiltersListView.swift
+++ b/Packages/Account/Sources/Account/Filters/FiltersListView.swift
@@ -34,6 +34,17 @@ public struct FiltersListView: View {
                     Text("\(filter.context.map { $0.name }.joined(separator: ", "))")
                       .font(.scaledBody)
                       .foregroundColor(.gray)
+                    if filter.hasExpiry() {
+                      if filter.isExpired() {
+                        Text("filter.expired")
+                          .font(.footnote)
+                          .foregroundColor(.gray)
+                      } else {
+                        Text("filter.expiry-\(filter.expiresAt!.relativeFormatted)")
+                          .font(.footnote)
+                          .foregroundColor(.gray)
+                      }
+                    }
                   }
                 }
               }

--- a/Packages/Env/Sources/Env/Duration.swift
+++ b/Packages/Env/Sources/Env/Duration.swift
@@ -1,14 +1,16 @@
 import SwiftUI
 
-enum MutingDuration: Int, CaseIterable {
+public enum Duration: Int, CaseIterable {
   case infinite = 0
   case fiveMinutes = 300
   case thirtyMinutes = 1800
   case oneHour = 3600
   case sixHours = 21600
+  case twelveHours = 43200
   case oneDay = 86400
   case threeDays = 259_200
   case sevenDays = 604_800
+  case custom = -1
 
   public var description: LocalizedStringKey {
     switch self {
@@ -22,12 +24,28 @@ enum MutingDuration: Int, CaseIterable {
       return "enum.durations.oneHour"
     case .sixHours:
       return "enum.durations.sixHours"
+    case .twelveHours:
+      return "enum.durations.twelveHours"
     case .oneDay:
       return "enum.durations.oneDay"
     case .threeDays:
       return "enum.durations.threeDays"
     case .sevenDays:
       return "enum.durations.sevenDays"
+    case .custom:
+      return "enum.durations.custom"
     }
+  }
+  
+  public static func mutingDurations() -> [Duration] {
+    return Self.allCases.filter { $0 != .custom }
+  }
+
+  public static func filterDurations() -> [Duration] {
+    return [.infinite, .thirtyMinutes, .oneHour, .sixHours, .twelveHours, .oneDay, .sevenDays, .custom]
+  }
+  
+  public static func pollDurations() -> [Duration] {
+    return [.fiveMinutes, .thirtyMinutes, .oneHour, .sixHours, .twelveHours, .oneDay, .threeDays, .sevenDays]
   }
 }

--- a/Packages/Env/Sources/Env/PollPreferences.swift
+++ b/Packages/Env/Sources/Env/PollPreferences.swift
@@ -1,31 +1,6 @@
 import Foundation
 import SwiftUI
 
-public enum PollDuration: Int, CaseIterable {
-  // rawValue == time in seconds; used for sending to the API
-  case fiveMinutes = 300
-  case halfAnHour = 1800
-  case oneHour = 3600
-  case sixHours = 21600
-  case twelveHours = 43200
-  case oneDay = 86400
-  case threeDays = 259_200
-  case sevenDays = 604_800
-
-  public var displayString: LocalizedStringKey {
-    switch self {
-    case .fiveMinutes: return "env.poll-duration.5m"
-    case .halfAnHour: return "env.poll-duration.30m"
-    case .oneHour: return "env.poll-duration.1h"
-    case .sixHours: return "env.poll-duration.6h"
-    case .twelveHours: return "env.poll-duration.12h"
-    case .oneDay: return "env.poll-duration.1d"
-    case .threeDays: return "env.poll-duration.3d"
-    case .sevenDays: return "env.poll-duration.7d"
-    }
-  }
-}
-
 public enum PollVotingFrequency: String, CaseIterable {
   case oneVote = "one-vote"
   case multipleVotes = "multiple-votes"

--- a/Packages/Models/Sources/Models/ServerFilter.swift
+++ b/Packages/Models/Sources/Models/ServerFilter.swift
@@ -20,7 +20,20 @@ public struct ServerFilter: Codable, Identifiable, Hashable, Sendable {
   public let keywords: [Keyword]
   public let filterAction: Action
   public let context: [Context]
-  public let expireIn: Int?
+  public let expiresIn: Int?
+  public let expiresAt: ServerDate?
+  
+  public func hasExpiry() -> Bool {
+    return expiresAt != nil
+  }
+  
+  public func isExpired() -> Bool {
+    if let expiresAtDate = expiresAt?.asDate {
+       return expiresAtDate < Date()
+    } else {
+      return false
+    }
+  }
 }
 
 public extension ServerFilter.Context {

--- a/Packages/Network/Sources/Network/Endpoint/ServerFilters.swift
+++ b/Packages/Network/Sources/Network/Endpoint/ServerFilters.swift
@@ -52,16 +52,20 @@ public struct ServerFilterData: Encodable, Sendable {
   public let title: String
   public let context: [ServerFilter.Context]
   public let filterAction: ServerFilter.Action
-  public let expireIn: Int?
+  // normally expiresIn is an Int according to the API, but it is not possible to send an empty
+  // value in the update filter call to set the expiry to infinite. Not sending this value does not delete
+  // the existing one. Using a String it is possible to send an empty value in order to delete
+  // the expiry of a filter
+  public let expiresIn: String?
 
   public init(title: String,
               context: [ServerFilter.Context],
               filterAction: ServerFilter.Action,
-              expireIn: Int?)
+              expiresIn: String?)
   {
     self.title = title
     self.context = context
     self.filterAction = filterAction
-    self.expireIn = expireIn
+    self.expiresIn = expiresIn
   }
 }

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorPollView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorPollView.swift
@@ -77,8 +77,8 @@ struct StatusEditorPollView: View {
         Spacer()
 
         Picker("status.poll.duration", selection: $viewModel.pollDuration) {
-          ForEach(PollDuration.allCases, id: \.rawValue) {
-            Text($0.displayString)
+          ForEach(Duration.pollDurations(), id: \.rawValue) {
+            Text($0.description)
               .tag($0)
           }
         }

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -67,7 +67,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
 
   @Published var showPoll: Bool = false
   @Published var pollVotingFrequency = PollVotingFrequency.oneVote
-  @Published var pollDuration = PollDuration.oneDay
+  @Published var pollDuration = Duration.oneDay
   @Published var pollOptions: [String] = ["", ""]
 
   @Published var spoilerOn: Bool = false


### PR DESCRIPTION
## Filter durations

Expiration values that are set on filters now are displayed in the filter list:

![image](https://user-images.githubusercontent.com/8456476/222549696-ab0b3208-0947-47a6-a5c5-427cff4cd96f.png)

When editing a filter, a new dropdown offers the different values:

![image](https://user-images.githubusercontent.com/8456476/222549896-fdac465b-ce64-4be7-8c71-1b7a5f1e150a.png)

When anything else than `infinite` is selected, a date picker is shown that reflects the selected entry (this is read only, except for the `custom` selection:

![image](https://user-images.githubusercontent.com/8456476/222550182-05dfd1bf-4d6d-4dc5-82b0-4847f7f2bb8d.png)

Custom selection allows setting a value:

![image](https://user-images.githubusercontent.com/8456476/222550377-30d2b4e8-9f88-40b7-8164-51786a1f1a2b.png)

I know that we normally don't hide controls that are inactive and only disable them, but with the datepicker this is a  problem: It's not possible to display a date picker with no date set which would be needed for the `infinite` entry. So for `infinite` we would show some random date which does not reflect the setting. So I chose to hide the datepicker for `infinite` setting.

## Consolidation of duration enums

All places that show some duration values (poll creation, account muting, filter expiration) now use the same `Duration` enum. This consolidates the numeric values for seconds to expire and the localizations in one place instead of duplicating them.


Closes #1124 