### PR TITLE
Make primary action bold:

### DIFF
--- a/Packages/Account/Sources/Account/Filters/EditFilterView.swift
+++ b/Packages/Account/Sources/Account/Filters/EditFilterView.swift
@@ -204,7 +204,7 @@ struct EditFilterView: View {
       if isSavingFilter {
         ProgressView()
       } else {
-        Text("action.done")
+        Text("action.save").bold()
       }
     }
     .disabled(!canSave)

--- a/Packages/Account/Sources/Account/Filters/FiltersListView.swift
+++ b/Packages/Account/Sources/Account/Filters/FiltersListView.swift
@@ -99,8 +99,10 @@ public struct FiltersListView: View {
   @ToolbarContentBuilder
   private var toolbarContent: some ToolbarContent {
     ToolbarItem(placement: .navigationBarTrailing) {
-      Button("action.done") {
+      Button {
         dismiss()
+      } label: {
+        Text("action.done").bold()
       }
     }
   }


### PR DESCRIPTION
- Edit filters: '**Save**' (was 'Done', but changes are only saved after tapping this button, so 'Save' is more appropriate than 'Done', I think)
- Filters list: '**Done**' 