### PR TITLE
Compose Post Screen Accessibility Tweaks

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -519,6 +519,8 @@
 "accessibility.editor.button.language" = "Мова";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Дадаць уліковы запіс";
 "accessibility.app-account.selector.accounts" = "Уліковыя запісы";
 

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -518,6 +518,7 @@
 "accessibility.editor.button.custom-emojis" = "Уласныя эмодзі";
 "accessibility.editor.button.language" = "Мова";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Дадаць уліковы запіс";
 "accessibility.app-account.selector.accounts" = "Уліковыя запісы";
 

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -517,6 +517,7 @@
 "accessibility.editor.button.drafts" = "Чарнавікі";
 "accessibility.editor.button.custom-emojis" = "Уласныя эмодзі";
 "accessibility.editor.button.language" = "Мова";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Дадаць уліковы запіс";
 "accessibility.app-account.selector.accounts" = "Уліковыя запісы";
 

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -511,6 +511,7 @@
 "accessibility.editor.button.drafts" = "Drafts";
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -512,6 +512,7 @@
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -513,6 +513,8 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -509,6 +509,8 @@
 "accessibility.editor.button.language" = "Sprache";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Konto hinzufügen";
 "accessibility.app-account.selector.accounts" = "Konten";
 

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -507,6 +507,7 @@
 "accessibility.editor.button.drafts" = "Entwürfe";
 "accessibility.editor.button.custom-emojis" = "Eigene Emojis";
 "accessibility.editor.button.language" = "Sprache";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Konto hinzufügen";
 "accessibility.app-account.selector.accounts" = "Konten";
 

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -508,6 +508,7 @@
 "accessibility.editor.button.custom-emojis" = "Eigene Emojis";
 "accessibility.editor.button.language" = "Sprache";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Konto hinzufügen";
 "accessibility.app-account.selector.accounts" = "Konten";
 

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -514,6 +514,7 @@
 "accessibility.editor.button.drafts" = "Drafts";
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -517,6 +517,8 @@
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.app-account.selector.accounts" = "Accounts";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -516,6 +516,7 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Add Account";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.app-account.selector.accounts" = "Accounts";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -514,6 +514,7 @@
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -515,6 +515,8 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.drafts" = "Drafts";
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -514,6 +514,7 @@
 "accessibility.editor.button.custom-emojis" = "Emojis personalizados";
 "accessibility.editor.button.language" = "Idioma";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Añadir cuenta";
 "accessibility.app-account.selector.accounts" = "Cuentas";
 

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.drafts" = "Borradores";
 "accessibility.editor.button.custom-emojis" = "Emojis personalizados";
 "accessibility.editor.button.language" = "Idioma";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Añadir cuenta";
 "accessibility.app-account.selector.accounts" = "Cuentas";
 

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -515,6 +515,8 @@
 "accessibility.editor.button.language" = "Idioma";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Añadir cuenta";
 "accessibility.app-account.selector.accounts" = "Cuentas";
 

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -503,6 +503,7 @@
 "accessibility.editor.button.custom-emojis" = "Instantziaren emojiak";
 "accessibility.editor.button.language" = "Hizkuntza";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Gehitu kontua";
 "accessibility.app-account.selector.accounts" = "Kontuak";
 

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -504,6 +504,8 @@
 "accessibility.editor.button.language" = "Hizkuntza";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Gehitu kontua";
 "accessibility.app-account.selector.accounts" = "Kontuak";
 

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -502,6 +502,7 @@
 "accessibility.editor.button.drafts" = "Zirriborroak";
 "accessibility.editor.button.custom-emojis" = "Instantziaren emojiak";
 "accessibility.editor.button.language" = "Hizkuntza";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Gehitu kontua";
 "accessibility.app-account.selector.accounts" = "Kontuak";
 

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -508,6 +508,7 @@
 "accessibility.editor.button.drafts" = "Brouillons";
 "accessibility.editor.button.custom-emojis" = "Emojis personalisés";
 "accessibility.editor.button.language" = "Langue";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Ajouter un compte>";
 "accessibility.app-account.selector.accounts" = "Comptes";
 

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -510,6 +510,8 @@
 "accessibility.editor.button.language" = "Langue";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Ajouter un compte>";
 "accessibility.app-account.selector.accounts" = "Comptes";
 

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -509,6 +509,7 @@
 "accessibility.editor.button.custom-emojis" = "Emojis personalisés";
 "accessibility.editor.button.language" = "Langue";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Ajouter un compte>";
 "accessibility.app-account.selector.accounts" = "Comptes";
 

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "accessibility.editor.button.language" = "Lingua";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Aggiungi account";
 "accessibility.app-account.selector.accounts" = "Account";
 

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -512,6 +512,7 @@
 "accessibility.editor.button.drafts" = "Bozze";
 "accessibility.editor.button.custom-emojis" = "Emoji personalizzate";
 "accessibility.editor.button.language" = "Lingua";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Aggiungi account";
 "accessibility.app-account.selector.accounts" = "Account";
 

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.custom-emojis" = "Emoji personalizzate";
 "accessibility.editor.button.language" = "Lingua";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Aggiungi account";
 "accessibility.app-account.selector.accounts" = "Account";
 

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "accessibility.editor.button.language" = "言語";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "アカウントを追加";
 "accessibility.app-account.selector.accounts" = "アカウント";
 

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.custom-emojis" = "カスタム絵文字";
 "accessibility.editor.button.language" = "言語";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "アカウントを追加";
 "accessibility.app-account.selector.accounts" = "アカウント";
 

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -512,6 +512,7 @@
 "accessibility.editor.button.drafts" = "下書き";
 "accessibility.editor.button.custom-emojis" = "カスタム絵文字";
 "accessibility.editor.button.language" = "言語";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "アカウントを追加";
 "accessibility.app-account.selector.accounts" = "アカウント";
 

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -515,6 +515,7 @@
 "accessibility.editor.button.custom-emojis" = "커스텀 이모지";
 "accessibility.editor.button.language" = "글 언어 지정";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "계정 추가";
 "accessibility.app-account.selector.accounts" = "계정";
 

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -516,6 +516,8 @@
 "accessibility.editor.button.language" = "글 언어 지정";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "계정 추가";
 "accessibility.app-account.selector.accounts" = "계정";
 

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -514,6 +514,7 @@
 "accessibility.editor.button.drafts" = "임시 보관함";
 "accessibility.editor.button.custom-emojis" = "커스텀 이모지";
 "accessibility.editor.button.language" = "글 언어 지정";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "계정 추가";
 "accessibility.app-account.selector.accounts" = "계정";
 

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -512,6 +512,7 @@
 "accessibility.editor.button.drafts" = "Drafts";
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -510,6 +510,7 @@
 "accessibility.editor.button.custom-emojis" = "Aangepaste emoji’s";
 "accessibility.editor.button.language" = "Taal";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Voeg account toe";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -509,6 +509,7 @@
 "accessibility.editor.button.drafts" = "Concepten";
 "accessibility.editor.button.custom-emojis" = "Aangepaste emoji’s";
 "accessibility.editor.button.language" = "Taal";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Voeg account toe";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -511,6 +511,8 @@
 "accessibility.editor.button.language" = "Taal";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Voeg account toe";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -506,6 +506,8 @@
 "accessibility.editor.button.language" = "Język";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Dodaj konto";
 "accessibility.app-account.selector.accounts" = "Konta";
 

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -504,6 +504,7 @@
 "accessibility.editor.button.drafts" = "Wersje robocze";
 "accessibility.editor.button.custom-emojis" = "Emotikony własne";
 "accessibility.editor.button.language" = "Język";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Dodaj konto";
 "accessibility.app-account.selector.accounts" = "Konta";
 

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -505,6 +505,7 @@
 "accessibility.editor.button.custom-emojis" = "Emotikony własne";
 "accessibility.editor.button.language" = "Język";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Dodaj konto";
 "accessibility.app-account.selector.accounts" = "Konta";
 

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "accessibility.editor.button.language" = "Idioma";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Adicionar conta";
 "accessibility.app-account.selector.accounts" = "Contas";
 

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -512,6 +512,7 @@
 "accessibility.editor.button.drafts" = "Rascunhos";
 "accessibility.editor.button.custom-emojis" = "Emojis customizados";
 "accessibility.editor.button.language" = "Idioma";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Adicionar conta";
 "accessibility.app-account.selector.accounts" = "Contas";
 

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.custom-emojis" = "Emojis customizados";
 "accessibility.editor.button.language" = "Idioma";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Adicionar conta";
 "accessibility.app-account.selector.accounts" = "Contas";
 

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -512,6 +512,7 @@
 "accessibility.editor.button.drafts" = "Drafts";
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.custom-emojis" = "Custom emojis";
 "accessibility.editor.button.language" = "Language";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
 

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -515,6 +515,8 @@
 "accessibility.editor.button.language" = "Мова";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "Додати профіль";
 "accessibility.app-account.selector.accounts" = "Профілі";
 

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -514,6 +514,7 @@
 "accessibility.editor.button.custom-emojis" = "Власні emojis";
 "accessibility.editor.button.language" = "Мова";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "Додати профіль";
 "accessibility.app-account.selector.accounts" = "Профілі";
 

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.drafts" = "Чернетка";
 "accessibility.editor.button.custom-emojis" = "Власні emojis";
 "accessibility.editor.button.language" = "Мова";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "Додати профіль";
 "accessibility.app-account.selector.accounts" = "Профілі";
 

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -515,6 +515,7 @@
 "accessibility.editor.button.custom-emojis" = "自定义表情";
 "accessibility.editor.button.language" = "选择语言";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "添加账户";
 "accessibility.app-account.selector.accounts" = "账户";
 

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -514,6 +514,7 @@
 "accessibility.editor.button.drafts" = "草稿";
 "accessibility.editor.button.custom-emojis" = "自定义表情";
 "accessibility.editor.button.language" = "选择语言";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "添加账户";
 "accessibility.app-account.selector.accounts" = "账户";
 

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -516,6 +516,8 @@
 "accessibility.editor.button.language" = "选择语言";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "添加账户";
 "accessibility.app-account.selector.accounts" = "账户";
 

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -514,6 +514,7 @@
 "accessibility.editor.button.custom-emojis" = "自定表情符號";
 "accessibility.editor.button.language" = "語言";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
