### PR TITLE
Tweak action feedback settings

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/HapticSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/HapticSettingsView.swift
@@ -10,14 +10,24 @@ struct HapticSettingsView: View {
 
   var body: some View {
     Form {
+      if true {
+        Section {
+          Toggle("settings.haptic.timeline", isOn: $userPreferences.hapticTimelineEnabled)
+          Toggle("settings.haptic.tab-selection", isOn: $userPreferences.hapticTabSelectionEnabled)
+          Toggle("settings.haptic.buttons", isOn: $userPreferences.hapticButtonPressEnabled)
+        } header: {
+          Text("Haptic Feedback")
+        }
+        .listRowBackground(theme.primaryBackgroundColor)
+      }
       Section {
-        Toggle("settings.haptic.timeline", isOn: $userPreferences.hapticTimelineEnabled)
-        Toggle("settings.haptic.tab-selection", isOn: $userPreferences.hapticTabSelectionEnabled)
-        Toggle("settings.haptic.buttons", isOn: $userPreferences.hapticButtonPressEnabled)
+        Toggle("settings.other.sound-effect", isOn: $userPreferences.soundEffectEnabled)
+      } header: {
+        Text("Sound Effects")
       }
       .listRowBackground(theme.primaryBackgroundColor)
     }
-    .navigationTitle("settings.haptic.navigation-title")
+    .navigationTitle("Action Feedback Settings")
     .scrollContentBackground(.hidden)
     .background(theme.secondaryBackgroundColor)
   }

--- a/IceCubesApp/App/Tabs/Settings/HapticSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/HapticSettingsView.swift
@@ -27,7 +27,7 @@ struct HapticSettingsView: View {
       }
       .listRowBackground(theme.primaryBackgroundColor)
     }
