### PR TITLE
Accessibility bug fixes

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -517,6 +517,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Далучыць фота";
 "accessibility.editor.button.poll" = "Апытанне";
 "accessibility.editor.button.spoiler" = "Папярэджанне пра спойлер";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -511,6 +511,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Attach photo";
 "accessibility.editor.button.poll" = "Poll";
 "accessibility.editor.button.spoiler" = "Spoiler warning";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -500,6 +500,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Foto anhängen";
 "accessibility.editor.button.poll" = "Umfrage";
 "accessibility.editor.button.spoiler" = "Inhaltswarnung";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -512,6 +512,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Attach photo";
 "accessibility.editor.button.poll" = "Poll";
 "accessibility.editor.button.spoiler" = "Spoiler warning";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -513,6 +513,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Attach photo";
 "accessibility.editor.button.poll" = "Poll";
 "accessibility.editor.button.spoiler" = "Spoiler warning";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -513,6 +513,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Añadir foto";
 "accessibility.editor.button.poll" = "Encuesta";
 "accessibility.editor.button.spoiler" = "Advertencia";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -501,6 +501,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Erantsi irudia";
 "accessibility.editor.button.poll" = "Bozketa";
 "accessibility.editor.button.spoiler" = "Edukiari buruzko oharra";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -508,6 +508,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Attacher la photo";
 "accessibility.editor.button.poll" = "Sondage";
 "accessibility.editor.button.spoiler" = "Alerte spoiler";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -512,6 +512,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Allega foto";
 "accessibility.editor.button.poll" = "Sondaggio";
 "accessibility.editor.button.spoiler" = "Avviso di Spoiler";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -512,6 +512,8 @@
 "filter.expiry-%@" = "有効期限: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "画像を添付";
 "accessibility.editor.button.poll" = "投票";
 "accessibility.editor.button.spoiler" = "ネタバレを警告";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "filter.expiry-%@" = "%@까지 가림";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "미디어 첨부";
 "accessibility.editor.button.poll" = "투표";
 "accessibility.editor.button.spoiler" = "열람 주의 문구";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -512,6 +512,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Attach photo";
 "accessibility.editor.button.poll" = "Poll";
 "accessibility.editor.button.spoiler" = "Spoiler warning";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -509,6 +509,8 @@
 "enum.expand-media.hide-sensitive" = "Verberg gevoelige";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Voeg foto toe";
 "accessibility.editor.button.poll" = "Poll";
 "accessibility.editor.button.spoiler" = "Spoilerwaarschuwing";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -503,6 +503,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Dołącz zdjęcie";
 "accessibility.editor.button.poll" = "Sondaż";
 "accessibility.editor.button.spoiler" = "Ostrzeżenie o spoilerze";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -512,6 +512,8 @@
 "filter.expiry-%@" = "Expiração: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Anexar foto";
 "accessibility.editor.button.poll" = "Enquete";
 "accessibility.editor.button.spoiler" = "Aviso de spoiler";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -512,6 +512,8 @@
 "enum.expand-media.hide-sensitive" = "Hide Sensitive";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Attach photo";
 "accessibility.editor.button.poll" = "Poll";
 "accessibility.editor.button.spoiler" = "Spoiler warning";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -513,6 +513,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "Додати світлину";
 "accessibility.editor.button.poll" = "Опитування";
 "accessibility.editor.button.spoiler" = "Увага! Спойлер.";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -514,6 +514,8 @@
 "enum.expand-media.hide-sensitive" = "隐藏敏感内容";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "添加图片";
 "accessibility.editor.button.poll" = "投票";
 "accessibility.editor.button.spoiler" = "剧透警告";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -513,6 +513,8 @@
 "filter.expiry-%@" = "Expiry: %@";
 
 // MARK: Accessibility
+"accessibility.general.toggle.on" = "On";
+"accessibility.general.toggle.off" = "Off";
 "accessibility.editor.button.attach-photo" = "附上相片";
 "accessibility.editor.button.poll" = "投票";
 "accessibility.editor.button.spoiler" = "劇透警告";

--- a/Packages/Account/Sources/Account/Follow/FollowButton.swift
+++ b/Packages/Account/Sources/Account/Follow/FollowButton.swift
@@ -97,9 +97,8 @@ public struct FollowButton: View {
           Text("account.follow.requested")
         } else {
           Text(viewModel.relationship.following ? "account.follow.following" : "account.follow.follow")
-            .accessibilityRepresentation {
-              Toggle("account.follow.following", isOn: .constant(viewModel.relationship.following))
-            }
+            .accessibilityLabel("account.follow.following")
+            .accessibilityValue(viewModel.relationship.following ? "accessibility.general.toggle.on" : "accessibility.general.toggle.off")
         }
       }
       if viewModel.relationship.following,
@@ -112,18 +111,18 @@ public struct FollowButton: View {
             }
           } label: {
             Image(systemName: viewModel.relationship.notifying ? "bell.fill" : "bell")
-          }.accessibilityRepresentation {
-            Toggle("accessibility.tabs.profile.user-notifications.label", isOn: .constant(viewModel.relationship.notifying))
           }
