### PR TITLE
Accessibility fix for Timeline `StatusRowView` and Status detail

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -455,6 +455,7 @@
 "status.editor.text.placeholder" = "Пра што вы думаеце?";
 "status.editor.visibility" = "Бачнасць допісу";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "Пры загрузцы паведамленняў адбылася памылка, паўтарыце спробу.";
 "status.error.message" = "Адбылася памылка ў кантэксце гэтай публікацыі, паспрабуйце яшчэ раз.";

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -582,6 +582,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Дадатковая інфармацыя";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -449,6 +449,7 @@
 "status.editor.text.placeholder" = "Què us passa pel cap?";
 "status.editor.visibility" = "Visibilitat de la publicació";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "S'ha produït un error en carregar les publicacions, torneu-ho a provar.";
 "status.error.message" = "S'ha produït un error en el context d'aquesta publicació, torneu-ho a provar.";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -576,6 +576,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -564,6 +564,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 
 // MARK: Report

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -444,6 +444,7 @@
 "status.editor.text.placeholder" = "Woran denkst du?";
 "status.editor.visibility" = "Sichtbarkeit";
 "status.editor.photo-library" = "Fotoalbum";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Dateien durchsuchen";
 "status.error.loading.message" = "Beim Laden der Beiträge ist ein Fehler aufgetreten. Bitte versuche es erneut.";
 "status.error.message" = "Es ist ein Fehler aufgetreten. Bitte versuche es erneut.";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -577,6 +577,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "status.editor.text.placeholder" = "What's on your mind?";
 "status.editor.visibility" = "Post visibility";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "An error occurred while loading posts, please try again.";
 "status.error.message" = "An error occurred in the context of this post, please try again.";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -578,6 +578,8 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
