### PR TITLE
Fix the lag of the display setting sliders

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
@@ -6,11 +6,13 @@ import Network
 import Status
 import SwiftUI
 
-class DisplaySettingsLocalColors: ObservableObject {
+class DisplaySettingsLocalValues: ObservableObject {
   @Published var tintColor = Theme.shared.tintColor
   @Published var primaryBackgroundColor = Theme.shared.primaryBackgroundColor
   @Published var secondaryBackgroundColor = Theme.shared.secondaryBackgroundColor
   @Published var labelColor = Theme.shared.labelColor
+  @Published var lineSpacing = Theme.shared.lineSpacing
+  @Published var fontSizeScale = Theme.shared.fontSizeScale
 
   private var subscriptions = Set<AnyCancellable>()
 
@@ -31,6 +33,14 @@ class DisplaySettingsLocalColors: ObservableObject {
       .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
       .sink(receiveValue: { newColor in Theme.shared.labelColor = newColor })
       .store(in: &subscriptions)
+    $lineSpacing
+      .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
+      .sink(receiveValue: { newSpacing in Theme.shared.lineSpacing = newSpacing })
+      .store(in: &subscriptions)
+    $fontSizeScale
+      .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
+      .sink(receiveValue: { newScale in Theme.shared.fontSizeScale = newScale })
+      .store(in: &subscriptions)
   }
 }
 
@@ -41,11 +51,9 @@ struct DisplaySettingsView: View {
   @EnvironmentObject private var theme: Theme
   @EnvironmentObject private var userPreferences: UserPreferences
 
-  @StateObject private var localColors = DisplaySettingsLocalColors()
+  @StateObject private var localValues = DisplaySettingsLocalValues()
 
   @State private var isFontSelectorPresented = false
-  @State var fontScale = 0.0
-  @State var lineSpacing = 0.0
 
   private let previewStatusViewModel = StatusRowViewModel(status: Status.placeholder(forSettings: true, language: "la"),
                                                           client: Client(server: ""),
@@ -94,18 +102,18 @@ struct DisplaySettingsView: View {
       Toggle("settings.display.theme.systemColor", isOn: $theme.followSystemColorScheme)
       themeSelectorButton
       Group {
-        ColorPicker("settings.display.theme.tint", selection: $localColors.tintColor)
-        ColorPicker("settings.display.theme.background", selection: $localColors.primaryBackgroundColor)
-        ColorPicker("settings.display.theme.secondary-background", selection: $localColors.secondaryBackgroundColor)
-        ColorPicker("settings.display.theme.text-color", selection: $localColors.labelColor)
+        ColorPicker("settings.display.theme.tint", selection: $localValues.tintColor)
+        ColorPicker("settings.display.theme.background", selection: $localValues.primaryBackgroundColor)
+        ColorPicker("settings.display.theme.secondary-background", selection: $localValues.secondaryBackgroundColor)
+        ColorPicker("settings.display.theme.text-color", selection: $localValues.labelColor)
       }
       .disabled(theme.followSystemColorScheme)
       .opacity(theme.followSystemColorScheme ? 0.5 : 1.0)
       .onChange(of: theme.selectedSet) { _ in
-        localColors.tintColor = theme.tintColor
-        localColors.primaryBackgroundColor = theme.primaryBackgroundColor
-        localColors.secondaryBackgroundColor = theme.secondaryBackgroundColor
-        localColors.labelColor = theme.labelColor
+        localValues.tintColor = theme.tintColor
+        localValues.primaryBackgroundColor = theme.primaryBackgroundColor
+        localValues.secondaryBackgroundColor = theme.secondaryBackgroundColor
+        localValues.labelColor = theme.labelColor
       }
     } header: {
       Text("settings.display.section.theme")
@@ -149,35 +157,21 @@ struct DisplaySettingsView: View {
       .navigationDestination(isPresented: $isFontSelectorPresented, destination: { FontPicker() })
 
       VStack {
-        Slider(value: $fontScale, in: 0.5 ... 1.5, step: 0.1) { editing in
-          if !editing {
-            theme.fontSizeScale = fontScale
-          }
-        }
-        Text("settings.display.font.scaling-\(String(format: "%.1f", fontScale))")
+        Slider(value: $localValues.fontSizeScale, in: 0.5 ... 1.5, step: 0.1)
+        Text("settings.display.font.scaling-\(String(format: "%.1f", localValues.fontSizeScale))")
           .font(.scaledBody)
       }
       .alignmentGuide(.listRowSeparatorLeading) { d in
         d[.leading]
-      }
-      .onAppear {
-        fontScale = theme.fontSizeScale
       }
 
       VStack {
-        Slider(value: $lineSpacing, in: 0.4 ... 10.0, step: 0.2) { editing in
-          if !editing {
-            theme.lineSpacing = lineSpacing
-          }
-        }
-        Text("settings.display.font.line-spacing-\(String(format: "%.1f", lineSpacing))")
+        Slider(value: $localValues.lineSpacing, in: 0.4 ... 10.0, step: 0.2)
+        Text("settings.display.font.line-spacing-\(String(format: "%.1f", localValues.lineSpacing))")
           .font(.scaledBody)
       }
       .alignmentGuide(.listRowSeparatorLeading) { d in
         d[.leading]
-      }
-      .onAppear {
-        lineSpacing = theme.lineSpacing
       }
     }
     .listRowBackground(theme.primaryBackgroundColor)
@@ -238,10 +232,10 @@ struct DisplaySettingsView: View {
         theme.avatarPosition = .top
         theme.statusActionsDisplay = .full
 
-        localColors.tintColor = theme.tintColor
-        localColors.primaryBackgroundColor = theme.primaryBackgroundColor
-        localColors.secondaryBackgroundColor = theme.secondaryBackgroundColor
-        localColors.labelColor = theme.labelColor
+        localValues.tintColor = theme.tintColor
+        localValues.primaryBackgroundColor = theme.primaryBackgroundColor
+        localValues.secondaryBackgroundColor = theme.secondaryBackgroundColor
+        localValues.labelColor = theme.labelColor
 
       } label: {
         Text("settings.display.restore")

--- a/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
@@ -44,6 +44,8 @@ struct DisplaySettingsView: View {
   @StateObject private var localColors = DisplaySettingsLocalColors()
 
   @State private var isFontSelectorPresented = false
+  @State var fontScale = 0.0
+  @State var lineSpacing = 0.0
 
   private let previewStatusViewModel = StatusRowViewModel(status: Status.placeholder(forSettings: true, language: "la"),
                                                           client: Client(server: ""),
@@ -147,21 +149,35 @@ struct DisplaySettingsView: View {
       .navigationDestination(isPresented: $isFontSelectorPresented, destination: { FontPicker() })
 
       VStack {
-        Slider(value: $theme.fontSizeScale, in: 0.5 ... 1.5, step: 0.1)
-        Text("settings.display.font.scaling-\(String(format: "%.1f", theme.fontSizeScale))")
+        Slider(value: $fontScale, in: 0.5 ... 1.5, step: 0.1) { editing in
+          if !editing {
+            theme.fontSizeScale = fontScale
+          }
+        }
+        Text("settings.display.font.scaling-\(String(format: "%.1f", fontScale))")
           .font(.scaledBody)
       }
       .alignmentGuide(.listRowSeparatorLeading) { d in
         d[.leading]
       }
-      
+      .onAppear {
+        fontScale = theme.fontSizeScale
+      }
+
       VStack {
-        Slider(value: $theme.lineSpacing, in: 0.4 ... 10.0, step: 0.2)
-        Text("settings.display.font.line-spacing-\(String(format: "%.1f", theme.lineSpacing))")
+        Slider(value: $lineSpacing, in: 0.4 ... 10.0, step: 0.2) { editing in
+          if !editing {
+            theme.lineSpacing = lineSpacing
+          }
+        }
+        Text("settings.display.font.line-spacing-\(String(format: "%.1f", lineSpacing))")
           .font(.scaledBody)
       }
       .alignmentGuide(.listRowSeparatorLeading) { d in
         d[.leading]
+      }
+      .onAppear {
+        lineSpacing = theme.lineSpacing
       }
     }
     .listRowBackground(theme.primaryBackgroundColor)

--- a/Packages/DesignSystem/Sources/DesignSystem/Theme.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Theme.swift
@@ -8,7 +8,8 @@ public class Theme: ObservableObject {
     case selectedSet, selectedScheme
     case followSystemColorSchme
     case displayFullUsernameTimeline
-    case lineSpacing
+    case lineSpacing, fontSizeScale
+    case chosenFont, isPreviouslySet
   }
 
   public enum FontState: Int, CaseIterable {
@@ -115,7 +116,7 @@ public class Theme: ObservableObject {
     }
   }
 
-  @AppStorage("is_previously_set") public var isThemePreviouslySet: Bool = false
+  @AppStorage(ThemeKey.isPreviouslySet.rawValue) public var isThemePreviouslySet: Bool = false
   @AppStorage(ThemeKey.selectedScheme.rawValue) public var selectedScheme: ColorScheme = .dark
   @AppStorage(ThemeKey.tint.rawValue) public var tintColor: Color = .black
   @AppStorage(ThemeKey.primaryBackground.rawValue) public var primaryBackgroundColor: Color = .white
@@ -129,8 +130,8 @@ public class Theme: ObservableObject {
   @AppStorage(ThemeKey.followSystemColorSchme.rawValue) public var followSystemColorScheme: Bool = true
   @AppStorage(ThemeKey.displayFullUsernameTimeline.rawValue) public var displayFullUsername: Bool = true
   @AppStorage(ThemeKey.lineSpacing.rawValue) public var lineSpacing: Double = 0.8
-  @AppStorage("font_size_scale") public var fontSizeScale: Double = 1
-  @AppStorage("chosen_font") public private(set) var chosenFontData: Data?
+  @AppStorage(ThemeKey.fontSizeScale.rawValue) public var fontSizeScale: Double = 1
+  @AppStorage(ThemeKey.chosenFont.rawValue) public private(set) var chosenFontData: Data?
 
   @Published public var avatarPosition: AvatarPosition = .top
   @Published public var avatarShape: AvatarShape = .rounded

--- a/Packages/DesignSystem/Sources/DesignSystem/Theme.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Theme.swift
@@ -8,8 +8,7 @@ public class Theme: ObservableObject {
     case selectedSet, selectedScheme
     case followSystemColorSchme
     case displayFullUsernameTimeline
-    case lineSpacing, fontSizeScale
-    case chosenFont, isPreviouslySet
+    case lineSpacing
   }
 
   public enum FontState: Int, CaseIterable {
@@ -116,7 +115,7 @@ public class Theme: ObservableObject {
     }
   }
 
-  @AppStorage(ThemeKey.isPreviouslySet.rawValue) public var isThemePreviouslySet: Bool = false
+  @AppStorage("is_previously_set") public var isThemePreviouslySet: Bool = false
   @AppStorage(ThemeKey.selectedScheme.rawValue) public var selectedScheme: ColorScheme = .dark
   @AppStorage(ThemeKey.tint.rawValue) public var tintColor: Color = .black
   @AppStorage(ThemeKey.primaryBackground.rawValue) public var primaryBackgroundColor: Color = .white
@@ -130,8 +129,8 @@ public class Theme: ObservableObject {
   @AppStorage(ThemeKey.followSystemColorSchme.rawValue) public var followSystemColorScheme: Bool = true
   @AppStorage(ThemeKey.displayFullUsernameTimeline.rawValue) public var displayFullUsername: Bool = true
   @AppStorage(ThemeKey.lineSpacing.rawValue) public var lineSpacing: Double = 0.8
-  @AppStorage(ThemeKey.fontSizeScale.rawValue) public var fontSizeScale: Double = 1
-  @AppStorage(ThemeKey.chosenFont.rawValue) public private(set) var chosenFontData: Data?
+  @AppStorage("font_size_scale") public var fontSizeScale: Double = 1
+  @AppStorage("chosen_font") public private(set) var chosenFontData: Data?
 
   @Published public var avatarPosition: AvatarPosition = .top
   @Published public var avatarShape: AvatarShape = .rounded


### PR DESCRIPTION
The sliders in the display settings were laggy because changing the value in the theme class needs comparatively much time. This writing to the class is now only done when the user lets go of the slider, so sliding it is responsive. I was unable to make writing to the class more responsive, the example post needs therefore a short time before it accepts the new values. Furthermore, all AppStorage keys are now realized with a ThemeKey to clean the class up. Fixes #1341