### PR TITLE
Profile tab accessibility uplift

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -519,6 +519,9 @@
 "accessibility.editor.button.language" = "Мова";
 "accessibility.tabs.timeline.add-account" = "Дадаць уліковы запіс";
 "accessibility.app-account.selector.accounts" = "Уліковыя запісы";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -522,6 +522,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Дадатковая інфармацыя";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -519,6 +519,9 @@
 "accessibility.editor.button.language" = "Мова";
 "accessibility.tabs.timeline.add-account" = "Дадаць уліковы запіс";
 "accessibility.app-account.selector.accounts" = "Уліковыя запісы";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Дадатковая інфармацыя";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -530,6 +530,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Дадатковая інфармацыя";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -483,6 +483,7 @@
 "status.show-full-post" = "Show full post";
 "status.summary.at-time" = " а ";
 "status.summary.edited-time" = "Апошняе рэдагаванне:";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld павышаных";
 "status.summary.n-favorites %lld" = "%lld улюбёных";
 "status.visibility.direct" = "Прыватны";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -538,6 +538,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Дадатковая інфармацыя";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -526,6 +526,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -543,6 +543,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Дадатковая інфармацыя";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -538,6 +538,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -522,6 +522,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -528,9 +528,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -545,6 +545,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Дадатковая інфармацыя";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -513,6 +513,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -532,6 +532,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -520,6 +520,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -516,6 +516,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -539,6 +539,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -516,6 +516,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -477,6 +477,7 @@
 "status.show-full-post" = "Show full post";
 "status.summary.at-time" = " a les ";
 "status.summary.edited-time" = "Darrera edició: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld impulsos";
 "status.summary.n-favorites %lld" = "%lld preferits";
 "status.visibility.direct" = "Privat";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -535,6 +535,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -524,6 +524,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -513,6 +513,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -532,6 +532,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -522,9 +522,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -537,6 +537,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -520,6 +520,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Zusätzliche Informationen";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -535,6 +535,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Zusätzliche Informationen";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -533,6 +533,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Zusätzliche Informationen";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -473,6 +473,7 @@
 "status.show-more" = "Mehr anzeigen";
 "status.show-full-post" = "Ganzen Beitrag anzeigen";
 "status.summary.at-time" = " um ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld Boosts";
 "status.summary.n-favorites %lld" = "%lld Favoriten";
 "status.summary.edited-time" = "Zuletzt bearbeitet: ";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -528,6 +528,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -512,6 +512,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -512,6 +512,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Zusätzliche Informationen";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -518,9 +518,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -531,6 +531,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -509,6 +509,9 @@
 "accessibility.editor.button.language" = "Sprache";
 "accessibility.tabs.timeline.add-account" = "Konto hinzufügen";
 "accessibility.app-account.selector.accounts" = "Konten";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Zusätzliche Informationen";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -509,6 +509,9 @@
 "accessibility.editor.button.language" = "Sprache";
 "accessibility.tabs.timeline.add-account" = "Konto hinzufügen";
 "accessibility.app-account.selector.accounts" = "Konten";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -528,6 +528,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Zusätzliche Informationen";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -516,6 +516,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -538,6 +538,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -516,6 +516,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -478,6 +478,7 @@
 "status.show-full-post" = "Show full post";
 "status.summary.at-time" = " at ";
 "status.summary.edited-time" = "Last edited: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld boosts";
 "status.summary.n-favorites %lld" = "%lld favourites";
 "status.visibility.direct" = "Private";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -516,6 +516,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -535,6 +535,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -527,6 +527,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -523,6 +523,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -519,6 +519,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -540,6 +540,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -519,6 +519,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -535,6 +535,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -525,9 +525,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -542,6 +542,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "status.show-full-post" = "Show full post";
 "status.summary.at-time" = " at ";
 "status.summary.edited-time" = "Last edited: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld boosts";
 "status.summary.n-favorites %lld" = "%lld favorites";
 "status.visibility.direct" = "Private";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -541,6 +541,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -537,6 +537,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -534,6 +534,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -526,6 +526,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -534,6 +534,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -524,9 +524,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -518,6 +518,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -518,6 +518,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -539,6 +539,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -522,6 +522,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add Account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -534,6 +534,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Información adicional";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "accessibility.editor.button.language" = "Idioma";
 "accessibility.tabs.timeline.add-account" = "Añadir cuenta";
 "accessibility.app-account.selector.accounts" = "Cuentas";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "status.show-full-post" = "Mostrar publicación completa";
 "status.summary.at-time" = " a las ";
 "status.summary.edited-time" = "Última edición: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld retoots";
 "status.summary.n-favorites %lld" = "%lld favoritos";
 "status.visibility.direct" = "Privado";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -537,6 +537,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -534,6 +534,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -524,9 +524,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -518,6 +518,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -541,6 +541,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Información adicional";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "accessibility.editor.button.language" = "Idioma";
 "accessibility.tabs.timeline.add-account" = "Añadir cuenta";
 "accessibility.app-account.selector.accounts" = "Cuentas";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Información adicional";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -539,6 +539,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Información adicional";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -518,6 +518,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Información adicional";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -522,6 +522,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -526,6 +526,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Información adicional";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -523,6 +523,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazio gehigarria";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazio gehigarria";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -504,6 +504,9 @@
 "accessibility.editor.button.language" = "Hizkuntza";
 "accessibility.tabs.timeline.add-account" = "Gehitu kontua";
 "accessibility.app-account.selector.accounts" = "Kontuak";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -504,6 +504,9 @@
 "accessibility.editor.button.language" = "Hizkuntza";
 "accessibility.tabs.timeline.add-account" = "Gehitu kontua";
 "accessibility.app-account.selector.accounts" = "Kontuak";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazio gehigarria";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -523,6 +523,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -507,6 +507,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -526,6 +526,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -471,6 +471,7 @@
 "status.show-full-post" = "Erakutsi osorik";
 "status.summary.at-time" = " · ";
 "status.summary.edited-time" = "Azkenekoz editatua: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.visibility.direct" = "Aipatutakoak";
 "status.visibility.follower" = "Jarraitzaileak";
 "status.visibility.public" = "Publikoa";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -507,6 +507,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazio gehigarria";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -515,6 +515,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazio gehigarria";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -528,6 +528,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazio gehigarria";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -511,6 +511,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -513,9 +513,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -529,6 +529,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Information supplémentaire";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -534,6 +534,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Information supplémentaire";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -521,6 +521,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Information supplémentaire";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 "status.show-full-post" = "Show full post";
 "status.summary.at-time" = " à ";
 "status.summary.edited-time" = "Dernière modification : ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld boosts";
 "status.summary.n-favorites %lld" = "%lld favoris";
 "status.visibility.direct" = "Privé";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -510,6 +510,9 @@
 "accessibility.editor.button.language" = "Langue";
 "accessibility.tabs.timeline.add-account" = "Ajouter un compte>";
 "accessibility.app-account.selector.accounts" = "Comptes";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -532,6 +532,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -510,6 +510,9 @@
 "accessibility.editor.button.language" = "Langue";
 "accessibility.tabs.timeline.add-account" = "Ajouter un compte>";
 "accessibility.app-account.selector.accounts" = "Comptes";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Information supplémentaire";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -529,6 +529,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -519,9 +519,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -513,6 +513,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Information supplémentaire";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -536,6 +536,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Information supplémentaire";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -517,6 +517,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -513,6 +513,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -517,6 +517,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazioni aggiuntive";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "Lingua";
 "accessibility.tabs.timeline.add-account" = "Aggiungi account";
 "accessibility.app-account.selector.accounts" = "Account";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazioni aggiuntive";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "Lingua";
 "accessibility.tabs.timeline.add-account" = "Aggiungi account";
 "accessibility.app-account.selector.accounts" = "Account";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -538,6 +538,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazioni aggiuntive";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -525,6 +525,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazioni aggiuntive";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -517,6 +517,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -540,6 +540,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazioni aggiuntive";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -536,6 +536,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -523,9 +523,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -533,6 +533,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazioni aggiuntive";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -533,6 +533,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -478,6 +478,7 @@
 "status.show-full-post" = "Mostra il post completo";
 "status.summary.at-time" = " alle ";
 "status.summary.edited-time" = "Ultima modifica: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld condivisioni";
 "status.summary.n-favorites %lld" = "%lld preferiti";
 "status.visibility.direct" = "Privato";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -521,6 +521,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "言語";
 "accessibility.tabs.timeline.add-account" = "アカウントを追加";
 "accessibility.app-account.selector.accounts" = "アカウント";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "追加情報";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -533,6 +533,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "追加情報";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -525,6 +525,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "追加情報";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -478,6 +478,7 @@
 "status.show-full-post" = "投稿をすべて表示";
 "status.summary.at-time" = " ";
 "status.summary.edited-time" = "最新編集日: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld ブースト";
 "status.summary.n-favorites %lld" = "%lld お気に入り";
 "status.visibility.direct" = "指定された相手のみ";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -538,6 +538,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "追加情報";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -517,6 +517,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "言語";
 "accessibility.tabs.timeline.add-account" = "アカウントを追加";
 "accessibility.app-account.selector.accounts" = "アカウント";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -536,6 +536,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -540,6 +540,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "追加情報";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -523,9 +523,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -517,6 +517,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "追加情報";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -533,6 +533,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -521,6 +521,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -538,6 +538,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -519,6 +519,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "추가 정보";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -535,6 +535,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -542,6 +542,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "추가 정보";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -516,6 +516,9 @@
 "accessibility.editor.button.language" = "글 언어 지정";
 "accessibility.tabs.timeline.add-account" = "계정 추가";
 "accessibility.app-account.selector.accounts" = "계정";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -535,6 +535,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "추가 정보";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -480,6 +480,7 @@
 "status.show-full-post" = "전체 내용 보기";
 "status.summary.at-time" = " ";
 "status.summary.edited-time" = "마지막 수정: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "부스트 %lld회";
 "status.summary.n-favorites %lld" = "좋아요 %lld회";
 "status.visibility.direct" = "언급된 사용자만";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -540,6 +540,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "추가 정보";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -523,6 +523,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -516,6 +516,9 @@
 "accessibility.editor.button.language" = "글 언어 지정";
 "accessibility.tabs.timeline.add-account" = "계정 추가";
 "accessibility.app-account.selector.accounts" = "계정";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "추가 정보";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -519,6 +519,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -527,6 +527,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "추가 정보";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -525,9 +525,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -478,6 +478,7 @@
 "status.show-full-post" = "Show full post";
 "status.summary.at-time" = "kl ";
 "status.summary.edited-time" = "Sist redigert: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld forsterkninger";
 "status.summary.n-favorites %lld" = "%lld favoritter";
 "status.visibility.direct" = "Privat";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -540,6 +540,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -538,6 +538,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -517,6 +517,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -525,6 +525,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -517,6 +517,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -536,6 +536,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -523,9 +523,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -533,6 +533,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -533,6 +533,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -521,6 +521,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -533,6 +533,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -511,6 +511,9 @@
 "accessibility.editor.button.language" = "Taal";
 "accessibility.tabs.timeline.add-account" = "Voeg account toe";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -511,6 +511,9 @@
 "accessibility.editor.button.language" = "Taal";
 "accessibility.tabs.timeline.add-account" = "Voeg account toe";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Aanvullende informatie";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Aanvullende informatie";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -472,6 +472,7 @@
 "status.show-full-post" = "Toon volledige post";
 "status.summary.at-time" = " om ";
 "status.summary.edited-time" = "Laatst gewijzigd: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld boosts";
 "status.summary.n-favorites %lld" = "%lld favorieten";
 "status.visibility.direct" = "Direct bericht";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -522,6 +522,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Aanvullende informatie";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -537,6 +537,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Aanvullende informatie";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -520,9 +520,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -535,6 +535,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Aanvullende informatie";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -518,6 +518,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -530,6 +530,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Aanvullende informatie";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -530,6 +530,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -506,6 +506,9 @@
 "accessibility.editor.button.language" = "Język";
 "accessibility.tabs.timeline.add-account" = "Dodaj konto";
 "accessibility.app-account.selector.accounts" = "Konta";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Informacja dodatkowa";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -517,6 +517,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Informacja dodatkowa";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -472,6 +472,7 @@
 "status.show-full-post" = "Pokaż cały post";
 "status.summary.at-time" = " o ";
 "status.summary.edited-time" = "Ostatnia edycja: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.visibility.direct" = "Post bezpośredni";
 "status.visibility.follower" = "Tylko obserwujący";
 "status.visibility.public" = "Publiczny";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -513,6 +513,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -530,6 +530,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Informacja dodatkowa";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -509,6 +509,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Informacja dodatkowa";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -515,9 +515,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -525,6 +525,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -506,6 +506,9 @@
 "accessibility.editor.button.language" = "Język";
 "accessibility.tabs.timeline.add-account" = "Dodaj konto";
 "accessibility.app-account.selector.accounts" = "Konta";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -525,6 +525,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Informacja dodatkowa";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -509,6 +509,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -528,6 +528,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -532,6 +532,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Informacja dodatkowa";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -517,6 +517,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Informação Adicional";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -533,6 +533,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Informação Adicional";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -478,6 +478,7 @@
 "status.show-full-post" = "Show full post";
 "status.summary.at-time" = " as ";
 "status.summary.edited-time" = "Última edição: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld boosts";
 "status.summary.n-favorites %lld" = "%lld favoritos";
 "status.visibility.direct" = "Privado";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "Idioma";
 "accessibility.tabs.timeline.add-account" = "Adicionar conta";
 "accessibility.app-account.selector.accounts" = "Contas";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Informação Adicional";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -540,6 +540,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Informação Adicional";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "Idioma";
 "accessibility.tabs.timeline.add-account" = "Adicionar conta";
 "accessibility.app-account.selector.accounts" = "Contas";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -517,6 +517,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -536,6 +536,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -523,9 +523,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -533,6 +533,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -521,6 +521,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -525,6 +525,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Informação Adicional";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -538,6 +538,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Informação Adicional";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -540,6 +540,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -538,6 +538,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -517,6 +517,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -525,6 +525,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 "status.show-full-post" = "Show full post";
 "status.summary.at-time" = " de ";
 "status.summary.edited-time" = "Son düzenleme: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld yükseltmeler";
 "status.summary.n-favorites %lld" = "%lld favoriler";
 "status.visibility.direct" = "Gizli";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -517,6 +517,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -536,6 +536,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -523,9 +523,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -514,6 +514,9 @@
 "accessibility.editor.button.language" = "Language";
 "accessibility.tabs.timeline.add-account" = "Add account";
 "accessibility.app-account.selector.accounts" = "Accounts";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -533,6 +533,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -533,6 +533,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -521,6 +521,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -518,6 +518,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "Додаткова інформація";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "accessibility.editor.button.language" = "Мова";
 "accessibility.tabs.timeline.add-account" = "Додати профіль";
 "accessibility.app-account.selector.accounts" = "Профілі";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -541,6 +541,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "Додаткова інформація";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -534,6 +534,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "Додаткова інформація";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -537,6 +537,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -534,6 +534,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -526,6 +526,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "Додаткова інформація";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -524,9 +524,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -518,6 +518,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "accessibility.editor.button.language" = "Мова";
 "accessibility.tabs.timeline.add-account" = "Додати профіль";
 "accessibility.app-account.selector.accounts" = "Профілі";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "Додаткова інформація";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -539,6 +539,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "Додаткова інформація";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -522,6 +522,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "status.show-full-post" = "Показати весь допис";
 "status.summary.at-time" = " о ";
 "status.summary.edited-time" = "Востаннє змінено: ";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld поширень";
 "status.summary.n-favorites %lld" = "%lld вподобань";
 "status.visibility.direct" = "Особисте";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -538,6 +538,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -516,6 +516,9 @@
 "accessibility.editor.button.language" = "选择语言";
 "accessibility.tabs.timeline.add-account" = "添加账户";
 "accessibility.app-account.selector.accounts" = "账户";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "附加信息";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -519,6 +519,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "附加信息";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -535,6 +535,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -535,6 +535,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "附加信息";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -516,6 +516,9 @@
 "accessibility.editor.button.language" = "选择语言";
 "accessibility.tabs.timeline.add-account" = "添加账户";
 "accessibility.app-account.selector.accounts" = "账户";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -477,6 +477,7 @@
 "status.show-full-post" = "显示全文";
 "status.summary.at-time" = " 在 ";
 "status.summary.edited-time" = "上次编辑：";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld 转发";
 "status.summary.n-favorites %lld" = "%lld 喜欢";
 "status.visibility.direct" = "私密";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -542,6 +542,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "附加信息";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -523,6 +523,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -519,6 +519,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -527,6 +527,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "附加信息";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -525,9 +525,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -540,6 +540,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "附加信息";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -534,6 +534,7 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report
 "report.comment.placeholder" = "附加資訊";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "accessibility.editor.button.language" = "語言";
 "accessibility.tabs.timeline.add-account" = "新增帳號";
 "accessibility.app-account.selector.accounts" = "帳號";