+
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "status.editor.text.placeholder" = "What's on your mind?";
 "status.editor.visibility" = "Post visibility";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "An error occurred while loading posts, please try again.";
 "status.error.message" = "An error occurred in the context of this post, please try again.";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "status.editor.text.placeholder" = "¿En qué estás pensando?";
 "status.editor.visibility" = "Visibilidad de la publicación";
 "status.editor.photo-library" = "Fototeca";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Archivos";
 "status.error.loading.message" = "Ha ocurrido un error al cargar las publicaciones, por favor, vuelve a intentarlo.";
 "status.error.message" = "Ha ocurrido un error al cargar el contexto de esta publicación, por favor, vuelve a intentarlo.";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -578,6 +578,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Información adicional";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -444,6 +444,7 @@
 "status.editor.text.placeholder" = "Zer duzu buruan?";
 "status.editor.visibility" = "Bidalketaren irismena";
 "status.editor.photo-library" = "Argazki-liburutegia";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Arakatu fitxategiak";
 "status.error.loading.message" = "Errorea bidalketak kargatzean; saiatu berriro.";
 "status.error.message" = "Errorea bidalketa honen testuinguruan; saiatu berriro.";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -566,6 +566,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazio gehigarria";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -446,6 +446,7 @@
 "status.editor.text.placeholder" = "Qu'est-ce qui vous passe par la tête ?";
 "status.editor.visibility" = "Visibilité de la publication";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "Une erreur s'est produite lors du chargement des publications, veuillez réessayer.";
 "status.error.message" = "Une erreur s'est produite dans le contexte de cette publication, veuillez réessayer.";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -573,6 +573,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Information supplémentaire";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -577,6 +577,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Informazioni aggiuntive";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "status.editor.text.placeholder" = "A cosa stai pensando?";
 "status.editor.visibility" = "Visibilità del post";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "Si è verificato un errore durante il caricamento dei post, per favore riprova.";
 "status.error.message" = "Si è verificato un errore durante il caricamento del post, per favore riprova.";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -577,6 +577,7 @@
 "accessibility.media.supported-type.audio.label" = "オーディオ";
 "accessibility.status.contains-media.label-%@" = "%@ を含む";
 "accessibility.status.application.label" = "アプリ";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "追加情報";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "status.editor.text.placeholder" = "いま、何を考えているの？";
 "status.editor.visibility" = "投稿の公開範囲";
 "status.editor.photo-library" = "写真ライブラリ";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "ファイルの参照";
 "status.error.loading.message" = "投稿の読み込み中にエラーが発生しました、もう一度試してください";
 "status.error.message" = "この投稿のコンテキストでエラーが発生しました、もう一度試してください";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -452,6 +452,7 @@
 "status.editor.text.placeholder" = "무슨 생각을 하고 계신가요?";
 "status.editor.visibility" = "글 공개 범위";
 "status.editor.photo-library" = "사진 보관함";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "파일 앱";
 "status.error.loading.message" = "글을 불러오지 못했습니다. 다시 시도해주세요.";
 "status.error.message" = "글의 상세 정보를 불러오지 못했습니다. 다시 시도해주세요.";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -579,6 +579,7 @@
 "accessibility.media.supported-type.audio.label" = "오디오";
 "accessibility.status.contains-media.label-%@" = "%@ 첨부됨";
 "accessibility.status.application.label" = "글 작성에 사용한 앱";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "추가 정보";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "status.editor.text.placeholder" = "Hva tenker du på?";
 "status.editor.visibility" = "Innleggssynlighet";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "Det oppsto en feil under innlasting av innlegg, prøv igjen.";
 "status.error.message" = "Det oppsto en feil i forbindelse med dette innlegget, prøv igjen.";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -577,6 +577,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -574,6 +574,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Aanvullende informatie";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -444,6 +444,7 @@
 "status.editor.text.placeholder" = "Waar denk je aan?";
 "status.editor.visibility" = "Zichtbaarheid";
 "status.editor.photo-library" = "Fotobibliotheek";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Bestanden";
 "status.error.loading.message" = "Er heeft zich een fout voorgedaan tijdens het laden van je posts. Probeer het nogmaals.";
 "status.error.message" = "Er heeft zich een fout voorgedaan. Probeer het nogmaals.";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -446,6 +446,7 @@
 "status.editor.text.placeholder" = "Co ci chodzi po głowie?";
 "status.editor.visibility" = "Widoczność postu";
 "status.editor.photo-library" = "Biblioteka zdjęć";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Przeglądaj pliki";
 "status.error.loading.message" = "Wystąpił błąd podczas ładowania postów, spróbuj ponownie.";
 "status.error.message" = "Wystąpił błąd dotyczący tego postu, proszę spróbuj ponownie.";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -568,6 +568,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Zawiera %@";
 "accessibility.status.application.label" = "Aplikacja";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Informacja dodatkowa";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -577,6 +577,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Informação Adicional";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -450,6 +450,7 @@
 "status.editor.text.placeholder" = "O que você está pensando?";
 "status.editor.visibility" = "Visibilidade da postagem";
 "status.editor.photo-library" = "Biblioteca de Fotos";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Procurar Arquivos";
 "status.error.loading.message" = "Ocorreu um erro enquanto as postagens eram carregadas, por favor, tente novamente.";
 "status.error.message" = "Ocorreu um erro com esta postagem, por favor, tente novamente.";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -577,6 +577,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Additional Info";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -446,6 +446,7 @@
 "status.editor.text.placeholder" = "Aklında ne var?";
 "status.editor.visibility" = "Görüntü görünürlüğü";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "Gönderi yüklenirken bir hata oluştu, lütfen tekrar deneyin.";
 "status.error.message" = "Bu gönderi bağlamında bir hata oluştu, lütfen tekrar deneyin.";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "status.editor.text.placeholder" = "Що у вас на думці?";
 "status.editor.visibility" = "Видимість допису";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "An error occurred while loading posts, please try again.";
 "status.error.message" = "An error occurred in the context of this post, please try again.";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -578,6 +578,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "Додаткова інформація";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -577,6 +577,7 @@
 "accessibility.media.supported-type.audio.label" = "音频";
 "accessibility.status.contains-media.label-%@" = "包含 %@";
 "accessibility.status.application.label" = "应用";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "附加信息";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -449,6 +449,7 @@
 "status.editor.text.placeholder" = "在想些什么呢？";
 "status.editor.visibility" = "嘟文可见性";
 "status.editor.photo-library" = "Photos Library";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "Browse Files";
 "status.error.loading.message" = "加载嘟文时发生错误，请重试。";
 "status.error.message" = "嘟文的上下文出现了错误，请重试。";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -578,6 +578,7 @@
 "accessibility.media.supported-type.audio.label" = "Audio";
 "accessibility.status.contains-media.label-%@" = "Contains %@";
 "accessibility.status.application.label" = "App";
