### PR TITLE
Hotfix: Tags for Simplified Chinese localization

### DIFF
--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -417,7 +417,7 @@
 "status.draft.delete" = "删除草稿";
 "status.draft.save" = "保存草稿";
 "status.editor.ai-prompt.correct" = "检查拼写和语法";
-"status.editor.ai-prompt.add-tags" = "就地添加#标签";
+"status.editor.ai-prompt.add-tags" = "自动添加#标签";
 "status.editor.ai-prompt.insert-tags" = "在末尾添加#标签";
 "status.editor.ai-prompt.emphasize" = "使用强调语气";
 "status.editor.ai-prompt.fit" = "精简文字";


### PR DESCRIPTION
@nixzhu 我觉得还是原来的“自动”好理解一些，“自动”就代表在原位置自动添加#了