+"accessibility.tabs.profile.options.label" = "Options";
+"accessibility.tabs.profile.options.inputLabel1" = "Settings";
+"accessibility.tabs.profile.options.inputLabel2" = "More";
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -537,6 +537,7 @@
 "accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
 "accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
+"accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -534,6 +534,9 @@
 "accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
 "accessibility.tabs.profile.picker.media" = "Media";
 "accessibility.tabs.profile.picker.lists" = "Lists";
+"accessibility.tabs.profile.user-notifications.label" = "Receive notifications";
+"accessibility.tabs.profile.user-reblogs.label" = "Display boosts";
+"accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.status.spoiler-full-content" = "Full Content";
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -539,6 +539,8 @@
 "accessibility.tabs.profile.fields.verified.label" = "Verified";
 "accessibility.tabs.profile.fields.container.label" = "User-defined fields";
 "accessibility.status.spoiler-full-content" = "Full Content";
+"accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
+"accessibility.status.a-replied-to-%@" = "%@ replied to";
 
 // MARK: Report
 "report.comment.placeholder" = "附加資訊";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -524,9 +524,9 @@
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
-"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
-"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
-"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list.";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list.";
 "accessibility.tabs.profile.picker.statuses" = "Posts";
 "accessibility.tabs.profile.picker.favorites" = "Favorites";
 "accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -518,6 +518,8 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.header-image.label" = "Header image";
