### PR TITLE
Fixed the problem that the header information on the profile screen was not displayed

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailViewModel.swift
+++ b/Packages/Account/Sources/Account/AccountDetailViewModel.swift
@@ -129,17 +129,18 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
 
   private func fetchAccountData(accountId: String, client: Client) async throws -> AccountData {
     async let account: Account = client.get(endpoint: Accounts.accounts(id: accountId))
-    let featuredTags: [FeaturedTag]
-    do {
-      featuredTags = try await client.get(endpoint: Accounts.featuredTags(id: accountId))
-    } catch {
-      featuredTags = []
-    }
+    async let featuredTags: [FeaturedTag] = client.get(endpoint: Accounts.featuredTags(id: accountId))
     if client.isAuth && !isCurrentUser {
       async let relationships: [Relationship] = client.get(endpoint: Accounts.relationships(ids: [accountId]))
-      return try await .init(account: account,
-                             featuredTags: featuredTags,
-                             relationships: relationships)
+      do {
+        return try await .init(account: account,
+                               featuredTags: featuredTags,
+                               relationships: relationships)
+      } catch {
+          return try await .init(account: account,
+                                 featuredTags: [],
+                                 relationships: relationships)
+      }
     }
     return try await .init(account: account,
                            featuredTags: featuredTags,

--- a/Packages/Account/Sources/Account/AccountDetailViewModel.swift
+++ b/Packages/Account/Sources/Account/AccountDetailViewModel.swift
@@ -129,7 +129,12 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
 
   private func fetchAccountData(accountId: String, client: Client) async throws -> AccountData {
     async let account: Account = client.get(endpoint: Accounts.accounts(id: accountId))
-    async let featuredTags: [FeaturedTag] = client.get(endpoint: Accounts.featuredTags(id: accountId))
+    let featuredTags: [FeaturedTag]
+    do {
+      featuredTags = try await client.get(endpoint: Accounts.featuredTags(id: accountId))
+    } catch {
+      featuredTags = []
+    }
     if client.isAuth && !isCurrentUser {
       async let relationships: [Relationship] = client.get(endpoint: Accounts.relationships(ids: [accountId]))
       return try await .init(account: account,


### PR DESCRIPTION
In my case, the tag search is generally closed, so the user profile screen does not return the list of tags.
However, I noticed that the current implementation has a problem that most of the header information is not displayed on the profile screen for that reason.
Here's how to solve it.