### PR TITLE
Use 'Done' text button on accounts selector

### DIFF
--- a/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
@@ -111,11 +111,11 @@ public struct AppAccountsSelectorView: View {
       .navigationTitle("settings.section.accounts")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
-        ToolbarItem(placement: .navigationBarLeading) {
+        ToolbarItem(placement: .navigationBarTrailing) {
           Button {
             isPresented.toggle()
           } label: {
-            Image(systemName: "xmark.circle")
+            Text("action.done").bold()
           }
         }
       }


### PR DESCRIPTION
This changes the 'xmark' button with a more idiomatic 'Done' text button.

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-14 at 10 11 36](https://user-images.githubusercontent.com/5955957/224960483-9d76efcb-ceb4-42be-90da-290427b62a7f.png)