+"accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "status.show-full-post" = "顯示全文";
 "status.summary.at-time" = " 於 ";
 "status.summary.edited-time" = "上次編輯：";
+"status.summary.n-replies %lld" = "%lld replies";
 "status.summary.n-boosts %lld" = "%lld 轉嘟";
 "status.summary.n-favorites %lld" = "%lld 最愛";
 "status.visibility.direct" = "私訊";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -522,6 +522,10 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.user.account-bot.label" = "Bot account";
+"accessibility.tabs.profile.user.account-blocked.label" = "Blocked";
+"accessibility.tabs.profile.user.account-muted.label" = "Muted";
+"accessibility.tabs.profile.user.account-private.label" = "Private account";
 "accessibility.tabs.profile.header-image.label" = "Header image";
 "accessibility.tabs.profile.header-image.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list.";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -541,6 +541,8 @@
 "accessibility.status.spoiler-full-content" = "Full Content";
 "accessibility.status.a-boosted-b-%@-%@" = "%@ boosted %@";
 "accessibility.status.a-replied-to-%@" = "%@ replied to";
+"accessibility.image.alt-text-%@" = "Image alt text: %@";
+"accessibility.image.alt-text-more.label" = "More alt text available";
 
 // MARK: Report
 "report.comment.placeholder" = "附加資訊";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -526,6 +526,13 @@
 "accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
 "accessibility.tabs.profile.following-count.hint" = "Navigates to list";
 "accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.picker.statuses" = "Posts";
+"accessibility.tabs.profile.picker.favorites" = "Favorites";
+"accessibility.tabs.profile.picker.bookmarks" = "Bookmarks";
+"accessibility.tabs.profile.picker.followed-tags" = "Tags";
+"accessibility.tabs.profile.picker.posts-and-replies" = "Posts and replies";
+"accessibility.tabs.profile.picker.media" = "Media";
+"accessibility.tabs.profile.picker.lists" = "Lists";
 
 // MARK: Report
 "report.comment.placeholder" = "附加資訊";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "accessibility.editor.button.language" = "語言";
 "accessibility.tabs.timeline.add-account" = "新增帳號";
 "accessibility.app-account.selector.accounts" = "帳號";
+"accessibility.tabs.profile.user-avatar.label" = "Profile photo";
+"accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
+"accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
 
 // MARK: Report
 "report.comment.placeholder" = "附加資訊";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -518,6 +518,9 @@
 "accessibility.tabs.profile.user-avatar.label" = "Profile photo";
 "accessibility.tabs.profile.user-avatar.hint" = "Displays a larger version.";
 "accessibility.tabs.profile.user-avatar.supporter.label" = "Supporter";
