### PR TITLE
Fix spoiler image content alignment

### DIFF
--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -149,7 +149,7 @@ public struct StatusRowMediaPreviewView: View {
 
   @ViewBuilder
   private func makeFeaturedImagePreview(attachment: MediaAttachment) -> some View {
-    ZStack(alignment: .bottomTrailing) {
+    ZStack(alignment: .bottomLeading) {
       let size: CGSize = size(for: attachment) ?? .init(width: imageMaxHeight, height: imageMaxHeight)
       let newSize = imageSize(from: size, newWidth: availableWidth - appLayoutWidth)
       switch attachment.supportedType {


### PR DESCRIPTION
Fixed an issue where the alignment of the spoiler button and the spoiler image is split left and right when the image size is set to compact.