### PR TITLE
Remove unnecessary dictionary in favor of tuple

### DIFF
--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -170,10 +170,8 @@ public struct StatusEditorView: View {
 
   @ViewBuilder
   private var languageConfirmationDialog: some View {
-    if let dialogVals = viewModel.languageConfirmationDialogLanguages,
-       let detected = dialogVals["detected"],
+      if let (detected: detected, selected: selected) = viewModel.languageConfirmationDialogLanguages,
        let detectedLong = Locale.current.localizedString(forLanguageCode: detected),
-       let selected = dialogVals["selected"],
        let selectedLong = Locale.current.localizedString(forLanguageCode: selected)
     {
       Button("status.editor.language-select.confirmation.detected-\(detectedLong)") {

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -15,7 +15,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
   var currentAccount: Account?
   var theme: Theme?
   var preferences: UserPreferences?
-  var languageConfirmationDialogLanguages: [String: String]?
+  var languageConfirmationDialogLanguages: (detected: String, selected: String)?
 
   var textView: UITextView? {
     didSet {
@@ -151,8 +151,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
        selectedLanguage != "",
        selectedLanguage != detectedLang
     {
-      languageConfirmationDialogLanguages = ["detected": detectedLang,
-                                             "selected": selectedLanguage]
+      languageConfirmationDialogLanguages = (detected: detectedLang, selected: selectedLanguage)
     } else {
       languageConfirmationDialogLanguages = nil
     }


### PR DESCRIPTION
The dictionary for the detected and selected language when posting is replaced with a named tuple to include named values that are checked at compile time. This removes a source of error while still being expressive.