-    .navigationTitle("Action Feedback Settings")
+    .navigationTitle("Sounds and Haptics")
     .scrollContentBackground(.hidden)
     .background(theme.secondaryBackgroundColor)
   }

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -131,10 +131,8 @@ struct SettingsTabs: View {
       NavigationLink(destination: DisplaySettingsView()) {
         Label("settings.general.display", systemImage: "paintpalette")
       }
-      if HapticManager.shared.supportsHaptics {
-        NavigationLink(destination: HapticSettingsView()) {
-          Label("settings.general.haptic", systemImage: "waveform.path")
-        }
+      NavigationLink(destination: HapticSettingsView()) {
+        Label("settings.general.action-feedback", systemImage: "waveform.path")
       }
       NavigationLink(destination: remoteLocalTimelinesView) {
         Label("settings.general.remote-timelines", systemImage: "dot.radiowaves.right")
@@ -178,9 +176,6 @@ struct SettingsTabs: View {
       }
       Toggle(isOn: $preferences.isSocialKeyboardEnabled) {
         Label("settings.other.social-keyboard", systemImage: "keyboard")
-      }
-      Toggle(isOn: $preferences.soundEffectEnabled) {
-        Label("settings.other.sound-effect", systemImage: "hifispeaker")
       }
     }
     .listRowBackground(theme.primaryBackgroundColor)

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.account.action.delete-cache" = "Ачысціць кэш";
 
 "settings.general.haptic" = "Тактыльная зваротная сувязь";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Тактыльныя налады";
 "settings.haptic.timeline" = "Шкала часу";
 "settings.haptic.tab-selection" = "Выбар укладкі";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -174,6 +174,7 @@
 "settings.account.action.delete-cache" = "Neteja la memòria cau";
 
 "settings.general.haptic" = "Retroacció tàctil";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Configuració tàctil";
 "settings.haptic.timeline" = "Línia de temps";
 "settings.haptic.tab-selection" = "Selecció de pestanyes";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 "settings.account.action.delete-cache" = "Cache leeren";
 
 "settings.general.haptic" = "Haptisches Feedback";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Haptikeinstellungen";
 "settings.haptic.timeline" = "Timeline";
 "settings.haptic.tab-selection" = "Tabauswahl";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -179,6 +179,7 @@
 
 "settings.general.haptic" = "Haptic Feedback";
 "settings.haptic.navigation-title" = "Haptic Settings";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.timeline" = "Timeline";
 "settings.haptic.tab-selection" = "Tab Selection";
 "settings.haptic.buttons" = "Button Press";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -177,6 +177,7 @@
 
 "settings.general.haptic" = "Haptic Feedback";
 "settings.haptic.navigation-title" = "Haptic Settings";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.timeline" = "Timeline";
 "settings.haptic.tab-selection" = "Tab Selection";
 "settings.haptic.buttons" = "Button Press";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 "settings.account.action.delete-cache" = "Vaciar caché";
 
 "settings.general.haptic" = "Respuesta háptica";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Respuesta háptica";
 "settings.haptic.timeline" = "Cronología";
 "settings.haptic.tab-selection" = "Selección de pestaña";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 "settings.account.action.delete-cache" = "Garbitu katxea";
 
 "settings.general.haptic" = "Erreakzio haptikoak";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Ezarpen haptikoak";
 "settings.haptic.timeline" = "Denbora-lerroan";
 "settings.haptic.tab-selection" = "Fitxak hautatzean";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.account.action.delete-cache" = "Effacer le cache";
 
 "settings.general.haptic" = "Retour vibrations";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Réglages vibrations";
 "settings.haptic.timeline" = "Chronologie";
 "settings.haptic.tab-selection" = "Sélection d'onglet";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.account.action.delete-cache" = "Cancella la cache";
 
 "settings.general.haptic" = "Feedback aptico";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Impostazioni feedback aptico";
 "settings.haptic.timeline" = "Timeline";
 "settings.haptic.tab-selection" = "Selezione Tab";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.account.action.delete-cache" = "キャッシュをクリア";
 
 "settings.general.haptic" = "触覚フィードバック";
+"settings.general.action-feedback" = "操作フィードバック";
 "settings.haptic.navigation-title" = "触覚設定";
 "settings.haptic.timeline" = "タイムライン";
 "settings.haptic.tab-selection" = "タブセレクト";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.account.action.delete-cache" = "캐시 데이터 지우기";
 
 "settings.general.haptic" = "햅틱 피드백 설정";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "햅틱 피드백 설정";
 "settings.haptic.timeline" = "타임라인에서";
 "settings.haptic.tab-selection" = "하단 탭 바를 누를 때";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.account.action.delete-cache" = "Clear cache";
 
 "settings.general.haptic" = "Haptic Feedback";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Haptic Settings";
 "settings.haptic.timeline" = "Timeline";
 "settings.haptic.tab-selection" = "Tab Selection";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 "settings.account.action.delete-cache" = "Leeg cache";
 
 "settings.general.haptic" = "Haptische feedback";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Haptische instellingen";
 "settings.haptic.timeline" = "Tijdlijn";
 "settings.haptic.tab-selection" = "Tabselectie";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.account.action.delete-cache" = "Wyczyść bufor postów";
 
 "settings.general.haptic" = "Sygnały haptyczne";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Ustawienia haptyki";
 "settings.haptic.timeline" = "Strumień";
 "settings.haptic.tab-selection" = "Wybór zakładki";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.account.action.delete-cache" = "Limpar cache";
 
 "settings.general.haptic" = "Feedback Haptic";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Configurações Haptic";
 "settings.haptic.timeline" = "Linha do tempo";
 "settings.haptic.tab-selection" = "Seleção de aba";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "settings.account.action.delete-cache" = "Clear cache";
 
 "settings.general.haptic" = "Haptic Feedback";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Haptic Settings";
 "settings.haptic.timeline" = "Timeline";
 "settings.haptic.tab-selection" = "Tab Selection";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.account.action.delete-cache" = "Очистити кеш";
 
 "settings.general.haptic" = "Гаптика";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "Налаштування гаптики";
 "settings.haptic.timeline" = "Стрічка";
 "settings.haptic.tab-selection" = "Вибір вкладки";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -170,6 +170,7 @@
 "settings.account.action.delete-cache" = "清除缓存";
 
 "settings.general.haptic" = "触感触控";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "触感触控设置";
 "settings.haptic.timeline" = "时间线";
 "settings.haptic.tab-selection" = "导航栏";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -176,6 +176,7 @@
 "settings.account.action.delete-cache" = "清除快取";
 
 "settings.general.haptic" = "觸覺回饋";
+"settings.general.action-feedback" = "Action Feedback";
 "settings.haptic.navigation-title" = "觸覺設定";
 "settings.haptic.timeline" = "時間軸";
 "settings.haptic.tab-selection" = "頁籤選擇";


### PR DESCRIPTION
The sound effects were very good, but it has to be quiet for public use.
So I looked for a menu to turn this feature off, but it was in an unexpected place.
I think it should be displayed without scrolling to get to the desired settings menu more intuitively.

![Simulator Screen Shot - iPhone](https://user-images.githubusercontent.com/108506642/223712155-8d4b4f06-6dd9-43a4-b0d3-2b0a27998468.png)