### PR TITLE
Add setting to control share button default behavior

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -27,6 +27,16 @@ struct ContentSettingsView: View {
           Text("settings.content.media.show.alt")
         }
       }.listRowBackground(theme.primaryBackgroundColor)
+      
+      Section("settings.content.sharing") {
+        Picker("settings.content.sharing.share-button-behavior", selection: $userPreferences.shareButtonBehavior) {
+          ForEach(PreferredShareButtonBehavior.allCases, id: \.rawValue) { option in
+            Text(option.title)
+              .tag(option)
+          }
+        }
+      }
+      .listRowBackground(theme.primaryBackgroundColor)
 
       Section("settings.content.instance-settings") {
         Toggle(isOn: $userPreferences.useInstanceContentSettings) {

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -130,6 +130,10 @@
 "settings.content.media.show.alt" = "Паказваць альт. тэкст";
 "settings.content.reading" = "Чытанне";
 "settings.content.posting" = "Размяшчэнне допісаў";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Паказаць усе";
 "enum.expand-media.hide" = "Схаваць усе";
 "enum.expand-media.hide-sensitive" = "Хаваць уражлівыя допісы";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -124,6 +124,10 @@
 "settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Llegint";
 "settings.content.posting" = "Publicant";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Mostra-ho tot";
 "enum.expand-media.hide" = "Oculta-ho tot";
 "enum.expand-media.hide-sensitive" = "Amaga el contingut sensible";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -164,6 +164,10 @@
 "settings.content.media.show.alt" = "ALT-Texte zeigen";
 "settings.content.reading" = "Lesen";
 "settings.content.posting" = "Schreiben";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "settings.push.duplicate.title" = "Doppelte-Mitteilungen-Korrigierer";
 "settings.push.duplicate.footer" = "Bekommst du doppelte Mitteilungen? Probier diesen magischen Knopf aus";
 "settings.push.duplicate.button.fix" = "🪄 Beheben";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -131,6 +131,10 @@
 "settings.content.media.show.alt" = "Show ALT Texts";
 "settings.content.reading" = "Reading";
 "settings.content.posting" = "Posting";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Show All";
 "enum.expand-media.hide" = "Hide All";
 "enum.expand-media.hide-sensitive" = "Hide Sensitive";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -130,6 +130,10 @@
 "settings.content.media.show.alt" = "Show ALT Texts";
 "settings.content.reading" = "Reading";
 "settings.content.posting" = "Posting";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Show All";
 "enum.expand-media.hide" = "Hide All";
 "enum.expand-media.hide-sensitive" = "Hide Sensitive";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -164,6 +164,10 @@
 "settings.content.media.show.alt" = "Mostrar texto ALT";
 "settings.content.reading" = "Leyendo";
 "settings.content.posting" = "Publicando";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "settings.push.duplicate.title" = "Arreglar notificaciones duplicadas";
 "settings.push.duplicate.footer" = "¿Recibes notificaciones por duplicado? Usa este botón mágico para arreglarlo";
 "settings.push.duplicate.button.fix" = "🪄 Arréglalo";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -164,6 +164,10 @@
 "settings.content.media.show.alt" = "Erakutsi deskribapenak";
 "settings.content.reading" = "Irakurtzean";
 "settings.content.posting" = "Bidaltzean";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "settings.push.duplicate.title" = "Bikoiztutako jakinarazpenen konpontzailea";
 "settings.push.duplicate.footer" = "Jakinarazpenak birritan jasotzen al dituzu? Sakatu botoi magikoa arazoa konpontzeko";
 "settings.push.duplicate.button.fix" = "🪄 Konpondu";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -125,6 +125,10 @@
 "settings.content.media.show.alt" = "Montrer les textes ALT";
 "settings.content.reading" = "Lecture";
 "settings.content.posting" = "Publication";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Afficher tout";
 "enum.expand-media.hide" = "Masquer tout";
 "enum.expand-media.hide-sensitive" = "Masquer sensible";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -163,6 +163,10 @@
 "settings.content.media.show.alt" = "Mostra i testi alternativi";
 "settings.content.reading" = "Lettura";
 "settings.content.posting" = "Composizione";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Mostra tutti";
 "enum.expand-media.hide" = "Nascondi tutti";
 "enum.expand-media.hide-sensitive" = "Nascondi sensibili";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -130,6 +130,10 @@
 "settings.content.media.show.alt" = "注釈を表示";
 "settings.content.reading" = "リーディング";
 "settings.content.posting" = "ポスティング";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "全て表示";
 "enum.expand-media.hide" = "全て隠す";
 "enum.expand-media.hide-sensitive" = "センシティブなものは隠す";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -125,6 +125,10 @@
 "settings.content.media.show.alt" = "미디어 설명 버튼 표시";
 "settings.content.reading" = "읽을 때";
 "settings.content.posting" = "올릴 때";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "모두 표시하기";
 "enum.expand-media.hide" = "모두 가리기";
 "enum.expand-media.hide-sensitive" = "민감한 미디어만 가리기";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -130,6 +130,10 @@
 "settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Lesing";
 "settings.content.posting" = "Innlegg";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Vis alle";
 "enum.expand-media.hide" = "Skjul alle";
 "enum.expand-media.hide-sensitive" = "Skjul sensitive";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -164,6 +164,10 @@
 "settings.content.media.show.alt" = "Toon ALT-teksten";
 "settings.content.reading" = "Lezen";
 "settings.content.posting" = "Posten";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "settings.push.duplicate.title" = "Dubbele meldingen";
 "settings.push.duplicate.footer" = "Ontvang je dubbele meldingen? Gebruik deze magische knop om dit probleem te verhelpen";
 "settings.push.duplicate.button.fix" = "🪄 Los op";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -125,6 +125,10 @@
 "settings.content.media.show.alt" = "Pokazuj alternatywny tekst";
 "settings.content.reading" = "Czytanie postów";
 "settings.content.posting" = "Wysyłanie postów";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Pokazuj wszystkie";
 "enum.expand-media.hide" = "Ukryj wszystkie";
 "enum.expand-media.hide-sensitive" = "Ukryj wrażliwe";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -125,6 +125,10 @@
 "settings.content.media.show.alt" = "Mostrar textos ALT";
 "settings.content.reading" = "Lendo";
 "settings.content.posting" = "Postagem";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Exibir Todas";
 "enum.expand-media.hide" = "Esconder Todas";
 "enum.expand-media.hide-sensitive" = "Ocultar Sensível";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -125,6 +125,10 @@
 "settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Reading";
 "settings.content.posting" = "Posting";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Show All";
 "enum.expand-media.hide" = "Hide All";
 "enum.expand-media.hide-sensitive" = "Hide Sensitive";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -130,6 +130,10 @@
 "settings.content.media.show.alt" = "Показати ALT тексти";
 "settings.content.reading" = "Читання";
 "settings.content.posting" = "Публікація";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "Відобразити все";
 "enum.expand-media.hide" = "Приховати все";
 "enum.expand-media.hide-sensitive" = "Приховувати вміст, позначений як делікатний";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -165,6 +165,10 @@
 "settings.content.media.show.alt" = "显示图片描述";
 "settings.content.reading" = "阅读设置";
 "settings.content.posting" = "发布设置";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 
 "settings.push.duplicate.title" = "重复推送通知修复器";
 "settings.push.duplicate.footer" = "有收到重复的推送通知？试试用这个魔法按钮去修复吧";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -130,6 +130,10 @@
 "settings.content.media.show.alt" = "顯示圖片描述";
 "settings.content.reading" = "閱讀";
 "settings.content.posting" = "發表";
+"settings.content.sharing" = "Sharing";
+"settings.content.sharing.share-button-behavior" = "Share Button Behavior";
+"settings.content.sharing.share-behavior.link-only" = "Link Only";
+"settings.content.sharing.share-behavior.link-and-text" = "Link and Text";
 "enum.expand-media.show" = "全部顯示";
 "enum.expand-media.hide" = "全部隱藏";
 "enum.expand-media.hide-sensitive" = "隱藏敏感題材";

--- a/Packages/Env/Sources/Env/PreferredShareButtonBehavior.swift
+++ b/Packages/Env/Sources/Env/PreferredShareButtonBehavior.swift
@@ -1,0 +1,14 @@
+import Foundation
+import SwiftUI
+
+public enum PreferredShareButtonBehavior: Int, CaseIterable, Codable {
+  case linkOnly
+  case linkAndText
+  
+  public var title: LocalizedStringKey {
+    switch self {
+    case .linkOnly: return "settings.content.sharing.share-behavior.link-only"
+    case .linkAndText: return "settings.content.sharing.share-behavior.link-and-text"
+    }
+  }
+}

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -53,6 +53,8 @@ public class UserPreferences: ObservableObject {
   @AppStorage("requested_review") public var requestedReview = false
 
   @AppStorage("collapse-long-posts") public var collapseLongPosts = true
+    
+  @AppStorage("share-button-behavior") public var shareButtonBehavior: PreferredShareButtonBehavior = .linkAndText
 
   public enum SwipeActionsIconStyle: String, CaseIterable {
     case iconWithText, iconOnly

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowActionsView.swift
@@ -8,6 +8,7 @@ struct StatusRowActionsView: View {
   @EnvironmentObject private var theme: Theme
   @EnvironmentObject private var currentAccount: CurrentAccount
   @EnvironmentObject private var statusDataController: StatusDataController
+  @EnvironmentObject private var userPreferences: UserPreferences
   @ObservedObject var viewModel: StatusRowViewModel
 
   func privateBoost() -> Bool {
@@ -121,15 +122,26 @@ struct StatusRowActionsView: View {
             if let urlString = viewModel.finalStatus.url,
                let url = URL(string: urlString)
             {
-              ShareLink(item: url,
-                        subject: Text(viewModel.finalStatus.account.safeDisplayName),
-                        message: Text(viewModel.finalStatus.content.asRawText))
-              {
-                action.image(dataController: statusDataController)
+              switch userPreferences.shareButtonBehavior {
+              case .linkOnly:
+                ShareLink(item: url)
+                {
+                  action.image(dataController: statusDataController)
+                }
+                .buttonStyle(.statusAction())
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("status.action.share-link")
+              case .linkAndText:
+                ShareLink(item: url,
+                          subject: Text(viewModel.finalStatus.account.safeDisplayName),
+                          message: Text(viewModel.finalStatus.content.asRawText))
+                {
+                  action.image(dataController: statusDataController)
+                }
+                .buttonStyle(.statusAction())
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("status.action.share-link")
               }
-              .buttonStyle(.statusAction())
-              .accessibilityElement(children: .combine)
-              .accessibilityLabel("status.action.share-link")
             }
           } else {
             actionButton(action: action)


### PR DESCRIPTION
This adds a setting to control the behavior of the share button on the status row actions view. Currently, it always shares the link to the post as well as the post text. 

In iOS 16.4, Apple added iMessage unfurling for Mastodon URLs. When sharing posts from Ice Cubes via iMessage, this leads to the recipient seeing two copies of the post: one from the unfurled link and one from Ice Cubes including the post text. 

Users will now have the option to exclude the post text from their sharing. This is easier than tapping the 3-dots button on the post (which is kind of small) and then expanding the Share menu in the context menu, which is the other way to access this functionality at the moment.

The default value for the new option will be "Link and Text", which is the current behavior - so we won't change the behavior on existing users.

[Settings Screenshot](https://github.com/Dimillian/IceCubesApp/assets/1245988/1d3070d0-da2c-4728-8007-d7742f0c1fe8)

