### PR TITLE
Add OSS licenses for SwiftUI-Introspect and RevenueCat

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/AboutView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AboutView.swift
@@ -74,6 +74,10 @@ struct AboutView: View {
         • [Atkinson Hyperlegible](https://github.com/googlefonts/atkinson-hyperlegible)
 
         • [OpenDyslexic](http://opendyslexic.org)
+
+        • [SwiftUI-Introspect](https://github.com/siteline/SwiftUI-Introspect)
+
+        • [RevenueCat](https://github.com/RevenueCat/purchases-ios)
         """)
         .padding(.horizontal, 25)
         .multilineTextAlignment(.leading)


### PR DESCRIPTION
I added OSS licenses for `SwiftUI-Introspect` and `RevenueCat` .

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-04 at 16 54 35](https://user-images.githubusercontent.com/19305363/222884446-54187dda-b0a2-4134-b558-11b1fdf1700d.png)
