### PR TITLE
Outlined icons in status editor

### DIFF
--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -9,6 +9,7 @@ struct StatusEditorAccessoryView: View {
   @EnvironmentObject private var preferences: UserPreferences
   @EnvironmentObject private var theme: Theme
   @EnvironmentObject private var currentInstance: CurrentInstance
+  @Environment(\.colorScheme) private var colorScheme
 
   @FocusState<Bool>.Binding var isSpoilerTextFocused: Bool
   @ObservedObject var viewModel: StatusEditorViewModel
@@ -30,7 +31,7 @@ struct StatusEditorAccessoryView: View {
               if viewModel.isMediasLoading {
                 ProgressView()
               } else {
-                Image(systemName: "photo.fill.on.rectangle.fill")
+                Image(systemName: "photo.on.rectangle.angled")
               }
             }
             .accessibilityLabel("accessibility.editor.button.attach-photo")
@@ -70,7 +71,10 @@ struct StatusEditorAccessoryView: View {
               Button {
                 isCustomEmojisSheetDisplay = true
               } label: {
-                Image(systemName: "face.smiling.inverse")
+                // This is a workaround for an apparent bug in the `face.smiling` SF Symbol.
+                // See https://github.com/Dimillian/IceCubesApp/issues/1193
+                let customEmojiSheetIconName = colorScheme == .light ? "face.smiling" : "face.smiling.inverse"
+                Image(systemName: customEmojiSheetIconName)
               }
               .accessibilityLabel("accessibility.editor.button.custom-emojis")
             }


### PR DESCRIPTION
* Brings the **photos** and **smiley face** icons in line with the rest of the accessory icons: they are always outlined. 
* resolves #1193

### Before 
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-07 at 10 39 31](https://user-images.githubusercontent.com/5955957/223402976-7812cc38-f6f6-48b3-9851-6e24fa0ea60d.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-07 at 10 39 42](https://user-images.githubusercontent.com/5955957/223402981-4e36f180-5b05-4eb2-9ee2-e8ab0e3dbb5a.png)

### After 
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-07 at 11 41 49](https://user-images.githubusercontent.com/5955957/223402880-2107fa06-0dae-4f07-add7-da5e1d706ca7.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-07 at 11 41 53](https://user-images.githubusercontent.com/5955957/223402883-eeac5de1-4901-4011-82f5-1116ddf67681.png)

