### PR TITLE
Fix account name would be blank when DisplayName is empty

### DIFF
--- a/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
@@ -99,12 +99,16 @@ public struct AppAccountsSelectorView: View {
             if let image = viewModel.roundedAvatar {
               Image(uiImage: image)
             }
+
+            let name = viewModel.account.flatMap { account in
+                account.displayName?.isEmpty != false ? "@\(account.acct)" : account.displayName
+            } ?? ""
             if let token = viewModel.appAccount.oauthToken,
                preferences.getNotificationsCount(for: token) > 0
             {
-              Text("\(viewModel.account?.displayName ?? "") (\(preferences.getNotificationsCount(for: token)))")
+              Text("\(name) (\(preferences.getNotificationsCount(for: token)))")
             } else {
-              Text("\(viewModel.account?.displayName ?? "")")
+              Text("\(name)")
             }
           }
         }


### PR DESCRIPTION
I fixed account name would be blank when DisplayName is empty.

| before | after |
|:--:|:--:|
|<img width=300 src=https://user-images.githubusercontent.com/19305363/222936533-d35b3498-fcb9-4bfd-b9be-7ded6a6cbcfe.png>|<img width=300 src=https://user-images.githubusercontent.com/19305363/222936537-8909e4a1-c864-4af9-8409-66b263233dc6.png>|
