### PR TITLE
Add an edit button to the remote timeline settings

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -283,6 +283,9 @@ struct SettingsTabs: View {
     .navigationTitle("settings.general.remote-timelines")
     .scrollContentBackground(.hidden)
     .background(theme.secondaryBackgroundColor)
+    .toolbar {
+        EditButton()
+    }
   }
 
   private func moveTimelineItems(from source: IndexSet, to destination: Int) {


### PR DESCRIPTION
An iOS-style edit button, which allows easy moving and deletion of items, is added to the list of remote timelines in the settings.