+"accessibility.tabs.profile.post-count.hint" = "Scrolls to list";
+"accessibility.tabs.profile.following-count.hint" = "Navigates to list";
+"accessibility.tabs.profile.follower-count.hint" = "Navigates to list";
 
 // MARK: Report
 "report.comment.placeholder" = "附加資訊";

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -165,6 +165,7 @@ struct AccountDetailHeaderView: View {
               .foregroundColor(theme.labelColor)
               .emojiSize(Font.scaledHeadlineFont.emojiSize)
               .emojiBaselineOffset(Font.scaledHeadlineFont.emojiBaselineOffset)
+              .accessibilityAddTraits(.isHeader)
             if account.bot {
               Text(Image(systemName: "poweroutlet.type.b.fill"))
                 .font(.footnote)

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -45,43 +45,48 @@ struct AccountDetailHeaderView: View {
   }
 
   private var headerImageView: some View {
-    ZStack(alignment: .bottomTrailing) {
-      if reasons.contains(.placeholder) {
-        Rectangle()
-          .foregroundColor(theme.secondaryBackgroundColor)
-          .frame(height: Constants.headerHeight)
-      } else {
-        LazyImage(url: account.header) { state in
-          if let image = state.image {
-            image
-              .resizable()
-              .aspectRatio(contentMode: .fill)
-              .overlay(account.haveHeader ? .black.opacity(0.50) : .clear)
-              .frame(height: Constants.headerHeight)
-              .clipped()
-          } else if state.isLoading {
-            theme.secondaryBackgroundColor
-              .frame(height: Constants.headerHeight)
-              .shimmering()
-          } else {
-            theme.secondaryBackgroundColor
-              .frame(height: Constants.headerHeight)
-          }
-        }
-        .frame(height: Constants.headerHeight)
-      }
-    }
-    .background(theme.secondaryBackgroundColor)
-    .frame(height: Constants.headerHeight)
-    .contentShape(Rectangle())
-    .onTapGesture {
+    Button {
       guard account.haveHeader else {
         return
       }
       Task {
         await quickLook.prepareFor(urls: [account.header], selectedURL: account.header)
       }
+    } label: {
+      ZStack(alignment: .bottomTrailing) {
+        if reasons.contains(.placeholder) {
+          Rectangle()
+            .foregroundColor(theme.secondaryBackgroundColor)
+            .frame(height: Constants.headerHeight)
+        } else {
+          LazyImage(url: account.header) { state in
+            if let image = state.image {
+              image
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .overlay(account.haveHeader ? .black.opacity(0.50) : .clear)
+                .frame(height: Constants.headerHeight)
+                .clipped()
+            } else if state.isLoading {
+              theme.secondaryBackgroundColor
+                .frame(height: Constants.headerHeight)
+                .shimmering()
+            } else {
+              theme.secondaryBackgroundColor
+                .frame(height: Constants.headerHeight)
+            }
+          }
+          .frame(height: Constants.headerHeight)
+        }
+      }
+      .background(theme.secondaryBackgroundColor)
+      .frame(height: Constants.headerHeight)
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityAddTraits(.isImage)
+    .accessibilityLabel("accessibility.tabs.profile.header-image.label")
+    .accessibilityHint("accessibility.tabs.profile.header-image.hint")
+    .accessibilityHidden(account.haveHeader == false)
   }
 
   private var accountAvatarView: some View {

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -324,7 +324,7 @@ struct AccountDetailHeaderView: View {
             Spacer()
           }
           .accessibilityElement(children: .combine)
-          .modifier(ConditionalUserDefinedFieldAccessibilityActionModifier(string: field.value, routerPath: routerPath))
+          .modifier(ConditionalUserDefinedFieldAccessibilityActionModifier(field: field, routerPath: routerPath))
         }
       }
       .padding(8)
@@ -343,11 +343,11 @@ struct AccountDetailHeaderView: View {
 /// A ``ViewModifier`` that creates a attaches an accessibility action if the field value is a valid link
 private struct ConditionalUserDefinedFieldAccessibilityActionModifier: ViewModifier {
 
-  let string: HTMLString
+  let field: Account.Field
   let routerPath: RouterPath
 
   func body(content: Content) -> some View {
-    if let url = URL(string: string.asRawText), UIApplication.shared.canOpenURL(url) {
+    if let url = URL(string: field.value.asRawText), UIApplication.shared.canOpenURL(url) {
       content
         .accessibilityAction {
           let _ = routerPath.handle(url: url)
@@ -355,6 +355,7 @@ private struct ConditionalUserDefinedFieldAccessibilityActionModifier: ViewModif
         // SwiftUI will automatically decorate this element with the link trait, so we remove the button trait manually.
         // March 18th, 2023: The button trait is still re-applied…
         .accessibilityRemoveTraits(.isButton)
+        .accessibilityInputLabels([field.name])
     } else {
       content
         // This element is not interactive; setting this property removes its button trait

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -165,21 +165,31 @@ struct AccountDetailHeaderView: View {
               .emojiSize(Font.scaledHeadlineFont.emojiSize)
               .emojiBaselineOffset(Font.scaledHeadlineFont.emojiBaselineOffset)
               .accessibilityAddTraits(.isHeader)
+
+            // The views here are wrapped in ZStacks as a Text(Image) does not provide an `accessibilityLabel`.
             if account.bot {
-              Text(Image(systemName: "poweroutlet.type.b.fill"))
-                .font(.footnote)
+              ZStack {
+                Text(Image(systemName: "poweroutlet.type.b.fill"))
+                  .font(.footnote)
+              }.accessibilityLabel("accessibility.tabs.profile.user.account-bot.label")
             }
             if account.locked {
-              Text(Image(systemName: "lock.fill"))
-                .font(.footnote)
+              ZStack {
+                Text(Image(systemName: "lock.fill"))
+                  .font(.footnote)
+              }.accessibilityLabel("accessibility.tabs.profile.user.account-private.label")
             }
             if viewModel.relationship?.blocking == true {
-              Text(Image(systemName: "person.crop.circle.badge.xmark.fill"))
-                .font(.footnote)
+              ZStack {
+                Text(Image(systemName: "person.crop.circle.badge.xmark.fill"))
+                  .font(.footnote)
+              }.accessibilityLabel("accessibility.tabs.profile.user.account-blocked.label")
             }
             if viewModel.relationship?.muting == true {
-              Text(Image(systemName: "speaker.slash.fill"))
-                .font(.footnote)
+              ZStack {
+                Text(Image(systemName: "speaker.slash.fill"))
+                  .font(.footnote)
+              }.accessibilityLabel("accessibility.tabs.profile.user.account-muted.label")
             }
           }
           Text("@\(account.acct)")

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -86,25 +86,33 @@ struct AccountDetailHeaderView: View {
 
   private var accountAvatarView: some View {
     HStack {
-      ZStack(alignment: .topTrailing) {
-        AvatarView(url: account.avatar, size: .account)
-          .onTapGesture {
-            guard account.haveAvatar else {
-              return
-            }
-            Task {
-              await quickLook.prepareFor(urls: [account.avatar], selectedURL: account.avatar)
-            }
+      Button {
+        guard account.haveAvatar else {
+          return
+        }
+        Task {
+          await quickLook.prepareFor(urls: [account.avatar], selectedURL: account.avatar)
+        }
+      } label: {
+        ZStack(alignment: .topTrailing) {
+          AvatarView(url: account.avatar, size: .account)
+            .accessibilityLabel("accessibility.tabs.profile.user-avatar.label")
+          if viewModel.isCurrentUser, isSupporter {
+            Image(systemName: "checkmark.seal.fill")
+              .resizable()
+              .frame(width: 25, height: 25)
+              .foregroundColor(theme.tintColor)
+              .offset(x: theme.avatarShape == .circle ? 0 : 10,
+                      y: theme.avatarShape == .circle ? 0 : -10)
+              .accessibilityRemoveTraits(.isSelected)
+              .accessibilityLabel("accessibility.tabs.profile.user-avatar.supporter.label")
           }
-        if viewModel.isCurrentUser, isSupporter {
-          Image(systemName: "checkmark.seal.fill")
-            .resizable()
-            .frame(width: 25, height: 25)
-            .foregroundColor(theme.tintColor)
-            .offset(x: theme.avatarShape == .circle ? 0 : 10,
-                    y: theme.avatarShape == .circle ? 0 : -10)
         }
       }
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(.isImage)
+      .accessibilityHint("accessibility.tabs.profile.user-avatar.hint")
+      .accessibilityHidden(account.haveAvatar == false)
       Spacer()
       Group {
         Button {

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -188,7 +188,7 @@ struct AccountDetailHeaderView: View {
             .textSelection(.enabled)
             .accessibilityRespondsToUserInteraction(false)
           joinedAtView
-        }
+        }.accessibilityElement(children: .contain)
         Spacer()
         if let relationship = viewModel.relationship, !viewModel.isCurrentUser {
           HStack {
@@ -294,6 +294,7 @@ struct AccountDetailHeaderView: View {
                 if field.verifiedAt != nil {
                   Image(systemName: "checkmark.seal")
                     .foregroundColor(Color.green.opacity(0.80))
+                    .accessibilityHidden(true)
                 }
                 EmojiTextApp(field.value, emojis: viewModel.account?.emojis ?? [])
                   .emojiSize(Font.scaledBodyFont.emojiSize)
@@ -302,6 +303,7 @@ struct AccountDetailHeaderView: View {
                   .environment(\.openURL, OpenURLAction { url in
                     routerPath.handle(url: url)
                   })
+                  .accessibilityValue(field.verifiedAt != nil ? "accessibility.tabs.profile.fields.verified.label" : "")
               }
               .font(.scaledBody)
               if viewModel.fields.last != field {
@@ -311,6 +313,7 @@ struct AccountDetailHeaderView: View {
             }
             Spacer()
           }
+          .accessibilityElement(children: .combine)
         }
       }
       .padding(8)

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -122,6 +122,7 @@ struct AccountDetailHeaderView: View {
         } label: {
           makeCustomInfoLabel(title: "account.posts", count: account.statusesCount)
         }
+        .accessibilityHint("accessibility.tabs.profile.post-count.hint")
         .buttonStyle(.borderless)
 
         Button {
@@ -129,6 +130,7 @@ struct AccountDetailHeaderView: View {
         } label: {
           makeCustomInfoLabel(title: "account.following", count: account.followingCount)
         }
+        .accessibilityHint("accessibility.tabs.profile.following-count.hint")
         .buttonStyle(.borderless)
 
         Button {
@@ -140,6 +142,7 @@ struct AccountDetailHeaderView: View {
             needsBadge: currentAccount.account?.id == account.id && !currentAccount.followRequests.isEmpty
           )
         }
+        .accessibilityHint("accessibility.tabs.profile.follower-count.hint")
         .buttonStyle(.borderless)
 
       }.offset(y: 20)
@@ -233,6 +236,9 @@ struct AccountDetailHeaderView: View {
         .font(.scaledFootnote)
         .foregroundColor(.gray)
     }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(title)
+    .accessibilityValue("\(count)")
   }
 
   @ViewBuilder

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -232,12 +232,14 @@ struct AccountDetailHeaderView: View {
     if let joinedAt = viewModel.account?.createdAt.asDate {
       HStack(spacing: 4) {
         Image(systemName: "calendar")
+          .accessibilityHidden(true)
         Text("account.joined")
         Text(joinedAt, style: .date)
       }
       .foregroundColor(.gray)
       .font(.footnote)
       .padding(.top, 6)
+      .accessibilityElement(children: .combine)
     }
   }
 

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -45,45 +45,44 @@ struct AccountDetailHeaderView: View {
   }
 
   private var headerImageView: some View {
-    Button {
+    ZStack(alignment: .bottomTrailing) {
+      if reasons.contains(.placeholder) {
+        Rectangle()
+          .foregroundColor(theme.secondaryBackgroundColor)
+          .frame(height: Constants.headerHeight)
+      } else {
+        LazyImage(url: account.header) { state in
+          if let image = state.image {
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+              .overlay(account.haveHeader ? .black.opacity(0.50) : .clear)
+              .frame(height: Constants.headerHeight)
+              .clipped()
+          } else if state.isLoading {
+            theme.secondaryBackgroundColor
+              .frame(height: Constants.headerHeight)
+              .shimmering()
+          } else {
+            theme.secondaryBackgroundColor
+              .frame(height: Constants.headerHeight)
+          }
+        }
+        .frame(height: Constants.headerHeight)
+      }
+    }
+    .background(theme.secondaryBackgroundColor)
+    .frame(height: Constants.headerHeight)
+    .onTapGesture {
       guard account.haveHeader else {
         return
       }
       Task {
         await quickLook.prepareFor(urls: [account.header], selectedURL: account.header)
       }
-    } label: {
-      ZStack(alignment: .bottomTrailing) {
-        if reasons.contains(.placeholder) {
-          Rectangle()
-            .foregroundColor(theme.secondaryBackgroundColor)
-            .frame(height: Constants.headerHeight)
-        } else {
-          LazyImage(url: account.header) { state in
-            if let image = state.image {
-              image
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .overlay(account.haveHeader ? .black.opacity(0.50) : .clear)
-                .frame(height: Constants.headerHeight)
-                .clipped()
-            } else if state.isLoading {
-              theme.secondaryBackgroundColor
-                .frame(height: Constants.headerHeight)
-                .shimmering()
-            } else {
-              theme.secondaryBackgroundColor
-                .frame(height: Constants.headerHeight)
-            }
-          }
-          .frame(height: Constants.headerHeight)
-        }
-      }
-      .background(theme.secondaryBackgroundColor)
-      .frame(height: Constants.headerHeight)
     }
     .accessibilityElement(children: .combine)
-    .accessibilityAddTraits(.isImage)
+    .accessibilityAddTraits([.isImage, .isButton])
     .accessibilityLabel("accessibility.tabs.profile.header-image.label")
     .accessibilityHint("accessibility.tabs.profile.header-image.hint")
     .accessibilityHidden(account.haveHeader == false)
@@ -91,33 +90,33 @@ struct AccountDetailHeaderView: View {
 
   private var accountAvatarView: some View {
     HStack {
-      Button {
+      ZStack(alignment: .topTrailing) {
+        AvatarView(url: account.avatar, size: .account)
+          .accessibilityLabel("accessibility.tabs.profile.user-avatar.label")
+        if viewModel.isCurrentUser, isSupporter {
+          Image(systemName: "checkmark.seal.fill")
+            .resizable()
+            .frame(width: 25, height: 25)
+            .foregroundColor(theme.tintColor)
+            .offset(x: theme.avatarShape == .circle ? 0 : 10,
+                    y: theme.avatarShape == .circle ? 0 : -10)
+            .accessibilityRemoveTraits(.isSelected)
+            .accessibilityLabel("accessibility.tabs.profile.user-avatar.supporter.label")
+        }
+      }
+      .onTapGesture {
         guard account.haveAvatar else {
           return
         }
         Task {
           await quickLook.prepareFor(urls: [account.avatar], selectedURL: account.avatar)
         }
-      } label: {
-        ZStack(alignment: .topTrailing) {
-          AvatarView(url: account.avatar, size: .account)
-            .accessibilityLabel("accessibility.tabs.profile.user-avatar.label")
-          if viewModel.isCurrentUser, isSupporter {
-            Image(systemName: "checkmark.seal.fill")
-              .resizable()
-              .frame(width: 25, height: 25)
-              .foregroundColor(theme.tintColor)
-              .offset(x: theme.avatarShape == .circle ? 0 : 10,
-                      y: theme.avatarShape == .circle ? 0 : -10)
-              .accessibilityRemoveTraits(.isSelected)
-              .accessibilityLabel("accessibility.tabs.profile.user-avatar.supporter.label")
-          }
-        }
       }
       .accessibilityElement(children: .combine)
-      .accessibilityAddTraits(.isImage)
+      .accessibilityAddTraits([.isImage, .isButton])
       .accessibilityHint("accessibility.tabs.profile.user-avatar.hint")
       .accessibilityHidden(account.haveAvatar == false)
+
       Spacer()
       Group {
         Button {

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -315,6 +315,7 @@ struct AccountDetailHeaderView: View {
             Spacer()
           }
           .accessibilityElement(children: .combine)
+          .modifier(ConditionalUserDefinedFieldAccessibilityActionModifier(string: field.value, routerPath: routerPath))
         }
       }
       .padding(8)
@@ -324,6 +325,29 @@ struct AccountDetailHeaderView: View {
         RoundedRectangle(cornerRadius: 4)
           .stroke(.gray.opacity(0.35), lineWidth: 1)
       )
+    }
+  }
+}
+
+/// A ``ViewModifier`` that creates a attaches an accessibility action if the field value is a valid link
+private struct ConditionalUserDefinedFieldAccessibilityActionModifier: ViewModifier {
+
+  let string: HTMLString
+  let routerPath: RouterPath
+
+  func body(content: Content) -> some View {
+    if let url = URL(string: string.asRawText), UIApplication.shared.canOpenURL(url) {
+      content
+        .accessibilityAction {
+          let _ = routerPath.handle(url: url)
+        }
+        // SwiftUI will automatically decorate this element with the link trait, so we remove the button trait manually.
+        // March 18th, 2023: The button trait is still re-applied…
+        .accessibilityRemoveTraits(.isButton)
+    } else {
+      content
+        // This element is not interactive; setting this property removes its button trait
+        .accessibilityRespondsToUserInteraction(false)
     }
   }
 }

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -186,6 +186,7 @@ struct AccountDetailHeaderView: View {
             .font(.scaledCallout)
             .foregroundColor(.gray)
             .textSelection(.enabled)
+            .accessibilityRespondsToUserInteraction(false)
           joinedAtView
         }
         Spacer()
@@ -217,6 +218,7 @@ struct AccountDetailHeaderView: View {
         .environment(\.openURL, OpenURLAction { url in
           routerPath.handle(url: url)
         })
+        .accessibilityRespondsToUserInteraction(false)
 
       fieldsView
     }

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -319,6 +319,8 @@ struct AccountDetailHeaderView: View {
         }
       }
       .padding(8)
+      .accessibilityElement(children: .contain)
+      .accessibilityLabel("accessibility.tabs.profile.fields.container.label")
       .background(theme.secondaryBackgroundColor)
       .cornerRadius(4)
       .overlay(

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -194,6 +194,7 @@ public struct AccountDetailView: View {
         Text("account.detail.familiar-followers")
           .font(.scaledHeadline)
           .padding(.leading, .layoutPadding)
+          .accessibilityAddTraits(.isHeader)
         ScrollView(.horizontal, showsIndicators: false) {
           LazyHStack(spacing: 0) {
             ForEach(viewModel.familiarFollowers) { account in

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -198,11 +198,14 @@ public struct AccountDetailView: View {
         ScrollView(.horizontal, showsIndicators: false) {
           LazyHStack(spacing: 0) {
             ForEach(viewModel.familiarFollowers) { account in
-              AvatarView(url: account.avatar, size: .badge)
-                .onTapGesture {
-                  routerPath.navigate(to: .accountDetailWithAccount(account: account))
-                }
-                .padding(.leading, -4)
+              Button {
+                routerPath.navigate(to: .accountDetailWithAccount(account: account))
+              } label: {
+                AvatarView(url: account.avatar, size: .badge)
+                  .padding(.leading, -4)
+                  .accessibilityLabel(account.safeDisplayName)
+
+              }.accessibilityAddTraits(.isImage)
             }
           }
           .padding(.leading, .layoutPadding + 4)

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -353,6 +353,12 @@ public struct AccountDetailView: View {
         }
       } label: {
         Image(systemName: "ellipsis.circle")
+          .accessibilityLabel("accessibility.tabs.profile.options.label")
+          .accessibilityInputLabels([
+            LocalizedStringKey("accessibility.tabs.profile.options.label"),
+            LocalizedStringKey("accessibility.tabs.profile.options.inputLabel1"),
+            LocalizedStringKey("accessibility.tabs.profile.options.inputLabel2")
+          ])
       }
     }
   }

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -281,6 +281,7 @@ public struct AccountDetailView: View {
   private var pinnedPostsView: some View {
     if !viewModel.pinned.isEmpty {
       Label("account.post.pinned", systemImage: "pin.fill")
+        .accessibilityAddTraits(.isHeader)
         .font(.scaledFootnote)
         .foregroundColor(.gray)
         .fontWeight(.semibold)

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -55,6 +55,7 @@ public struct AccountDetailView: View {
           { tab in
             Image(systemName: tab.iconName)
               .tag(tab)
+              .accessibilityLabel(tab.accessibilityLabel)
           }
         }
         .pickerStyle(.segmented)

--- a/Packages/Account/Sources/Account/AccountDetailViewModel.swift
+++ b/Packages/Account/Sources/Account/AccountDetailViewModel.swift
@@ -36,6 +36,18 @@ class AccountDetailViewModel: ObservableObject, StatusesFetcher {
       case .lists: return "list.bullet"
       }
     }
+
+    var accessibilityLabel: LocalizedStringKey {
+      switch self {
+        case .statuses: return "accessibility.tabs.profile.picker.statuses"
+        case .favorites: return "accessibility.tabs.profile.picker.favorites"
+        case .bookmarks: return "accessibility.tabs.profile.picker.bookmarks"
+        case .followedTags: return "accessibility.tabs.profile.picker.followed-tags"
+        case .postsAndReplies: return "accessibility.tabs.profile.picker.posts-and-replies"
+        case .media: return "accessibility.tabs.profile.picker.media"
+        case .lists: return "accessibility.tabs.profile.picker.lists"
+      }
+    }
   }
 
   enum TabState {

--- a/Packages/Account/Sources/Account/Follow/FollowButton.swift
+++ b/Packages/Account/Sources/Account/Follow/FollowButton.swift
@@ -97,6 +97,9 @@ public struct FollowButton: View {
           Text("account.follow.requested")
         } else {
           Text(viewModel.relationship.following ? "account.follow.following" : "account.follow.follow")
+            .accessibilityRepresentation {
+              Toggle("account.follow.following", isOn: .constant(viewModel.relationship.following))
+            }
         }
       }
       if viewModel.relationship.following,
@@ -109,6 +112,8 @@ public struct FollowButton: View {
             }
           } label: {
             Image(systemName: viewModel.relationship.notifying ? "bell.fill" : "bell")
+          }.accessibilityRepresentation {
+            Toggle("accessibility.tabs.profile.user-notifications.label", isOn: .constant(viewModel.relationship.notifying))
           }
           Button {
             Task {
@@ -116,6 +121,8 @@ public struct FollowButton: View {
             }
           } label: {
             Image(viewModel.relationship.showingReblogs ? "Rocket.Fill" : "Rocket")
+          }.accessibilityRepresentation {
+            Toggle("accessibility.tabs.profile.user-reblogs.label", isOn: .constant(viewModel.relationship.showingReblogs))
           }
         }
       }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -248,12 +248,12 @@ private struct ConditionalAccessibilityLabelModifier: ViewModifier {
     Text(hasSpoiler
       ? viewModel.finalStatus.spoilerText.asRawText
       : viewModel.finalStatus.content.asRawText
-    ) + Text(" ") +
+    ) + Text(", ") +
     Text(hasSpoiler
       ? "status.editor.spoiler"
       : ""
-    ) + Text(" ") +
-    imageAltText() + Text(" ") +
+    ) + Text(", ") +
+    imageAltText() + Text(", ") +
     Text(viewModel.finalStatus.createdAt.relativeFormatted) + Text(", ") +
     Text("status.summary.n-replies \(viewModel.finalStatus.repliesCount)") + Text(", ") +
     Text("status.summary.n-boosts \(viewModel.finalStatus.reblogsCount)") + Text(", ") +
@@ -265,9 +265,9 @@ private struct ConditionalAccessibilityLabelModifier: ViewModifier {
       case (true, false):
         return Text("accessibility.status.a-replied-to-\(finalUserDisplayName())") + Text(" ")
       case (_, true):
-        return Text("accessibility.status.a-boosted-b-\(userDisplayName())-\(finalUserDisplayName())")  + Text(" ")
+        return Text("accessibility.status.a-boosted-b-\(userDisplayName())-\(finalUserDisplayName())")  + Text(", ")
       default:
-        return Text(userDisplayName()) + Text(" ")
+        return Text(userDisplayName()) + Text(", ")
     }
   }
 

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -216,7 +216,6 @@ private struct ConditionalAccessibilityLabelModifier: ViewModifier {
     viewModel.displaySpoiler && viewModel.finalStatus.spoilerText.asRawText.isEmpty == false
   }
 
-  // viewModel.finalStatus.spoilerText.asRawText
   func body(content: Content) -> some View {
     if setLabel {
       if hasSpoiler {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -116,7 +116,7 @@ public struct StatusRowView: View {
     .accessibilityElement(children: viewModel.isFocused ? .contain : .combine)
     .accessibilityActions {
       if UIAccessibility.isVoiceOverRunning {
-        accesibilityActions
+        accessibilityActions
       }
     }
     .background {
@@ -155,7 +155,7 @@ public struct StatusRowView: View {
   }
 
   @ViewBuilder
-  private var accesibilityActions: some View {
+  private var accessibilityActions: some View {
     // Add the individual mentions as accessibility actions
     ForEach(viewModel.status.mentions, id: \.id) { mention in
       Button("@\(mention.username)") {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -253,6 +253,7 @@ private struct ConditionalAccessibilityLabelModifier: ViewModifier {
       ? "status.editor.spoiler"
       : ""
     ) + Text(" ") +
+    imageAltText() + Text(" ") +
     Text(viewModel.finalStatus.createdAt.relativeFormatted) + Text(", ") +
     Text("status.summary.n-replies \(viewModel.finalStatus.repliesCount)") + Text(", ") +
     Text("status.summary.n-boosts \(viewModel.finalStatus.reblogsCount)") + Text(", ") +
@@ -280,5 +281,18 @@ private struct ConditionalAccessibilityLabelModifier: ViewModifier {
     viewModel.finalStatus.account.displayNameWithoutEmojis.count < 4
       ? viewModel.finalStatus.account.safeDisplayName
       : viewModel.finalStatus.account.displayNameWithoutEmojis
+  }
+
+  func imageAltText() -> Text {
+    let descriptions = viewModel.finalStatus.mediaAttachments
+      .compactMap(\.description)
+
+    if descriptions.count == 1 {
+      return Text("accessibility.image.alt-text-\(descriptions[0])")
+    } else if descriptions.count > 1 {
+      return Text("accessibility.image.alt-text-\(descriptions[0])") + Text(", ") + Text("accessibility.image.alt-text-more.label")
+    } else {
+      return Text("")
+    }
   }
 }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -97,12 +97,14 @@ public struct StatusRowView: View {
       contextMenu
     }
     .swipeActions(edge: .trailing) {
-      if !isCompact {
+      // The actions associated with the swipes are exposed as custom accessibility actions and there is no way to remove them.
+      if !isCompact, UIAccessibility.isVoiceOverRunning == false {
         StatusRowSwipeView(viewModel: viewModel, mode: .trailing)
       }
     }
     .swipeActions(edge: .leading) {
-      if !isCompact {
+      // The actions associated with the swipes are exposed as custom accessibility actions and there is no way to remove them.
+      if !isCompact, UIAccessibility.isVoiceOverRunning == false {
         StatusRowSwipeView(viewModel: viewModel, mode: .leading)
       }
     }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -115,9 +115,7 @@ public struct StatusRowView: View {
       viewModel.navigateToDetail()
     }
     .accessibilityActions {
-      if UIAccessibility.isVoiceOverRunning {
-        accessibilityActions
-      }
+      accessibilityActions
     }
     .background {
       Color.clear
@@ -172,8 +170,6 @@ public struct StatusRowView: View {
     Button("@\(viewModel.status.account.username)") {
       viewModel.routerPath.navigate(to: .accountDetail(id: viewModel.status.account.id))
     }
-
-    contextMenu
   }
 
   private func makeFilterView(filter: Filter) -> some View {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -211,26 +211,46 @@ private struct ConditionalAccessibilityLabelModifier: ViewModifier {
 
   @ObservedObject var viewModel: StatusRowViewModel
   let setLabel: Bool
-  
+
+  var hasSpoiler: Bool {
+    viewModel.displaySpoiler && viewModel.finalStatus.spoilerText.asRawText.isEmpty == false
+  }
+
+  // viewModel.finalStatus.spoilerText.asRawText
   func body(content: Content) -> some View {
     if setLabel {
-      content
-        .accessibilityLabel(
-          Text(viewModel.finalStatus.account.displayNameWithoutEmojis.count < 4
-            ? viewModel.finalStatus.account.safeDisplayName
-            : viewModel.finalStatus.account.displayNameWithoutEmojis
-          ) + Text(". ") +
-          Text(viewModel.finalStatus.content.asRawText) + Text(", ") +
-          boostLabel() +
-          replyLabel() +
-          Text(viewModel.finalStatus.createdAt.relativeFormatted) + Text(". ") +
-          Text("status.summary.n-replies \(viewModel.finalStatus.repliesCount)") + Text(", ") +
-          Text("status.summary.n-boosts \(viewModel.finalStatus.reblogsCount)") + Text(", ") +
-          Text("status.summary.n-favorites \(viewModel.finalStatus.favouritesCount)")
-        )
+      if hasSpoiler {
+        // Use the spoiler text in the label and place the full text as custom content
+        content
+          .accessibilityLabel(combinedAccessibilityLabel())
+          .accessibilityCustomContent(
+            LocalizedStringKey("accessibility.status.spoiler-full-content"),
+            viewModel.finalStatus.content.asRawText
+          )
+      } else {
+        content
+          .accessibilityLabel(combinedAccessibilityLabel())
+      }
     } else {
       content
     }
+  }
+
+  func combinedAccessibilityLabel() -> Text {
+    Text(viewModel.finalStatus.account.displayNameWithoutEmojis.count < 4
+      ? viewModel.finalStatus.account.safeDisplayName
+      : viewModel.finalStatus.account.displayNameWithoutEmojis
+    ) + Text(". ") +
+    Text(hasSpoiler
+      ? viewModel.finalStatus.spoilerText.asRawText
+      : viewModel.finalStatus.content.asRawText
+    ) + Text(", ") +
+    boostLabel() +
+    replyLabel() +
+    Text(viewModel.finalStatus.createdAt.relativeFormatted) + Text(". ") +
+    Text("status.summary.n-replies \(viewModel.finalStatus.repliesCount)") + Text(", ") +
+    Text("status.summary.n-boosts \(viewModel.finalStatus.reblogsCount)") + Text(", ") +
+    Text("status.summary.n-favorites \(viewModel.finalStatus.favouritesCount)")
   }
 
   func replyLabel() -> Text {

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
@@ -50,6 +50,30 @@ struct StatusRowActionsView: View {
       }
     }
 
+    func accessibilityLabel(dataController: StatusDataController, privateBoost: Bool = false) -> LocalizedStringKey {
+      switch self {
+      case .respond:
+          return "status.action.reply"
+      case .boost:
+          if dataController.isReblogged {
+            return "status.action.unboost"
+          }
+          return privateBoost
+            ? "status.action.boost-to-followers"
+            : "status.action.boost"
+      case .favorite:
+          return dataController.isFavorited
+            ? "status.action.unfavorite"
+            : "status.action.favorite"
+      case .bookmark:
+          return dataController.isBookmarked
+            ? "status.action.unbookmark"
+            : "status.action.bookmark"
+      case .share:
+          return "status.action.share"
+      }
+    }
+
     func count(dataController: StatusDataController, viewModel: StatusRowViewModel, theme: Theme) -> Int? {
       if theme.statusActionsDisplay == .discret && !viewModel.isFocused {
         return nil
@@ -104,6 +128,8 @@ struct StatusRowActionsView: View {
                 action.image(dataController: statusDataController)
               }
               .buttonStyle(.statusAction())
+              .accessibilityElement(children: .combine)
+              .accessibilityLabel("status.action.share-link")
             }
           } else {
             actionButton(action: action)
@@ -151,6 +177,8 @@ struct StatusRowActionsView: View {
           .monospacedDigit()
       }
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(action.accessibilityLabel(dataController: statusDataController, privateBoost: privateBoost()))
   }
 
   private func handleAction(action: Action) {

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -90,6 +90,9 @@ public struct StatusRowMediaPreviewView: View {
               await quickLook.prepareFor(urls: attachments.compactMap { $0.url }, selectedURL: attachment.url!)
             }
           }
+          .accessibilityElement(children: .combine)
+          .modifier(ConditionalAccessibilityLabelAltTextModifier(attachment: attachment))
+          .accessibilityAddTraits([.isButton, .isImage])
       } else {
         if isCompact || theme.statusDisplayStyle == .compact {
           HStack {
@@ -269,6 +272,9 @@ public struct StatusRowMediaPreviewView: View {
           await quickLook.prepareFor(urls: attachments.compactMap { $0.url }, selectedURL: attachment.url!)
         }
       }
+      .accessibilityElement(children: .combine)
+      .modifier(ConditionalAccessibilityLabelAltTextModifier(attachment: attachment))
+      .accessibilityAddTraits([.isButton, .isImage])
     }
   }
 
@@ -328,3 +334,19 @@ public struct StatusRowMediaPreviewView: View {
     }
   }
 }
+
+/// A ``ViewModifier`` that creates a suitable accessibility label for an image that may or may not have alt text
+private struct ConditionalAccessibilityLabelAltTextModifier: ViewModifier {
+
+  let attachment: MediaAttachment
+
+  func body(content: Content) -> some View {
+    if let altText = attachment.description {
+      content
+        .accessibilityLabel("accessibility.image.alt-text-\(altText)")
+    } else {
+      content
+    }
+  }
+}
+

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowReblogView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowReblogView.swift
@@ -12,7 +12,7 @@ struct StatusRowReblogView: View {
         EmojiTextApp(.init(stringValue: viewModel.status.account.safeDisplayName), emojis: viewModel.status.account.emojis)
         Text("status.row.was-boosted")
       }
-      .accessibilityElement()
+      .accessibilityElement(children: .combine)
       .accessibilityLabel(
         Text("\(viewModel.status.account.safeDisplayName)")
           + Text(" ")

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowReplyView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowReplyView.swift
@@ -13,6 +13,12 @@ struct StatusRowReplyView: View {
         Text("status.row.was-reply")
         Text(mention.username)
       }
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel(
+        Text("status.row.was-reply")
+        + Text(" ")
+        + Text(mention.username)
+      )
       .font(.scaledFootnote)
       .foregroundColor(.gray)
       .fontWeight(.semibold)


### PR DESCRIPTION
# This PR

…is a major one. There were a fair few changes here that affect the accessible representation in other parts of the app, most notably the non-focused — not displayed as a single post — `StatusRowView`.

_Touch target sizes remains a concern — a lot of the elements are less than the recommended 44x44pts, but changing them would necessitate substantial design changes, so I've left them off._

## Profile tab specific

- Combines many partial views into one accessibility element
- Adds labels and hints to the header and avatar images
- Tweaks the order of elements to flow more naturally
- Tweaks `CustomInfoLabels` to have the numerical value as its `accessibilityValue`, and adds hints indicating what action they have (scrolling or navigating)
- Changes the `accessibilityLabel` of the nav bar item to _Options_ and adds more alternatives to allow for faster use with Voice Control and Full Keyboard Access
- Adds explicit `accessibilityLabel`s to the `Picker`. Previously, these were the fallback labels provided by SF Symbols, which didn't really make complete sense.
- Removes `StatusRowView` swipe actions if VoiceOver is running. These actions were folded into the custom actions on the accessibility element, which meant there were a lot of duplicate actions being surfaced.
- Removes user interaction flag from `staticText` elements with no associated action
- Changes the accessible representation of `FollowButton`s to a `Toggle`, which is the natural interaction mode for these. This means that VoiceOver will read _Display boosts, Switch Button, on, Double-tap to toggle setting._, which provides ample context.
- Combines the user-defined fields title and values, and adds a _Verified_ `value` where applicable. For valid URLs, a `.link` trait is added automatically. The group of user-defined fields is now its own accessibility container, so when a user moves focus to the container, it will prefix _User-defined fields_ before reading the element description.
- Add image descriptions for familiar follows to their `safeDisplayName`; previously there was no way to know the difference between them. Also added a `.button` trait, as tapping them performs navigation.

## More general
- Adds explicit `accessibilityLabel`s to `StatusRowActionsView` actions. Previously, they were _close_, but there was one SF symbol key that snuck in there.
- Adds image alt text to the `StatusRowView` `accessibilityLabel`. If there is more than one image present, it will read the first one and indicate that there is more alt text available.
- Create an explicit accessibilityLabel for unfocused `StatusRowView`s.
- Fix a bug that prevented people with VoiceOver enabled from double-tapping a `StatusRowView` to go to the post detail.

## `StatusRowView` combined label

This is a bit of a complicated one ([code](https://github.com/Dimillian/IceCubesApp/blob/61afd769fd55e2f4e825f9e0ba6f9206f7b001b4/Packages/Status/Sources/Status/Row/StatusRowView.swift#L205-L298), reuses existing logic where possible), but the end result looks like this for a plain post with one image with alt text:

> [RobWhitaker new] I just connected a Bluetooth keyboard to my iPhone. Can anyone explain how connecting a keyboard can affect Wi-Fi?  **Image alt text: Using "keyboard" may affect Wi-Fi and Bluetooth connectivity.** 1 wk. ago, 3 replies, 1 boosts, 0 favorites

For a boosted post:

> Patrick H. Lauke boosted Frank Whitehouse Today I finally told my kids that St Patrick isn't real, and it's been me putting the snakes under their pillows all these years.  1 day ago, 8 replies, 218 boosts, 12 favorites

For a reply:

> Ellen Shapiro replied to @malin Oh those came out nice! What kind of wood/stains did you use?   9 hr. ago, 0 replies, 0 boosts, 0 favorites

# Profile tab, before

<img width="100%" alt="Profile-Tab-VoiceOver-Before" src="https://user-images.githubusercontent.com/5979418/226110664-c2d1df7e-ccb3-4317-9f3d-79d5efb02c4c.png">


<img width="100%" alt="Profile-Tab-VoiceControl-Before" src="https://user-images.githubusercontent.com/5979418/226110657-d8115367-e870-4ae3-83d3-37a24f25d0e8.png">

# Profile tab, after

<img width="100%" alt="Profile-Tab-VoiceOver-After" src="https://user-images.githubusercontent.com/5979418/226110704-3ffe19e6-692b-4f7a-af6d-1ff2b1d64f4b.png">

Note that for the user-defined fields, VoiceOver on device will add `link` traits where it detects urls; adding them in SwiftUI will result in `Link` being read out twice.

Note also that  the _Following_, _Receive notifications_ and _Display boosts_ will be read as _Label, Switch Button, on|off_, but Reveal doesn't support the private `toggle` trait Apple uses for that label yet.

<img width="100%" alt="Profile-Tab-VoiceControl-After" src="https://user-images.githubusercontent.com/5979418/226110696-0065a0dc-b9ee-4507-8331-6a7d55f55367.png">

# Timeline, before

<img width="100%" alt="Timeline-VoiceOver-Before" src="https://user-images.githubusercontent.com/5979418/226110727-32f872cf-c844-41d8-8be8-8b1c33cefd5f.png">

_Note the "0,0,0, Button" label, which I believe is some kind of bug that inserted the full description into a custom action label_

# Timeline, after

<img width="1598" alt="Timeline-VoiceOver-After" src="https://user-images.githubusercontent.com/5979418/226110755-9c71ad1f-f1a4-4484-a612-13cf40fc9505.png">



