### PR TITLE
Fix account order.

### DIFF
--- a/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
@@ -78,7 +78,7 @@ public struct AppAccountsSelectorView: View {
 
   @ViewBuilder
   private var menuView: some View {
-    ForEach(accountsViewModel, id: \.appAccount.id) { viewModel in
+    ForEach(accountsViewModel.sorted { $0.acct < $1.acct }, id: \.appAccount.id) { viewModel in
       Section(viewModel.acct) {
         Button {
           if let account = currentAccount.account,


### PR DESCRIPTION
I found out in #1169 that the account names are in order of acquisition, so the order may change each time.
Fixed it so that the order is fixed by account name.