### PR TITLE
Add option to not show replies

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -19,6 +19,13 @@ struct ContentSettingsView: View {
         }
       }.listRowBackground(theme.primaryBackgroundColor)
 
+      Section("settings.content.replies") {
+        Toggle(isOn: $userPreferences.showReplies) {
+          Text("settings.content.show-replies")
+        }
+      }
+      .listRowBackground(theme.primaryBackgroundColor)
+
       Section("settings.content.media") {
         Toggle(isOn: $userPreferences.autoPlayVideo) {
           Text("settings.other.autoplay-video")

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -120,6 +120,8 @@
 "settings.content.collapse-long-posts" = "Collapse long posts";
 "settings.content.collapse-long-posts-hint" = "Collapsed posts only display a limited number of lines together with a button to show the full post";
 "settings.content.hide-repeated-boosts" = "Схаваць паўторныя павышэння";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Налады змесціва серверу";
 "settings.content.use-instance-settings" = "Ужыць налады серверу";
 "settings.content.expand-spoilers" = "Заўсёды паказваць уражлівыя допісы";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "settings.content.collapse-long-posts" = "Collapse long posts";
 "settings.content.collapse-long-posts-hint" = "Collapsed posts only display a limited number of lines together with a button to show the full post";
 "settings.content.hide-repeated-boosts" = "Hide repeated boosts";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Server Content Settings";
 "settings.content.expand-spoilers" = "Mostra'm sempre els espòilers";
 "settings.content.expand-media" = "Visibilitat del contingut multimèdia";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -156,6 +156,8 @@
 "settings.content.collapse-long-posts" = "Lange Beiträge einklappen";
 "settings.content.collapse-long-posts-hint" = "Eingeklappte Beiträge zeigen nur eine begrenzte Anzahl an Zeilen sowie eine Schaltfläche an, mit der der komplette Beitrag angezeigt werden kann";
 "settings.content.hide-repeated-boosts" = "Wiederholte Boosts verstecken";
+"settings.content.replies" = "Antworten";
+"settings.content.show-replies" = "Antworten anzeigen";
 "settings.content.instance-settings" = "Serverinhaltseinstellungen";
 "settings.content.use-instance-settings" = "Servereinstellungen verwenden";
 "settings.content.expand-spoilers" = "Sensible Inhalte immer zeigen";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -123,6 +123,8 @@
 "settings.content.instance-settings" = "Server Content Settings";
 "settings.content.main-toggle.description" = "Use the settings from your home Instance";
 "settings.content.hide-repeated-boosts" = "Hide Repeated Boosts";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.expand-spoilers" = "Always Show Sensitive Posts";
 "settings.content.expand-media" = "Media Display";
 "settings.content.default-sensitive" = "Always Mark Media as Sensitive";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -120,6 +120,8 @@
 "settings.content.collapse-long-posts" = "Collapse long posts";
 "settings.content.collapse-long-posts-hint" = "Collapsed posts only display a limited number of lines together with a button to show the full post";
 "settings.content.hide-repeated-boosts" = "Hide Repeated Boosts";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Server Content Settings";
 "settings.content.use-instance-settings" = "Use Server Settings";
 "settings.content.expand-spoilers" = "Always Show Sensitive Posts";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -156,6 +156,8 @@
 "settings.content.collapse-long-posts" = "Colapsar publicaciones largas";
 "settings.content.collapse-long-posts-hint" = "Las publicaciones colapsadas sólo muestran un número limitado de líneas junto a un botón para mostrar la publicación completa";
 "settings.content.hide-repeated-boosts" = "Ocultar boosts repetidos";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Ajustes de contenido del servidor";
 "settings.content.use-instance-settings" = "Usar ajustes del servidor";
 "settings.content.expand-spoilers" = "Mostrar siempre el contenido sensible";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -156,6 +156,8 @@
 "settings.content.collapse-long-posts" = "Tolestu bidalketa luzeak";
 "settings.content.collapse-long-posts-hint" = "Tolestutako bidalketek lerro kopuru jakin bat baino ez dute erakusten, bidalketa osorik irakurri ahal izateko hedatzeko botoiarekin batera";
 "settings.content.hide-repeated-boosts" = "Ezkutatu errepikatutako bultzadak";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Edukiari buruzko ezarpenak";
 "settings.content.use-instance-settings" = "Erabili zerbitzariko ezarpenak";
 "settings.content.expand-spoilers" = "Erakutsi beti eduki hunkigarria";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "settings.content.collapse-long-posts" = "Collapse long posts";
 "settings.content.collapse-long-posts-hint" = "Collapsed posts only display a limited number of lines together with a button to show the full post";
 "settings.content.hide-repeated-boosts" = "Masquer les boosts répétés";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Réglages de contenu serveur";
 "settings.content.use-instance-settings" = "Utiliser les paramètres du serveur";
 "settings.content.expand-spoilers" = "Toujours afficher les messages sensibles";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -156,6 +156,8 @@
 "settings.content.collapse-long-posts" = "Comprimi i post lunghi";
 "settings.content.collapse-long-posts-hint" = "I post compressi visualizzano alcune righe del contenuto assieme ad un bottone per visualizzare tutto il post";
 "settings.content.hide-repeated-boosts" = "Nascondi le condivisioni ripetute";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Configurazione dei contenuti del Server";
 "settings.content.expand-spoilers" = "Visualizza sempre i contenuti sensibili";
 "settings.content.expand-media" = "Visualizzazione dei media";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -120,6 +120,8 @@
 "settings.content.collapse-long-posts" = "長い投稿を折りたたむ";
 "settings.content.collapse-long-posts-hint" = "折りたたまれた投稿には、限られた数の行のみが表示され、投稿全体を表示するボタンが表示されます";
 "settings.content.hide-repeated-boosts" = "度重なるブーストを隠す";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "サーバーコンテンツ設定";
 "settings.content.use-instance-settings" = "サーバー設定を使用する";
 "settings.content.expand-spoilers" = "センシティブな投稿を常に表示する";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -117,6 +117,8 @@
 "settings.content.hide-repeated-boosts" = "중복으로 부스트된 글 숨김";
 "settings.content.instance-settings" = "서버 콘텐츠 설정";
 "settings.content.use-instance-settings" = "서버에서 설정한 대로 맞춤";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.expand-spoilers" = "열람 주의 표시된 글 항상 가리지 않음";
 "settings.content.expand-media" = "표시할 미디어";
 "settings.content.default-sensitive" = "내 미디어 항상 민감함으로 표시";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -121,6 +121,8 @@
 "settings.content.collapse-long-posts-hint" = "Skjulte innlegg viser bare et begrenset antall linjer sammen med en knapp for å vise hele innlegget";
 "settings.content.hide-repeated-boosts" = "Skjul gjentatte forsterkninger";
 "settings.content.instance-settings" = "Innstillinger for serverinnhold";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.use-instance-settings" = "Bruk serverinnstillinger";
 "settings.content.expand-spoilers" = "Vis alltid sensitive innlegg";
 "settings.content.expand-media" = "Medievisning";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -156,6 +156,8 @@
 "settings.content.collapse-long-posts" = "Klap lange posts in";
 "settings.content.collapse-long-posts-hint" = "Alleen een beperkt aantal regels van ingeklapte posts wordt getoond, samen met een knop om de volledige post te tonen";
 "settings.content.hide-repeated-boosts" = "Verberg herhaalde boosts";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Serverinstellingen voor inhoud";
 "settings.content.use-instance-settings" = "Gebruik serverinstellingen";
 "settings.content.expand-spoilers" = "Toon gevoelige posts altijd";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "settings.content.collapse-long-posts" = "Zwijaj długie posty";
 "settings.content.collapse-long-posts-hint" = "Zwinięte posty wyświetlają tylko ograniczoną liczbę wierszy wraz z przyciskiem do wyświetlenia pełnego postu";
 "settings.content.hide-repeated-boosts" = "Ukryj powtórzone podbicia";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Ustawienia treści serwera";
 "settings.content.use-instance-settings" = "Zastosuj ustawienia serwera";
 "settings.content.expand-spoilers" = "Pokazuj wrażliwe posty";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "settings.content.collapse-long-posts" = "Reduzir postagens longas";
 "settings.content.collapse-long-posts-hint" = "As postagens reduzidas exibem apenas um número limitado de linhas junto com um botão para mostrá-la completa";
 "settings.content.hide-repeated-boosts" = "Ocultar boosts repetidos";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Configurações de conteúdo do servidor";
 "settings.content.use-instance-settings" = "Usar configurações do servidor";
 "settings.content.expand-spoilers" = "Sempre exibir postagens sensíveis";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "settings.content.collapse-long-posts-hint" = "Collapsed posts only display a limited number of lines together with a button to show the full post";
 "settings.content.boosts" = "Yükseltmeler";
 "settings.content.hide-repeated-boosts" = "Hide repeated boosts";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Server Content Settings";
 "settings.content.use-instance-settings" = "Use server settings";
 "settings.content.expand-spoilers" = "Always show sensitive posts";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -120,6 +120,8 @@
 "settings.content.collapse-long-posts" = "Згортати довгі дописи";
 "settings.content.collapse-long-posts-hint" = "У згорнутих публікаціях відображається лише обмежена кількість рядків разом із кнопкою, щоб показати повну публікацію";
 "settings.content.hide-repeated-boosts" = "Не відображати повторні поширення";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "Налаштування відображення сервера";
 "settings.content.use-instance-settings" = "Використовувати налаштування сервера";
 "settings.content.expand-spoilers" = "Дозволити відображати делікатний вміст";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -157,6 +157,8 @@
 "settings.content.collapse-long-posts" = "折叠长嘟文";
 "settings.content.collapse-long-posts-hint" = "被折叠嘟文只会显示前几行但会提供查看全文的按钮";
 "settings.content.hide-repeated-boosts" = "隐藏重复的转发";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "服务器内容设置";
 "settings.content.use-instance-settings" = "使用服务器设置";
 "settings.content.expand-spoilers" = "始终显示敏感内容";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -120,6 +120,8 @@
 "settings.content.collapse-long-posts" = "縮限長文";
 "settings.content.collapse-long-posts-hint" = "「縮限長文」將只顯示數行文字，另可按紐閱讀全文";
 "settings.content.hide-repeated-boosts" = "隱藏多重轉嘟";
+"settings.content.replies" = "Replies";
+"settings.content.show-replies" = "Show Replies";
 "settings.content.instance-settings" = "伺服器內容設定";
 "settings.content.use-instance-settings" = "沿用伺服器設定";
 "settings.content.expand-spoilers" = "顯示所有敏感嘟文";

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -70,7 +70,8 @@ public struct AccountDetailView: View {
           }
           StatusesListView(fetcher: viewModel,
                            client: client,
-                           routerPath: routerPath)
+                           routerPath: routerPath,
+                           showRepliesRegardless: true)
         case .followedTags:
           tagsListView
         case .lists:

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -34,6 +34,8 @@ public class UserPreferences: ObservableObject {
 
   @AppStorage("suppress_dupe_reblogs") public var suppressDupeReblogs: Bool = false
 
+  @AppStorage("show_replies") public var showReplies: Bool = true
+
   @AppStorage("inAppBrowserReaderView") public var inAppBrowserReaderView = false
 
   @AppStorage("haptic_tab") public var hapticTabSelectionEnabled = true

--- a/Packages/Models/Sources/Models/Status.swift
+++ b/Packages/Models/Sources/Models/Status.swift
@@ -103,6 +103,11 @@ public final class Status: AnyStatus, Codable, Identifiable, Equatable, Hashable
   public let sensitive: Bool
   public let language: String?
 
+  public var isThread: Bool{
+    reblog?.inReplyToId != nil || reblog?.inReplyToAccountId != nil ||
+      inReplyToId != nil || inReplyToAccountId != nil
+  }
+
   public init(id: String, content: HTMLString, account: Account, createdAt: ServerDate, editedAt: ServerDate?, reblog: ReblogStatus?, mediaAttachments: [MediaAttachment], mentions: [Mention], repliesCount: Int, reblogsCount: Int, favouritesCount: Int, card: Card?, favourited: Bool?, reblogged: Bool?, pinned: Bool?, bookmarked: Bool?, emojis: [Emoji], url: String?, application: Application?, inReplyToId: String?, inReplyToAccountId: String?, visibility: Visibility, poll: Poll?, spoilerText: HTMLString, filtered: [Filtered]?, sensitive: Bool, language: String?) {
     self.id = id
     self.content = content

--- a/Packages/Status/Sources/Status/List/StatusesListView.swift
+++ b/Packages/Status/Sources/Status/List/StatusesListView.swift
@@ -7,22 +7,26 @@ import SwiftUI
 
 public struct StatusesListView<Fetcher>: View where Fetcher: StatusesFetcher {
   @EnvironmentObject private var theme: Theme
+  @EnvironmentObject private var userPreferences: UserPreferences
 
   @ObservedObject private var fetcher: Fetcher
   // Whether this status is on a remote local timeline (many actions are unavailable if so)
   private let isRemote: Bool
   private let routerPath: RouterPath
   private let client: Client
+    private let showRepliesRegardless: Bool
 
   public init(fetcher: Fetcher,
               client: Client,
               routerPath: RouterPath,
-              isRemote: Bool = false)
+              isRemote: Bool = false,
+              showRepliesRegardless: Bool = false)
   {
     self.fetcher = fetcher
     self.isRemote = isRemote
     self.client = client
     self.routerPath = routerPath
+    self.showRepliesRegardless = showRepliesRegardless
   }
 
   public var body: some View {
@@ -45,7 +49,10 @@ public struct StatusesListView<Fetcher>: View where Fetcher: StatusesFetcher {
       .listRowSeparator(.hidden)
 
     case let .display(statuses, nextPageState):
-      ForEach(statuses, id: \.viewId) { status in
+      ForEach(statuses.filter({status in
+          !status.isThread || userPreferences.showReplies || showRepliesRegardless
+          
+      }), id: \.viewId) { status in
         StatusRowView(viewModel: { StatusRowViewModel(status: status,
                                                       client: client,
                                                       routerPath: routerPath,

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -82,8 +82,7 @@ public class StatusRowViewModel: ObservableObject {
   }
 
   var isThread: Bool {
-    status.reblog?.inReplyToId != nil || status.reblog?.inReplyToAccountId != nil ||
-      status.inReplyToId != nil || status.inReplyToAccountId != nil
+    status.isThread
   }
 
   var highlightRowColor: Color {

--- a/Packages/Timeline/Sources/Timeline/PendingStatusesObserver.swift
+++ b/Packages/Timeline/Sources/Timeline/PendingStatusesObserver.swift
@@ -5,19 +5,25 @@ import SwiftUI
 
 @MainActor
 class PendingStatusesObserver: ObservableObject {
-  @Published var pendingStatusesCount: Int = 0
+  @Published private(set) var pendingStatusesCount: Int = 0
 
   var disableUpdate: Bool = false
   var scrollToIndex: ((Int) -> Void)?
 
-  var pendingStatuses: [String] = [] {
+  let userPreferences = UserPreferences.shared
+
+  var pendingStatuses: [Status] = [] {
     didSet {
-      pendingStatusesCount = pendingStatuses.count
+      refreshCount()
     }
   }
 
+  func refreshCount() {
+    pendingStatusesCount = pendingStatuses.filter { !$0.isThread || userPreferences.showReplies }.count
+  }
+
   func removeStatus(status: Status) {
-    if !disableUpdate, let index = pendingStatuses.firstIndex(of: status.id) {
+    if !disableUpdate, let index = pendingStatuses.firstIndex(of: status) {
       pendingStatuses.removeSubrange(index ... (pendingStatuses.count - 1))
       HapticManager.shared.fireHaptic(of: .timeline)
     }
@@ -28,25 +34,31 @@ class PendingStatusesObserver: ObservableObject {
 
 struct PendingStatusesObserverView: View {
   @ObservedObject var observer: PendingStatusesObserver
+  @EnvironmentObject var userPreferences: UserPreferences
 
   var body: some View {
-    if observer.pendingStatusesCount > 0 {
-      HStack(spacing: 6) {
-        Spacer()
-        Button {
-          observer.scrollToIndex?(observer.pendingStatusesCount)
-        } label: {
-          Text("\(observer.pendingStatusesCount)")
-            // Accessibility: this results in a frame with a size of at least 44x44 at regular font size
-            .frame(minWidth: 30, minHeight: 30)
+    Group {
+      if observer.pendingStatusesCount > 0 {
+        HStack(spacing: 6) {
+          Spacer()
+          Button {
+            observer.scrollToIndex?(observer.pendingStatusesCount)
+          } label: {
+            Text("\(observer.pendingStatusesCount)")
+              // Accessibility: this results in a frame with a size of at least 44x44 at regular font size
+              .frame(minWidth: 30, minHeight: 30)
+          }
+          .accessibilityLabel("accessibility.tabs.timeline.unread-posts.label-\(observer.pendingStatusesCount)")
+          .accessibilityHint("accessibility.tabs.timeline.unread-posts.hint")
+          .buttonStyle(.bordered)
+          .background(.thinMaterial)
+          .cornerRadius(8)
         }
-        .accessibilityLabel("accessibility.tabs.timeline.unread-posts.label-\(observer.pendingStatusesCount)")
-        .accessibilityHint("accessibility.tabs.timeline.unread-posts.hint")
-        .buttonStyle(.bordered)
-        .background(.thinMaterial)
-        .cornerRadius(8)
+        .padding(12)
       }
-      .padding(12)
+    }
+    .onChange(of: userPreferences.showReplies) { _ in
+      observer.refreshCount()
     }
   }
 }

--- a/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineViewModel.swift
@@ -110,7 +110,7 @@ class TimelineViewModel: ObservableObject {
          isTimelineVisible,
          await !datasource.contains(statusId: event.status.id)
       {
-        pendingStatusesObserver.pendingStatuses.insert(event.status.id, at: 0)
+        pendingStatusesObserver.pendingStatuses.insert(event.status, at: 0)
         let newStatus = event.status
         await datasource.insert(newStatus, at: 0)
         await cacheHome()
@@ -292,7 +292,7 @@ extension TimelineViewModel: StatusesFetcher {
     await cacheHome()
 
     // Append new statuses in the timeline indicator.
-    pendingStatusesObserver.pendingStatuses.insert(contentsOf: newStatuses.map { $0.id }, at: 0)
+    pendingStatusesObserver.pendingStatuses.insert(contentsOf: newStatuses, at: 0)
 
     // High chance the user is scrolled to the top.
     // We need to update the statuses state, and then scroll to the previous top most status.


### PR DESCRIPTION
An user option to not show replies. There is the possibility to overwrite the option via a flag set when creating the view. This is necessary to show the replies when being in the specific tab in the account view. This option is triggered for all statuses in the account views, the display of replies is there (account tab) only managed via the old way.
Closes #1209