+          .accessibilityLabel("accessibility.tabs.profile.user-notifications.label")
+          .accessibilityValue(viewModel.relationship.notifying ? "accessibility.general.toggle.on" : "accessibility.general.toggle.off")
           Button {
             Task {
               await viewModel.toggleReboosts()
             }
           } label: {
             Image(viewModel.relationship.showingReblogs ? "Rocket.Fill" : "Rocket")
-          }.accessibilityRepresentation {
-            Toggle("accessibility.tabs.profile.user-reblogs.label", isOn: .constant(viewModel.relationship.showingReblogs))
           }
+          .accessibilityLabel("accessibility.tabs.profile.user-reblogs.label")
+          .accessibilityValue(viewModel.relationship.showingReblogs ? "accessibility.general.toggle.on" : "accessibility.general.toggle.off")
         }
       }
     }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -91,7 +91,7 @@ public struct StatusRowMediaPreviewView: View {
             }
           }
           .accessibilityElement(children: .combine)
-          .modifier(ConditionalAccessibilityLabelAltTextModifier(attachment: attachment))
+          .accessibilityLabel(Self.accessibilityLabel(for: attachment))
           .accessibilityAddTraits([.isButton, .isImage])
       } else {
         if isCompact || theme.statusDisplayStyle == .compact {
@@ -275,8 +275,8 @@ public struct StatusRowMediaPreviewView: View {
         }
       }
       .accessibilityElement(children: .combine)
-      .modifier(ConditionalAccessibilityLabelAltTextModifier(attachment: attachment))
       .accessibilityAddTraits(.isButton)
+      .accessibilityLabel(Self.accessibilityLabel(for: attachment))
     }
   }
 
@@ -335,21 +335,14 @@ public struct StatusRowMediaPreviewView: View {
       Spacer()
     }
   }
-}
 
-/// A ``ViewModifier`` that creates a suitable accessibility label for an image that may or may not have alt text
-private struct ConditionalAccessibilityLabelAltTextModifier: ViewModifier {
-  let attachment: MediaAttachment
-
-  func body(content: Content) -> some View {
+  private static func accessibilityLabel(for attachment: MediaAttachment) -> Text {
     if let altText = attachment.description {
-      content
-        .accessibilityLabel("accessibility.image.alt-text-\(altText)")
+      return Text("accessibility.image.alt-text-\(altText)")
     } else if let typeDescription = attachment.localizedTypeDescription {
-      content
-        .accessibilityLabel(typeDescription)
+      return Text(typeDescription)
     } else {
-      content
+      return Text("accessibility.tabs.profile.picker.media")
     }
   }
 }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -90,7 +90,7 @@ public struct StatusRowMediaPreviewView: View {
               await quickLook.prepareFor(urls: attachments.compactMap { $0.url }, selectedURL: attachment.url!)
             }
           }
-          .accessibilityElement(children: .combine)
+          .accessibilityElement(children: .ignore)
           .accessibilityLabel(Self.accessibilityLabel(for: attachment))
           .accessibilityAddTraits([.isButton, .isImage])
       } else {
@@ -254,7 +254,6 @@ public struct StatusRowMediaPreviewView: View {
                 .cornerRadius(4)
               }
             }
-            .accessibilityAddTraits(.isImage)
           case .gifv, .video, .audio:
             if let url = attachment.url {
               VideoPlayerView(viewModel: .init(url: url))
@@ -274,9 +273,9 @@ public struct StatusRowMediaPreviewView: View {
           await quickLook.prepareFor(urls: attachments.compactMap { $0.url }, selectedURL: attachment.url!)
         }
       }
-      .accessibilityElement(children: .combine)
-      .accessibilityAddTraits(.isButton)
+      .accessibilityElement(children: .ignore)
       .accessibilityLabel(Self.accessibilityLabel(for: attachment))
+      .accessibilityAddTraits(attachment.supportedType == .image ? [.isImage, .isButton] : .isButton)
     }
   }
 


### PR DESCRIPTION
# This PR…

1. Works around a bug caused by SwiftUI displaying inconsistent behaviour when `accessibilityRepresentation` is used to vend a `Toggle`.

> SwiftUI hides the view that you provide in the representation closure and makes it non-interactive. The framework uses it only to generate accessibility elements. — [Apple documentation](https://developer.apple.com/documentation/swiftui/view/accessibilityrepresentation(representation:))

However, what actually happened was that it was attempting to set the `.constant` binding and didn't fire the button action 🤔 

2. Removes a conditional `ViewModifier` in `StatusRowMediaPreviewView` in favour of an inlined modifier.

Just erring on the side of caution here with regard to `StatusRow` performance.

3.  Avoids combining `StatusRowMediaPreviewView` accessibility children.

Previously, image previews accessibility action would _not_ be opening QuickLook, but rather display the alt text alert. This is not the intended behaviour.