### PR TITLE
Add 2 missing localization strings

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -513,6 +513,8 @@
 "filter.contexts.profiles" = "Профілі";
 "filter.action.warning" = "Схаваць з папярэджаннем";
 "filter.action.hide" = "Схаваць цалкам";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Далучыць фота";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -507,6 +507,8 @@
 "filter.contexts.profiles" = "Perfils";
 "filter.action.warning" = "Amaga amb un avís";
 "filter.action.hide" = "Amaga per complet";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Attach photo";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -503,6 +503,8 @@
 "filter.contexts.profiles" = "Profile";
 "filter.action.warning" = "Mit einer Warnung ausblenden";
 "filter.action.hide" = "Komplett ausblenden";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Foto anhängen";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -509,6 +509,8 @@
 "filter.contexts.profiles" = "Profiles";
 "filter.action.warning" = "Hide with a warning";
 "filter.action.hide" = "Hide completely";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Attach photo";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -509,6 +509,8 @@
 "filter.contexts.profiles" = "Perfiles";
 "filter.action.warning" = "Ocultar con una advertencia";
 "filter.action.hide" = "Ocultar completamente";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Añadir foto";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -497,6 +497,8 @@
 "filter.contexts.profiles" = "Profilak";
 "filter.action.warning" = "Ezkutatu ohartarazpen batekin";
 "filter.action.hide" = "Ezkutatu guztiz";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Erantsi irudia";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -504,6 +504,8 @@
 "filter.contexts.profiles" = "Profils";
 "filter.action.warning" = "Cacher avec avertissement";
 "filter.action.hide" = "Cacher complètement";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Attacher la photo";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -508,6 +508,8 @@
 "filter.contexts.profiles" = "Nei profili";
 "filter.action.warning" = "Nascondi con un avviso";
 "filter.action.hide" = "Nascondi completamente";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Allega foto";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -508,6 +508,8 @@
 "filter.contexts.profiles" = "プロフィール";
 "filter.action.warning" = "警告して非表示";
 "filter.action.hide" = "完全に非表示";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "画像を添付";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -510,6 +510,8 @@
 "filter.contexts.profiles" = "프로필";
 "filter.action.warning" = "경고 표시하고 글 가림";
 "filter.action.hide" = "완전히 숨김";
+"filter.expired" = "기간 종료됨";
+"filter.expiry-%@" = "%@까지 가림";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "미디어 첨부";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -174,8 +174,8 @@
 "settings.display.font" = "타임라인 글꼴";
 "settings.display.font.system" = "시스템 글꼴";
 "settings.display.font.custom" = "직접 설정";
-"settings.display.font.scaling-%@" = "폰트 크기 조절: %@";
-"settings.display.font.line-spacing-%@" = "Line Spacing: %@";
+"settings.display.font.scaling-%@" = "글꼴 크기 조절: %@";
+"settings.display.font.line-spacing-%@" = "줄 간격 조절: %@";
 "settings.about.built-with" = "Ice Cubes는 다음 오픈 소스 소프트웨어를 사용하여 개발되었습니다:";
 "settings.about.title" = "Ice Cubes";
 "settings.account.cached-posts-%@" = "캐시 데이터로 저장된 글: %@개";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -508,6 +508,8 @@
 "filter.contexts.profiles" = "Profiler";
 "filter.action.warning" = "Skjul med advarsel";
 "filter.action.hide" = "Skjul helt";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Attach photo";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "filter.contexts.profiles" = "Profielen";
 "filter.action.warning" = "Verberg met waarschuwing";
 "filter.action.hide" = "Verberg volledig";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 "enum.expand-media.show" = "Toon alle";
 "enum.expand-media.hide" = "Verberg alle";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -499,6 +499,8 @@
 "filter.contexts.profiles" = "Profile";
 "filter.action.warning" = "Ukryj z ostrzeżeniem";
 "filter.action.hide" = "Ukryj całkowicie";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Dołącz zdjęcie";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -508,6 +508,8 @@
 "filter.contexts.profiles" = "Perfis";
 "filter.action.warning" = "Ocultar com um aviso";
 "filter.action.hide" = "Ocultar completamente";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Anexar foto";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -504,6 +504,8 @@
 "filter.contexts.profiles" = "Profiles";
 "filter.action.warning" = "Hide with a warning";
 "filter.action.hide" = "Hide completely";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 "enum.expand-media.show" = "Show All";
 "enum.expand-media.hide" = "Hide All";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -509,6 +509,8 @@
 "filter.contexts.profiles" = "Профілі";
 "filter.action.warning" = "Приховати з попередженням";
 "filter.action.hide" = "Повністю приховати";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "Додати світлину";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -506,6 +506,8 @@
 "filter.contexts.profiles" = "个人主页";
 "filter.action.warning" = "隐藏并提醒";
 "filter.action.hide" = "完全隐藏";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 "enum.expand-media.show" = "显示所有";
 "enum.expand-media.hide" = "隐藏所有";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -508,6 +508,8 @@
 "filter.contexts.profiles" = "個人檔案";
 "filter.action.warning" = "警告之後隱藏";
 "filter.action.hide" = "完全隱藏";
+"filter.expired" = "Expired";
+"filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
 "accessibility.editor.button.attach-photo" = "附上相片";


### PR DESCRIPTION
- Add `filter.expired` and `filter.expiry-%@` entries for the other 18 languages. (Only en-GB had them)
- Add a Korean translation for the line spacing setting.