### PR TITLE
Fix display of hashtags in editor to recognize unicode word characters

### DIFF
--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -300,7 +300,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
                               .backgroundColor: UIColor.clear,
                               .underlineColor: UIColor.clear],
                              range: NSMakeRange(0, statusText.string.utf16.count))
-    let hashtagPattern = "(#+[a-zA-Z0-9(_)]{1,})"
+    let hashtagPattern = "(#+[\\w0-9(_)]{1,})"
     let mentionPattern = "(@+[a-zA-Z0-9(_).-]{1,})"
     let urlPattern = "(?i)https?://(?:www\\.)?\\S+(?:/|\\b)"
 


### PR DESCRIPTION
Currently hashtag recognition only considers the word characters a-zA-Z. This PR fixes this to include all unicode word characters.

Closes #947