### PR TITLE
Fix poll percentage wrapping with larger font sizes

### DIFF
--- a/Packages/Status/Sources/Status/Poll/StatusPollView.swift
+++ b/Packages/Status/Sources/Status/Poll/StatusPollView.swift
@@ -77,9 +77,15 @@ public struct StatusPollView: View {
             .disabled(viewModel.poll.expired || (viewModel.poll.voted ?? false))
           if viewModel.showResults || status.account.id == currentAccount.account?.id {
             Spacer()
-            Text("\(percentForOption(option: option))%")
-              .font(.scaledSubheadline)
-              .frame(width: 40)
+            // Make sure they're all the same width using a ZStack with 100% hiding behind the
+            // real percentage.
+            ZStack(alignment: .trailing) {
+              Text("100%")
+                .hidden()
+
+              Text("\(percentForOption(option: option))%")
+                .font(.scaledSubheadline)
+            }
           }
         }
       }


### PR DESCRIPTION
Using a fixed width for poll percentages doesn't play nicely with larger font sizes. This introduces a `ZStack` with a hidden "100%" to make all of the percentages the same width at any font size.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="454" alt="CleanShot 2023-03-05 at 18 54 52@2x" src="https://user-images.githubusercontent.com/32487/223010504-b19d65d6-2756-47c1-8b1c-159810ee4f84.png">

</td>
<td>
<img width="453" alt="CleanShot 2023-03-05 at 19 04 37@2x" src="https://user-images.githubusercontent.com/32487/223010515-20e3b4e7-f362-47f5-9c9c-10635408e10c.png">
</td>
</tr>
</tbody>
</table>