+"accessibility.status.media-viewer-action.label" = "Open media viewer";
 
 // MARK: Report
 "report.comment.placeholder" = "附加資訊";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "status.editor.text.placeholder" = "您在想些什麼呢？";
 "status.editor.visibility" = "嘟文能見度";
 "status.editor.photo-library" = "相片圖庫";
+"status.editor.camera-picker" = "Take Photo";
 "status.editor.browse-file" = "瀏覽檔案";
 "status.error.loading.message" = "下載嘟文時發生錯誤，請再試一次。";
 "status.error.message" = "嘟文上下文發生錯誤，請再試一次。";

--- a/Packages/Status/Sources/Status/Detail/StatusDetailView.swift
+++ b/Packages/Status/Sources/Status/Detail/StatusDetailView.swift
@@ -17,6 +17,10 @@ public struct StatusDetailView: View {
   @State private var isLoaded: Bool = false
   @State private var statusHeight: CGFloat = 0
 
+  /// April 4th, 2023: Without explicit focus being set, VoiceOver will skip over a seemingly random number of elements on this screen when pushing in from the main timeline.
+  /// By using ``@AccessibilityFocusState`` and setting focus once, we work around this issue.
+  @AccessibilityFocusState private var initialFocusBugWorkaround: Bool
+
   public init(statusId: String) {
     _viewModel = StateObject(wrappedValue: .init(statusId: statusId))
   }
@@ -145,6 +149,7 @@ public struct StatusDetailView: View {
                                      client: client,
                                      routerPath: routerPath,
                                      isFocused: true) })
