### PR TITLE
Remove an unnecessary icon.

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -11,7 +11,7 @@ struct TranslationSettingsView: View {
   var body: some View {
     Form {
       Toggle(isOn: preferences.$alwaysUseDeepl) {
-        Label("settings.translation.always-deepl", systemImage: "captions.bubble")
+        Text("settings.translation.always-deepl")
       }
       .listRowBackground(theme.primaryBackgroundColor)
 


### PR DESCRIPTION
The icon next to the "always translate using DeepL" was unnecessary and looked weird since it forced the text into two lines while itself being displayed on the first one, not centered.