### PR TITLE
Fix build error for DesignSystem package

### DIFF
--- a/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/divadretlaw/EmojiText",
       "state" : {
-        "revision" : "3b1bd89937470d8970d3fdb6ac34943ecd2cda76",
-        "version" : "2.5.0"
+        "revision" : "b5b0a30933a6dcb6601ad3625690a823fa3f6965",
+        "version" : "2.6.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "branch" : "nuke-12",
-        "revision" : "baccf1b00f458a77a9f9615e415bc4463029cf5e"
+        "revision" : "6241e100294a2aa70d1811641585ab7da780bd0f",
+        "version" : "12.0.0"
       }
     },
     {

--- a/Packages/DesignSystem/Package.swift
+++ b/Packages/DesignSystem/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     .package(name: "Models", path: "../Models"),
     .package(name: "Env", path: "../Env"),
     .package(url: "https://github.com/markiv/SwiftUI-Shimmer", exact: "1.1.0"),
-    .package(url: "https://github.com/kean/Nuke", branch: "nuke-12"),
-    .package(url: "https://github.com/divadretlaw/EmojiText", from: "2.5.0"),
+    .package(url: "https://github.com/kean/Nuke", from: "12.0.0"),
+    .package(url: "https://github.com/divadretlaw/EmojiText", from: "2.6.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Fixed a problem that prevented the `DesignSystem` package from being built by itself.
This is because the `DesignSystem` package depends on Nuke 12 and EmojiText 2.5.0 depends on Nuke 11.
Aligned Nuke versions of both the `DesignSystem` package and EmojiText.