+"accessibility.editor.button.characters-remaining" = "Characters remaining";
 "accessibility.tabs.timeline.add-account" = "新增帳號";
 "accessibility.app-account.selector.accounts" = "帳號";
 

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -513,6 +513,7 @@
 "accessibility.editor.button.drafts" = "草稿";
 "accessibility.editor.button.custom-emojis" = "自定表情符號";
 "accessibility.editor.button.language" = "語言";
+"accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.tabs.timeline.add-account" = "新增帳號";
 "accessibility.app-account.selector.accounts" = "帳號";
 

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -515,6 +515,8 @@
 "accessibility.editor.button.language" = "語言";
 "accessibility.editor.button.ai-prompt" = "AI prompt";
 "accessibility.editor.button.characters-remaining" = "Characters remaining";
+"accessibility.editor.privacy.label" = "Visibility";
+"accessibility.editor.privacy.hint" = "Changes post audience.";
 "accessibility.tabs.timeline.add-account" = "新增帳號";
 "accessibility.app-account.selector.accounts" = "帳號";
 

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -308,6 +308,11 @@ struct StatusEditorAccessoryView: View {
     Text("\(value)")
       .foregroundColor(value < 0 ? .red : .secondary)
       .font(.scaledCallout)
+      .accessibilityLabel("accessibility.editor.button.characters-remaining")
+      .accessibilityValue("\(value)")
+      .accessibilityRemoveTraits(.isStaticText)
+      .accessibilityAddTraits(.updatesFrequently)
+      .accessibilityRespondsToUserInteraction(false)
   }
 
   private var recentlyUsedLanguages: [Language] {

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -275,10 +275,13 @@ struct StatusEditorAccessoryView: View {
                   .resizable()
                   .aspectRatio(contentMode: .fill)
                   .frame(width: 40, height: 40)
+                  .accessibilityLabel(emoji.shortcode.replacingOccurrences(of: "_", with: " "))
+                  .accessibilityAddTraits(.isButton)
               } else if state.isLoading {
                 Rectangle()
                   .fill(Color.gray)
                   .frame(width: 40, height: 40)
+                  .accessibility(hidden: true)
                   .shimmering()
               }
             }

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -237,13 +237,13 @@ struct StatusEditorAccessoryView: View {
     NavigationStack {
       List {
         ForEach(preferences.draftsPosts, id: \.self) { draft in
-          Text(draft)
-            .lineLimit(3)
-            .listRowBackground(theme.primaryBackgroundColor)
-            .onTapGesture {
-              viewModel.insertStatusText(text: draft)
-              isDraftsSheetDisplayed = false
-            }
+          Button {
+            viewModel.insertStatusText(text: draft)
+            isDraftsSheetDisplayed = false
+          } label: {
+            Text(draft)
+              .lineLimit(3)
+          }.listRowBackground(theme.primaryBackgroundColor)
         }
         .onDelete { indexes in
           if let index = indexes.first {

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -176,6 +176,7 @@ struct StatusEditorAccessoryView: View {
         ProgressView()
       } else {
         Image(systemName: "faxmachine")
+          .accessibilityLabel("accessibility.editor.button.ai-prompt")
       }
     }
   }

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -303,7 +303,7 @@ struct StatusEditorAccessoryView: View {
 
   private var characterCountView: some View {
     Text("\((currentInstance.instance?.configuration?.statuses.maxCharacters ?? 500) + viewModel.statusTextCharacterLength)")
-      .foregroundColor(.gray)
+      .foregroundColor(.secondary)
       .font(.scaledCallout)
   }
 

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -301,9 +301,12 @@ struct StatusEditorAccessoryView: View {
     .presentationDetents([.medium])
   }
 
+  @ViewBuilder
   private var characterCountView: some View {
-    Text("\((currentInstance.instance?.configuration?.statuses.maxCharacters ?? 500) + viewModel.statusTextCharacterLength)")
-      .foregroundColor(.secondary)
+    let value = (currentInstance.instance?.configuration?.statuses.maxCharacters ?? 500) + viewModel.statusTextCharacterLength
+
+    Text("\(value)")
+      .foregroundColor(value < 0 ? .red : .secondary)
       .font(.scaledCallout)
   }
 

--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -66,7 +66,7 @@ public struct StatusEditorView: View {
           }
           .padding(.top, 8)
           .padding(.bottom, 40)
-        }
+        }.accessibilitySortPriority(1) // Ensure that all elements inside the `ScrollView` occur earlier than the accessory views
         VStack(alignment: .leading, spacing: 0) {
           StatusEditorAutoCompleteView(viewModel: viewModel)
           StatusEditorAccessoryView(isSpoilerTextFocused: $isSpoilerTextFocused,

--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -262,6 +262,9 @@ public struct StatusEditorView: View {
     } label: {
       HStack {
         Label(viewModel.visibility.title, systemImage: viewModel.visibility.iconName)
+          .accessibilityLabel("accessibility.editor.privacy.label")
+          .accessibilityValue(viewModel.visibility.title)
+          .accessibilityHint("accessibility.editor.privacy.hint")
         Image(systemName: "chevron.down")
       }
       .font(.scaledFootnote)

--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -235,6 +235,7 @@ public struct StatusEditorView: View {
         } else {
           AvatarView(url: account.avatar, size: .status)
             .environmentObject(theme)
+            .accessibilityHidden(true)
         }
         VStack(alignment: .leading, spacing: 4) {
           privacyMenu

--- a/Packages/Status/Sources/Status/Editor/UITextView/Modifiers.swift
+++ b/Packages/Status/Sources/Status/Editor/UITextView/Modifiers.swift
@@ -19,6 +19,7 @@ public extension TextView {
     var view = self
     let text = Text(placeholder)
     view.placeholderView = AnyView(configure(text))
+    view.placeholderText = placeholder
     return view
   }
 

--- a/Packages/Status/Sources/Status/Editor/UITextView/TextView.swift
+++ b/Packages/Status/Sources/Status/Editor/UITextView/TextView.swift
@@ -13,6 +13,7 @@ public struct TextView: View {
   private var getTextView: ((UITextView) -> Void)?
 
   var placeholderView: AnyView?
+  var placeholderText: String?
   var keyboard: UIKeyboardType = .default
 
   /// Makes a new TextView that supports `NSAttributedString`
@@ -41,6 +42,7 @@ public struct TextView: View {
       minHeight: calculatedHeight,
       maxHeight: calculatedHeight
     )
+    .accessibilityValue($text.wrappedValue.string.isEmpty ? (placeholderText ?? "") : $text.wrappedValue.string)
     .background(
       placeholderView?
         .foregroundColor(Color(.placeholderText))

--- a/Packages/Status/Sources/Status/Editor/UITextView/TextView.swift
+++ b/Packages/Status/Sources/Status/Editor/UITextView/TextView.swift
@@ -50,7 +50,8 @@ public struct TextView: View {
         .font(.scaledBody)
         .padding(.horizontal, 0)
         .padding(.vertical, 0)
-        .opacity(isEmpty ? 1 : 0),
+        .opacity(isEmpty ? 1 : 0)
+        .accessibilityHidden(true),
       alignment: .topLeading
     )
   }


### PR DESCRIPTION
# This PR

… makes a few relatively small changes that make big improvements to the accessibility of the screen:

- Adds a localized label for the AI prompt accessory view icon. Previously this was falling back to the SF symbol key _faxmachine_.
- Darken the remaining character count element to a `.secondary` colour, which just passes [APCA Bronze](https://www.myndex.com/APCA/), but is still quite a way off passing WCAG 2.1 AA (3.3:1 vs 4.5:1). 
- Changes the remaining character count element to have the `.updatesFrequently` trait, moves the count to the `accessibilityValue` and adds a label that contextualises the value.
- Sets `accessibilitySortPriority` on the contents of the `ScrollView`. Previously, the elements in the scroll view would come last in the traversal order, meaning that a VoiceOver user would move from the disabled _Post_ button in the nav bar to the first of the accessory view icons.
- Changes the `TextView` accessible behaviour to match that of other text inputs: On most text fields, the place holder value is set as the `accessibilityValue` before the user enters text, after which point it is replaced. I also set `accessibilityHidden` on the separate placeholder view, which you can see was also part of the accessibility tree.
- Hides the `AvatarView` from accessibility. There is no functionality associated with it on this screen, so it is effectively decorative. There is no need to display it, even with alt text, as this is the user's own avatar (which they would presumably be familiar with 😅 )
- Changes the `privacyMenu`, moving the current value to `accessibilityValue`, and adding context through a new label and hint.
- Adds `.button` trait and the emoji shortcote as `accessibilityLabel` in the custom emoji picker, which previously offered no way for VoiceOver users to discern what the emoji was.
- Changes the list items in the drafts sheet to be buttons, rather than `Text` + tap gesture.

<small>_All screenshots are from [Reveal](https://www.revealapp.com/)_</small>

## Compose screen, before
<img width="100%" alt="The compose screen VoiceOver element breakdown before the changes in this PR" src="https://user-images.githubusercontent.com/5979418/225807285-68811970-50cf-4f5e-9fd8-d9732fa2eaf5.png">

## Compose screen, After
<img width="100%" alt="The compose screen VoiceOver element breakdown after the changes in this PR" src="https://user-images.githubusercontent.com/5979418/225807350-ec428f57-a32c-42c8-a95b-02d835e00e76.png">

## Custom emoji sheet, before

<img width="100%" alt="The compose custom emoji sheet VoiceOver element breakdown before the changes in this PR" src="https://user-images.githubusercontent.com/5979418/225807421-ed1bfd2f-d63c-4f26-aad0-4d69433265a1.png">

## Custom emoji sheet, after

<img width="100%" alt="The compose custom emoji sheet VoiceOver element breakdown after the changes in this PR" src="https://user-images.githubusercontent.com/5979418/225807481-fc2b343b-2f88-41b3-990b-c4a51ec2576a.png">

