### PR TITLE
Settings screen Accessibility tweaks

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -208,6 +208,7 @@ struct SettingsTabs: View {
       Link(destination: URL(string: "https://github.com/Dimillian/IceCubesApp")!) {
         Label("settings.app.source", systemImage: "link")
       }
+      .accessibilityRemoveTraits(.isButton)
       .tint(theme.labelColor)
 
       NavigationLink(destination: SupportAppView()) {
@@ -218,6 +219,7 @@ struct SettingsTabs: View {
         Link(destination: reviewURL) {
           Label("settings.rate", systemImage: "link")
         }
+        .accessibilityRemoveTraits(.isButton)
         .tint(theme.labelColor)
       }
 

--- a/Packages/AppAccount/Sources/AppAccount/AppAccountView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountView.swift
@@ -4,6 +4,7 @@ import Env
 import SwiftUI
 
 public struct AppAccountView: View {
+  @EnvironmentObject private var theme: Theme
   @EnvironmentObject private var routerPath: RouterPath
   @EnvironmentObject private var appAccounts: AppAccountsManager
   @EnvironmentObject private var preferences: UserPreferences
@@ -90,6 +91,7 @@ public struct AppAccountView: View {
         VStack(alignment: .leading) {
           if let account = viewModel.account {
             EmojiTextApp(.init(stringValue: account.safeDisplayName), emojis: account.emojis)
+              .foregroundColor(theme.labelColor)
             Text("\(account.username)@\(viewModel.appAccount.server)")
               .font(.scaledSubheadline)
               .emojiSize(Font.scaledSubheadlineFont.emojiSize)

--- a/Packages/AppAccount/Sources/AppAccount/AppAccountView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountView.swift
@@ -41,55 +41,7 @@ public struct AppAccountView: View {
   }
 
   private var fullView: some View {
-    HStack {
-      if let account = viewModel.account {
-        ZStack(alignment: .topTrailing) {
-          AvatarView(url: account.avatar)
-          if viewModel.appAccount.id == appAccounts.currentAccount.id {
-            Image(systemName: "checkmark.circle.fill")
-              .foregroundStyle(.white, .green)
-              .offset(x: 5, y: -5)
-          } else if viewModel.showBadge,
-                    let token = viewModel.appAccount.oauthToken,
-                    preferences.getNotificationsCount(for: token) > 0
-          {
-            let notificationsCount = preferences.getNotificationsCount(for: token)
-            ZStack {
-              Circle()
-                .fill(.red)
-              Text(notificationsCount > 99 ? "99+" : String(notificationsCount))
-                .foregroundColor(.white)
-                .font(.system(size: 9))
-            }
-            .frame(width: 20, height: 20)
-            .offset(x: 5, y: -5)
-          }
-        }
-      } else {
-        ProgressView()
-        Text(viewModel.appAccount.accountName ?? viewModel.acct)
-          .font(.scaledSubheadline)
-          .foregroundColor(.gray)
-          .padding(.leading, 6)
-      }
-      VStack(alignment: .leading) {
-        if let account = viewModel.account {
-          EmojiTextApp(.init(stringValue: account.safeDisplayName), emojis: account.emojis)
-          Text("\(account.username)@\(viewModel.appAccount.server)")
-            .font(.scaledSubheadline)
-            .emojiSize(Font.scaledSubheadlineFont.emojiSize)
-            .emojiBaselineOffset(Font.scaledSubheadlineFont.emojiBaselineOffset)
-            .foregroundColor(.gray)
-        }
-      }
-      if viewModel.isInNavigation {
-        Spacer()
-        Image(systemName: "chevron.right")
-          .foregroundColor(.gray)
-      }
-    }
-    .contentShape(Rectangle())
-    .onTapGesture {
+    Button {
       if appAccounts.currentAccount.id == viewModel.appAccount.id,
          let account = viewModel.account
       {
@@ -101,6 +53,54 @@ public struct AppAccountView: View {
         withTransaction(transation) {
           appAccounts.currentAccount = viewModel.appAccount
           HapticManager.shared.fireHaptic(of: .notification(.success))
+        }
+      }
+    } label: {
+      HStack {
+        if let account = viewModel.account {
+          ZStack(alignment: .topTrailing) {
+            AvatarView(url: account.avatar)
+            if viewModel.appAccount.id == appAccounts.currentAccount.id {
+              Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.white, .green)
+                .offset(x: 5, y: -5)
+            } else if viewModel.showBadge,
+                      let token = viewModel.appAccount.oauthToken,
+                      preferences.getNotificationsCount(for: token) > 0
+            {
+              let notificationsCount = preferences.getNotificationsCount(for: token)
+              ZStack {
+                Circle()
+                  .fill(.red)
+                Text(notificationsCount > 99 ? "99+" : String(notificationsCount))
+                  .foregroundColor(.white)
+                  .font(.system(size: 9))
+              }
+              .frame(width: 20, height: 20)
+              .offset(x: 5, y: -5)
+            }
+          }
+        } else {
+          ProgressView()
+          Text(viewModel.appAccount.accountName ?? viewModel.acct)
+            .font(.scaledSubheadline)
+            .foregroundColor(.gray)
+            .padding(.leading, 6)
+        }
+        VStack(alignment: .leading) {
+          if let account = viewModel.account {
+            EmojiTextApp(.init(stringValue: account.safeDisplayName), emojis: account.emojis)
+            Text("\(account.username)@\(viewModel.appAccount.server)")
+              .font(.scaledSubheadline)
+              .emojiSize(Font.scaledSubheadlineFont.emojiSize)
+              .emojiBaselineOffset(Font.scaledSubheadlineFont.emojiBaselineOffset)
+              .foregroundColor(.gray)
+          }
+        }
+        if viewModel.isInNavigation {
+          Spacer()
+          Image(systemName: "chevron.right")
+            .foregroundColor(.gray)
         }
       }
     }


### PR DESCRIPTION
# This PR

1. Removes `button` traits from the settings options that are `Link`-backed. 
 
These two traits indicate different behaviours and shouldn't co-exist on the same element. Currently, SwiftUI sets both, which is being tracked as _FB11507660_.

2. Wraps `AppAccountView` in a `Button`, which results in a single accessibility element per account. 

Previously, the selected tick would render as its own element, as would the profile image (with no descriptive label). Because there was a `onTapGesture` attached to a `.contentShape`, each of these 5 component elements would be interactive, all performing the same action.

## Before
<img width="100%" alt="IceCubes-Settings-Before" src="https://user-images.githubusercontent.com/5979418/225777654-0400d3e7-171d-4628-a164-41a7f875b055.png">

## After
<img width="100%" alt="IceCubes-Settings-After" src="https://user-images.githubusercontent.com/5979418/225777703-f6f56c70-2f93-4046-b1db-9071a0f7eb3c.png">