+      .accessibilityFocused($initialFocusBugWorkaround, equals: true)
       .overlay {
         GeometryReader { reader in
           VStack {}
@@ -154,6 +159,10 @@ public struct StatusDetailView: View {
         }
       }
       .id(status.id)
+      // VoiceOver / Switch Control focus workaround
+      .onAppear {
+        self.initialFocusBugWorkaround = true
+      }
   }
 
   private var errorView: some View {

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -21,6 +21,7 @@ struct StatusEditorAccessoryView: View {
   @State private var isLoadingAIRequest: Bool = false
   @State private var isPhotosPickerPresented: Bool = false
   @State private var isFileImporterPresented: Bool = false
+  @State private var isCameraPickerPresented: Bool = false
 
   var body: some View {
     VStack(spacing: 0) {
@@ -33,6 +34,11 @@ struct StatusEditorAccessoryView: View {
                 isPhotosPickerPresented = true
               } label: {
                 Label("status.editor.photo-library", systemImage: "photo")
+              }
+              Button {
+                isCameraPickerPresented = true
+              } label: {
+                Label("status.editor.camera-picker", systemImage: "camera")
               }
               Button {
                 isFileImporterPresented = true
@@ -48,6 +54,7 @@ struct StatusEditorAccessoryView: View {
             }
             .photosPicker(isPresented: $isPhotosPickerPresented,
                           selection: $viewModel.selectedMedias,
+                          maxSelectionCount: 4,
                           matching: .any(of: [.images, .videos]))
             .fileImporter(isPresented: $isFileImporterPresented,
                           allowedContentTypes: [.image, .video],
@@ -57,6 +64,16 @@ struct StatusEditorAccessoryView: View {
                 viewModel.processURLs(urls: urls)
               }
             }
+            .fullScreenCover(isPresented: $isCameraPickerPresented, content: {
+              StatusEditorCameraPickerView(selectedImage: .init(get: {
+                nil
+              }, set: { image in
+                if let image {
+                  viewModel.processCameraPhoto(image: image)
+                }
+              }))
+              .background(.black)
+            })
             .accessibilityLabel("accessibility.editor.button.attach-photo")
             .disabled(viewModel.showPoll)
 

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorCameraPickerView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorCameraPickerView.swift
@@ -22,6 +22,7 @@ struct StatusEditorCameraPickerView: UIViewControllerRepresentable {
   func makeUIViewController(context: Context) -> UIImagePickerController {
     let imagePicker = UIImagePickerController()
     imagePicker.sourceType = .camera
+    imagePicker.delegate = context.coordinator
     return imagePicker
   }
   

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorCameraPickerView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorCameraPickerView.swift
@@ -1,0 +1,35 @@
+import UIKit
+import SwiftUI
+
+struct StatusEditorCameraPickerView: UIViewControllerRepresentable {
+  @Binding var selectedImage: UIImage?
+  @Environment(\.presentationMode) var isPresented
+  
+  class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+    let picker: StatusEditorCameraPickerView
+    
+    init(picker: StatusEditorCameraPickerView) {
+      self.picker = picker
+    }
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+      guard let selectedImage = info[.originalImage] as? UIImage else { return }
+      self.picker.selectedImage = selectedImage
+      self.picker.isPresented.wrappedValue.dismiss()
+    }
+  }
+  
+  func makeUIViewController(context: Context) -> UIImagePickerController {
+    let imagePicker = UIImagePickerController()
+    imagePicker.sourceType = .camera
+    return imagePicker
+  }
+  
+  func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+    
+  }
+  
+  func makeCoordinator() -> Coordinator {
+    Coordinator(picker: self)
+  }
+}

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -371,6 +371,14 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
       .compactMap { NSItemProvider(contentsOf: $0) }
     processItemsProvider(items: items)
   }
+  
+  func processCameraPhoto(image: UIImage) {
+    mediasImages.append(.init(image: image,
+                              movieTransferable: nil,
+                              gifTransferable: nil,
+                              mediaAttachment: nil,
+                              error: nil))
+  }
 
   private func processItemsProvider(items: [NSItemProvider]) {
     Task {

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -378,6 +378,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
                               gifTransferable: nil,
                               mediaAttachment: nil,
                               error: nil))
+    processMediasToUpload()
   }
 
   private func processItemsProvider(items: [NSItemProvider]) {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -13,6 +13,7 @@ public struct StatusRowView: View {
   @Environment(\.isCompact) private var isCompact: Bool
   @Environment(\.accessibilityEnabled) private var accessibilityEnabled
 
+  @EnvironmentObject private var quickLook: QuickLook
   @EnvironmentObject private var theme: Theme
 
   @StateObject var viewModel: StatusRowViewModel
@@ -173,6 +174,16 @@ public struct StatusRowView: View {
     Button("settings.swipeactions.status.action.quote") {
       HapticManager.shared.fireHaptic(of: .notification(.success))
       viewModel.routerPath.presentedSheet = .quoteStatusEditor(status: viewModel.status)
+    }
+
+    if viewModel.finalStatus.mediaAttachments.isEmpty == false {
+      Button("accessibility.status.media-viewer-action.label") {
+        HapticManager.shared.fireHaptic(of: .notification(.success))
+        Task {
+          let attachments = viewModel.finalStatus.mediaAttachments
+          await quickLook.prepareFor(urls: attachments.compactMap { $0.url }, selectedURL: attachments[0].url!)
+        }
+      }
     }
 
     Button(viewModel.displaySpoiler ? "status.show-more" : "status.show-less") {


### PR DESCRIPTION
# This PR…

1. Adds an _Open Media Viewer_ action to the `StatusRowView` when displayed in the timeline. This allows the user to open QuickLook to browse the media attachments, which would otherwise not be possible from this screen.

2. Respects filters when creating accessibility labels (see last video). This closes #1331 

3. Works around a tricky bug to do with accessibility element focus order in the `StatusDetailView`. This issue may — I think — be caused by view identity across the screens in conjunction with loading states, but it's hard to be sure. There's no _one thing_ I could find that conclusively and repeatably causes it.

This workaround explicitly sets the focus state to the current element (e.g the post you wanted to see in the the `StatusDetailView`). This helps avoid the issue you can see in the video below.

To reproduce on `main`.

1. Enable Voiceover
3. Select and double-tap any post on the timeline
4. Attempt to swipe right with one finger to move the focus to the next element.

What's meant to happen here is that the focus moves from the post header to the post content. What actually happens is that it moves _much_ farther down the focus order list, often as far as the next reply.

## VoiceOver focus bug
https://user-images.githubusercontent.com/5979418/229654242-d6e68ac3-85a8-4fec-840d-d2cefa01f7aa.mp4

## `accessibilityLabel` Filter fix
https://user-images.githubusercontent.com/5979418/229659509-8c9009e6-062e-4140-95f2-8a400d2cacc2.MP4


