### PR TITLE
Add navigation title to the Translation Settings view

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -39,6 +39,7 @@ struct TranslationSettingsView: View {
         }
       }
     }
+    .navigationTitle("settings.translation.navigation-title")
     .scrollContentBackground(.hidden)
     .background(theme.secondaryBackgroundColor)
     .onChange(of: apiKey, perform: writeNewValue)

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -166,6 +166,7 @@
 "settings.other.social-keyboard" = "Уключыць сацыяльную клавіятуру";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "settings.other.social-keyboard" = "Activa el teclat social";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -142,6 +142,7 @@
 "settings.other.social-keyboard" = "Soziale Tastatur aktivieren";
 "settings.other.sound-effect" = "Klänge aktivieren";
 "settings.general.translate" = "Übersetzungseinstellungen";
+"settings.translation.navigation-title" = "Übersetzung";
 "settings.translation.always-deepl" = "Immer mit DeepL übersetzen";
 "settings.translation.user-api-key" = "DeepL-API-Schlüssel";
 "settings.translation.api-key-type" = "Typ des Schlüssels";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "settings.other.social-keyboard" = "Enable Social Keyboard";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -166,6 +166,7 @@
 "settings.other.social-keyboard" = "Enable Social Keyboard";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -142,6 +142,7 @@
 "settings.other.social-keyboard" = "Activar teclado social";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -142,6 +142,7 @@
 "settings.other.social-keyboard" = "Gaitu teklatu soziala";
 "settings.other.sound-effect" = "Gaitu soinu efektuak";
 "settings.general.translate" = "Itzulpen ezarpenak";
+"settings.translation.navigation-title" = "Itzulpen ezarpenak";
 "settings.translation.always-deepl" = "Itzuli beti DeepL erabiliz";
 "settings.translation.user-api-key" = "DeepL API gakoa";
 "settings.translation.api-key-type" = "Gako mota";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -162,6 +162,7 @@
 "settings.other.social-keyboard" = "Activer le clavier social";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -141,6 +141,7 @@
 "settings.other.social-keyboard" = "Abilita social keyboard";
 "settings.other.sound-effect" = "Attiva gli effetti sonori";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -166,6 +166,7 @@
 "settings.other.social-keyboard" = "ソーシャルメディア向けキーボードの有効化";
 "settings.other.sound-effect" = "サウンドエフェクトを有効化";
 "settings.general.translate" = "翻訳設定";
+"settings.translation.navigation-title" = "翻訳設定";
 "settings.translation.always-deepl" = "DeepLを使用して常に翻訳する";
 "settings.translation.user-api-key" = "DeepL APIキー";
 "settings.translation.api-key-type" = "キーのタイプ";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -162,6 +162,7 @@
 "settings.other.social-keyboard" = "SNS 키보드";
 "settings.other.sound-effect" = "효과음";
 "settings.general.translate" = "번역 설정";
+"settings.translation.navigation-title" = "번역 설정";
 "settings.translation.always-deepl" = "항상 DeepL을 통해 번역";
 "settings.translation.user-api-key" = "DeepL API 키";
 "settings.translation.api-key-type" = "API 키 종류";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -166,6 +166,7 @@
 "settings.other.social-keyboard" = "Aktiver sosialt tastatur";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -141,11 +141,12 @@
 "settings.other.hide-openai" = "Gebruik 🤖-hulp";
 "settings.other.social-keyboard" = "Gebruik socialmedia-toetsenbord";
 "settings.other.sound-effect" = "Geluidseffecten";
-"settings.general.translate" = "Translation Settings";
-"settings.translation.always-deepl" = "Always Translate using DeepL";
-"settings.translation.user-api-key" = "DeepL API Key";
-"settings.translation.api-key-type" = "Type of the Key";
-"settings.translation.needed-message" = "This feature requires a DeepL API key";
+"settings.general.translate" = "Vertalingsinstellingen";
+"settings.translation.navigation-title" = "Vertaling";
+"settings.translation.always-deepl" = "Vertaal altijd met DeepL";
+"settings.translation.user-api-key" = "DeepL API-sleutel";
+"settings.translation.api-key-type" = "Sleuteltype";
+"settings.translation.needed-message" = "Deze functionaliteit vereist een DeepL API-sleutel";
 "settings.general.content" = "Inhoud";
 "settings.system" = "Systeeminstellingen";
 "settings.content.navigation-title" = "Inhoud";
@@ -384,9 +385,9 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Vertaal";
-"status.action.translate-with-deepl" = "Translate with DeepL";
-"status.action.translated-label-%@" = "Vertaald met behulp van %@";
-"status.action.translated-label-from-%@-%@" = "Vertaald uit het %@ met behulp van %@";
+"status.action.translate-with-deepl" = "Vertaal met DeepL";
+"status.action.translated-label-%@" = "Vertaald met %@";
+"status.action.translated-label-from-%@-%@" = "Vertaald uit het %@ met %@";
 "status.action.bookmark" = "Voeg bladwijzer toe";
 "status.action.boost" = "Boost";
 "status.action.boost-to-followers" = "Boost aan volgers";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -163,6 +163,7 @@
 "settings.other.sound-effect" = "Włącz efekty dźwiękowe";
 "settings.push.duplicate.title" = "Korektor duplikatów powiadomień";
 "settings.general.translate" = "Ustawienia tłumaczenia";
+"settings.translation.navigation-title" = "Ustawienia tłumaczenia";
 "settings.translation.always-deepl" = "Zawsze tłumacz przy pomocy DeepL";
 "settings.translation.user-api-key" = "Klucz DeepL API";
 "settings.translation.api-key-type" = "Rodzaj klucza";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -162,6 +162,7 @@
 "settings.other.social-keyboard" = "Habilitar Teclado Social";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -162,6 +162,7 @@
 "settings.other.social-keyboard" = "Sosyal Klavyeyi Aktive Et";
 "settings.other.sound-effect" = "Enable Sound Effects";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -166,6 +166,7 @@
 "settings.other.social-keyboard" = "Увімкнути Social Keyboard";
 "settings.other.sound-effect" = "Увімкнути звукові ефекти";
 "settings.general.translate" = "Translation Settings";
+"settings.translation.navigation-title" = "Translation";
 "settings.translation.always-deepl" = "Always Translate using DeepL";
 "settings.translation.user-api-key" = "DeepL API Key";
 "settings.translation.api-key-type" = "Type of the Key";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -142,6 +142,7 @@
 "settings.other.social-keyboard" = "启用社交键盘";
 "settings.other.sound-effect" = "启用声音效果";
 "settings.general.translate" = "翻译设置";
+"settings.translation.navigation-title" = "翻译设置";
 "settings.translation.always-deepl" = "总是使用 DeepL 翻译";
 "settings.translation.user-api-key" = "DeepL API 密钥";
 "settings.translation.api-key-type" = "密钥类型";


### PR DESCRIPTION
I noticed the new Translation Settings View didn't have a navigation title, so I added it. 

This PR also contains updates to the Dutch localization.


![Simulator Screen Shot - iPhone 14 Pro - 2023-03-16 at 16 21 07](https://user-images.githubusercontent.com/5955957/225664404-c2aea4cc-6f65-44e0-a556-f127e38720be.png)