### PR TITLE
Changed the display of numerical values ​​toward accurate values

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -210,7 +210,7 @@ struct AccountDetailHeaderView: View {
 
   private func makeCustomInfoLabel(title: LocalizedStringKey, count: Int, needsBadge: Bool = false) -> some View {
     VStack {
-      Text(count, format: .number.notation(.compactName))
+      Text(count, format: .number.notation(.automatic))
         .font(.scaledHeadline)
         .foregroundColor(theme.tintColor)
         .overlay(alignment: .trailing) {


### PR DESCRIPTION
I see this client as a mastodon tool for advanced users rather than a simple and easy tool for beginners.
Accurate information is therefore preferred over terse numerical representations.
This change was made to comply with the actual values.