### PR TITLE
More compact account list rows

### DIFF
--- a/IceCubesApp/Resources/Localization/Plurals/be.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/be.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/IceCubesApp/Resources/Localization/Plurals/ca.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/ca.lproj/Localizable.stringsdict
@@ -2,37 +2,53 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>timeline-new-posts %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@timelineNewPosts@</string>
-        <key>timelineNewPosts</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string>%lld publicació nova</string>
-            <key>other</key>
-            <string>%lld publicacions noves</string>
-        </dict>
-    </dict>
-    <key>notifications-others-count %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@noficationsOthersCount@</string>
-        <key>noficationsOthersCount</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string> i %lld més </string>
-            <key>other</key>
-            <string> i %lld més </string>
-        </dict>
-    </dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
+	<key>timeline-new-posts %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@timelineNewPosts@</string>
+		<key>timelineNewPosts</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld publicació nova</string>
+			<key>other</key>
+			<string>%lld publicacions noves</string>
+		</dict>
+	</dict>
+	<key>notifications-others-count %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@noficationsOthersCount@</string>
+		<key>noficationsOthersCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string> i %lld més </string>
+			<key>other</key>
+			<string> i %lld més </string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/Plurals/de.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/de.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.detail.featured-tags-n-posts %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@accountDetailFeaturedTagsPosts@</string>
+		<key>accountDetailFeaturedTagsPosts</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld Beitrag</string>
+			<key>other</key>
+			<string>%lld Beiträge</string>
+		</dict>
+	</dict>
 	<key>account.detail.n-fields %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -18,20 +34,20 @@
 			<string>%lld Felder</string>
 		</dict>
 	</dict>
-	<key>account.detail.featured-tags-n-posts %lld</key>
+	<key>account.label.followers %lld %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@accountDetailFeaturedTagsPosts@</string>
-		<key>accountDetailFeaturedTagsPosts</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lld</string>
 			<key>one</key>
-			<string>%lld Beitrag</string>
+			<string>%2$@ follower</string>
 			<key>other</key>
-			<string>%lld Beiträge</string>
+			<string>%2$@ followers</string>
 		</dict>
 	</dict>
 	<key>timeline-new-posts %lld</key>

--- a/IceCubesApp/Resources/Localization/Plurals/en-GB.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/en-GB.lproj/Localizable.stringsdict
@@ -2,37 +2,53 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>timeline-new-posts %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@timelineNewPosts@</string>
-        <key>timelineNewPosts</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string>%lld new post</string>
-            <key>other</key>
-            <string>%lld new posts</string>
-        </dict>
-    </dict>
-    <key>notifications-others-count %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@noficationsOthersCount@</string>
-        <key>noficationsOthersCount</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string> and %lld other </string>
-            <key>other</key>
-            <string> and %lld others </string>
-        </dict>
-    </dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
+	<key>timeline-new-posts %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@timelineNewPosts@</string>
+		<key>timelineNewPosts</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld new post</string>
+			<key>other</key>
+			<string>%lld new posts</string>
+		</dict>
+	</dict>
+	<key>notifications-others-count %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@noficationsOthersCount@</string>
+		<key>noficationsOthersCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string> and %lld other </string>
+			<key>other</key>
+			<string> and %lld others </string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/Plurals/en.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/en.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/IceCubesApp/Resources/Localization/Plurals/eu.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/eu.lproj/Localizable.stringsdict
@@ -2,7 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>account.detail.n-fields %lld</key>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
+	<key>account.detail.n-fields %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@accountDetailFields@</string>
@@ -18,7 +34,7 @@
 			<string>%lld eremu</string>
 		</dict>
 	</dict>
-    <key>account.detail.featured-tags-n-posts %lld</key>
+	<key>account.detail.featured-tags-n-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@accountDetailFeaturedTagsPosts@</string>
@@ -34,7 +50,7 @@
 			<string>%lld bidalketa</string>
 		</dict>
 	</dict>
-    <key>timeline-new-posts %lld</key>
+	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@timelineNewPosts@</string>
@@ -50,7 +66,7 @@
 			<string>%lld bidalketa berri</string>
 		</dict>
 	</dict>
-    <key>notifications-others-count %lld</key>
+	<key>notifications-others-count %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@noficationsOthersCount@</string>
@@ -66,7 +82,7 @@
 			<string> eta beste %lld</string>
 		</dict>
 	</dict>
-    <key>notifications.label.favorite %lld</key>
+	<key>notifications.label.favorite %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@count@</string>
@@ -82,7 +98,7 @@
 			<string>(e)k gogoko dute</string>
 		</dict>
 	</dict>
-    <key>notifications.label.follow %lld</key>
+	<key>notifications.label.follow %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@count@</string>
@@ -98,7 +114,7 @@
 			<string>(e)k jarraitzen dizute</string>
 		</dict>
 	</dict>
-    <key>notifications.label.mention %lld</key>
+	<key>notifications.label.mention %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@count@</string>
@@ -114,7 +130,7 @@
 			<string>(e)k aipatu zaituzte</string>
 		</dict>
 	</dict>
-    <key>notifications.label.reblog %lld</key>
+	<key>notifications.label.reblog %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@count@</string>
@@ -130,7 +146,7 @@
 			<string>(e)k bultzatu dute</string>
 		</dict>
 	</dict>
-    <key>status.summary.n-favorites %lld</key>
+	<key>status.summary.n-favorites %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@statusFavouritesCount@</string>
@@ -146,7 +162,7 @@
 			<string>%lld(e)k gogoko</string>
 		</dict>
 	</dict>
-    <key>status.summary.n-boosts %lld</key>
+	<key>status.summary.n-boosts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@statusBoostsCount@</string>
@@ -162,23 +178,23 @@
 			<string>%lld bultzada</string>
 		</dict>
 	</dict>
-    <key>status.summary.n-replies %lld</key>
- 	<dict>
- 		<key>NSStringLocalizedFormatKey</key>
- 		<string>%#@statusRepliesCount@</string>
- 		<key>statusRepliesCount</key>
- 		<dict>
- 			<key>NSStringFormatSpecTypeKey</key>
- 			<string>NSStringPluralRuleType</string>
- 			<key>NSStringFormatValueTypeKey</key>
- 			<string>lld</string>
- 			<key>one</key>
- 			<string>Erantzun %lld</string>
- 			<key>other</key>
- 			<string>%lld erantzun</string>
- 		</dict>
- 	</dict>
-    <key>status.poll.n-votes %lld</key>
+	<key>status.summary.n-replies %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@statusRepliesCount@</string>
+		<key>statusRepliesCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>Erantzun %lld</string>
+			<key>other</key>
+			<string>%lld erantzun</string>
+		</dict>
+	</dict>
+	<key>status.poll.n-votes %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@statusVotesCount@</string>
@@ -194,13 +210,13 @@
 			<string>%lld boto</string>
 		</dict>
 	</dict>
-    <key>design.tag.n-posts-from-n-participants %lld %lld</key>
+	<key>design.tag.n-posts-from-n-participants %lld %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%2$#@tagParticipantsCount@ %1$#@tagPostsCount@</string>
 		<key>tagParticipantsCount</key>
 		<dict>
-            	<key>NSStringFormatSpecTypeKey</key>
+			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lld</string>
@@ -221,13 +237,13 @@
 			<string>%lld bidalketa</string>
 		</dict>
 	</dict>
-    <key>timeline.n-recent-from-n-participants %lld %lld</key>
+	<key>timeline.n-recent-from-n-participants %lld %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%2$#@tagParticipantsCount@ %1$#@tagPostsCount@</string>
 		<key>tagParticipantsCount</key>
 		<dict>
-            	<key>NSStringFormatSpecTypeKey</key>
+			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lld</string>
@@ -248,7 +264,7 @@
 			<string>%lld bidalketa</string>
 		</dict>
 	</dict>
-    <key>status.poll.n-votes-voters %lld %lld</key>
+	<key>status.poll.n-votes-voters %lld %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%2$#@tagVotersCount@ %1$#@tagVotesCount@</string>
@@ -275,7 +291,7 @@
 			<string>%lld boto-emaileren</string>
 		</dict>
 	</dict>
-    <key>tag.suggested.mentions-%lld</key>
+	<key>tag.suggested.mentions-%lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@mentionsCount@</string>

--- a/IceCubesApp/Resources/Localization/Plurals/fr.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/fr.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ abonné·e</string>
+			<key>other</key>
+			<string>%2$@ abonné·e·s</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/IceCubesApp/Resources/Localization/Plurals/it.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/it.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -19,20 +35,20 @@
 		</dict>
 	</dict>
 	<key>notifications-others-count %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@noficationsOthersCount@</string>
-        <key>noficationsOthersCount</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string> e un altro </string>
-            <key>other</key>
-            <string> e %lld altri </string>
-        </dict>
-    </dict>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@noficationsOthersCount@</string>
+		<key>noficationsOthersCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string> e un altro </string>
+			<key>other</key>
+			<string> e %lld altri </string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/Plurals/ja.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/ja.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -19,20 +35,20 @@
 		</dict>
 	</dict>
 	<key>notifications-others-count %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@noficationsOthersCount@</string>
-        <key>noficationsOthersCount</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string> and %lld other </string>
-            <key>other</key>
-            <string> and %lld others </string>
-        </dict>
-    </dict>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@noficationsOthersCount@</string>
+		<key>noficationsOthersCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string> and %lld other </string>
+			<key>other</key>
+			<string> and %lld others </string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/Plurals/nb.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/nb.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/IceCubesApp/Resources/Localization/Plurals/nl.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/nl.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -18,23 +34,22 @@
 			<string>%lld nieuwe posts</string>
 		</dict>
 	</dict>
-
 	<key>notifications-others-count %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@noficationsOthersCount@</string>
-        <key>noficationsOthersCount</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string> en %lld andere </string>
-            <key>other</key>
-            <string> en %lld anderen </string>
-        </dict>
-    </dict>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@noficationsOthersCount@</string>
+		<key>noficationsOthersCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string> en %lld andere </string>
+			<key>other</key>
+			<string> en %lld anderen </string>
+		</dict>
+	</dict>
 	<key>notifications.label.mention %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -51,7 +66,6 @@
 			<string>hebben jou vermeld</string>
 		</dict>
 	</dict>
-
 	<key>notifications.label.follow %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -68,7 +82,6 @@
 			<string>volgen jou</string>
 		</dict>
 	</dict>
-
 	<key>notifications.label.reblog %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -85,7 +98,6 @@
 			<string>boostten</string>
 		</dict>
 	</dict>
-
 	<key>notifications.label.favorite %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -102,6 +114,5 @@
 			<string>markeerden jouw bericht als favoriet</string>
 		</dict>
 	</dict>
-
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/Plurals/pl.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/pl.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -73,7 +89,7 @@
 			<key>other</key>
 			<string>%lld podbić</string>
 		</dict>
-	</dict>	
+	</dict>
 	<key>status.poll.n-votes %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -91,7 +107,7 @@
 			<key>other</key>
 			<string>%lld głosów</string>
 		</dict>
-	</dict>	
+	</dict>
 	<key>status.summary.n-replies %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -107,7 +123,7 @@
 			<key>other</key>
 			<string>%lld odpowiedzi</string>
 		</dict>
-	</dict>		
+	</dict>
 	<key>status.poll.n-votes-voters %lld %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -136,7 +152,7 @@
 			<key>other</key>
 			<string>od %lld głosujących</string>
 		</dict>
-	</dict>	
+	</dict>
 	<key>account.detail.featured-tags-n-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -172,7 +188,7 @@
 			<key>other</key>
 			<string>%lld pól</string>
 		</dict>
-	</dict>	
+	</dict>
 	<key>tag.suggested.mentions-%lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -190,7 +206,7 @@
 			<key>other</key>
 			<string>%lld wzmianek</string>
 		</dict>
-	</dict>	
+	</dict>
 	<key>design.tag.n-posts-from-n-participants %lld %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -248,7 +264,6 @@
 			<key>other</key>
 			<string>od %lld uczestników</string>
 		</dict>
-	</dict>	
-	
+	</dict>
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/Plurals/pt-BR.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/pt-BR.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/IceCubesApp/Resources/Localization/Plurals/tr.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/tr.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -19,20 +35,20 @@
 		</dict>
 	</dict>
 	<key>notifications-others-count %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@noficationsOthersCount@</string>
-        <key>noficationsOthersCount</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string> and %lld other </string>
-            <key>other</key>
-            <string> and %lld others </string>
-        </dict>
-    </dict>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@noficationsOthersCount@</string>
+		<key>noficationsOthersCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string> and %lld other </string>
+			<key>other</key>
+			<string> and %lld others </string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/Plurals/uk.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/uk.lproj/Localizable.stringsdict
@@ -2,37 +2,53 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>timeline-new-posts %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@timelineNewPosts@</string>
-        <key>timelineNewPosts</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string>%lld new post</string>
-            <key>other</key>
-            <string>%lld new posts</string>
-        </dict>
-    </dict>
-    <key>notifications-others-count %lld</key>
-    <dict>
-        <key>NSStringLocalizedFormatKey</key>
-        <string>%#@noficationsOthersCount@</string>
-        <key>noficationsOthersCount</key>
-        <dict>
-            <key>NSStringFormatSpecTypeKey</key>
-            <string>NSStringPluralRuleType</string>
-            <key>NSStringFormatValueTypeKey</key>
-            <string>lld</string>
-            <key>one</key>
-            <string> and %lld other </string>
-            <key>other</key>
-            <string> and %lld others </string>
-        </dict>
-    </dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
+	<key>timeline-new-posts %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@timelineNewPosts@</string>
+		<key>timelineNewPosts</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld new post</string>
+			<key>other</key>
+			<string>%lld new posts</string>
+		</dict>
+	</dict>
+	<key>notifications-others-count %lld</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@noficationsOthersCount@</string>
+		<key>noficationsOthersCount</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string> and %lld other </string>
+			<key>other</key>
+			<string> and %lld others </string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/IceCubesApp/Resources/Localization/Plurals/zh-Hans.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/zh-Hans.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/IceCubesApp/Resources/Localization/Plurals/zh-Hant.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/zh-Hant.lproj/Localizable.stringsdict
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>account.label.followers %lld %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@followers@</string>
+		<key>followers</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%2$@ follower</string>
+			<key>other</key>
+			<string>%2$@ followers</string>
+		</dict>
+	</dict>
 	<key>timeline-new-posts %lld</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -287,7 +287,7 @@
 "account.follow-request.reject" = "Rejeter";
 "account.follow-requests.pending-requests" = "Demandes en attente";
 "account.follow-requests.instructions" = "Les utilisateurs ne verront pas vos messages tant que vous ne les acceptez pas.";
-"account.followers" = "Abonnés";
+"account.followers" = "Abonné·e·s";
 "account.following" = "Abonnements";
 "account.list.create" = "Créer une nouvelle liste";
 "account.list.create.confirm" = "Créer la liste";
@@ -486,7 +486,7 @@
 "status.summary.n-favorites %lld" = "%lld favoris";
 "status.summary.edit-history" = "Edit History";
 "status.visibility.direct" = "Privé";
-"status.visibility.follower" = "Abonnés";
+"status.visibility.follower" = "Abonné·e";
 "status.visibility.public" = "Tout le monde";
 "status.visibility.unlisted" = "Non répertorié";
 

--- a/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
+++ b/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
@@ -50,39 +50,35 @@ public struct AccountsListRow: View {
         Text("@\(viewModel.account.acct)")
           .font(.scaledFootnote)
           .foregroundColor(.gray)
-        EmojiTextApp(viewModel.account.note, emojis: viewModel.account.emojis)
+
+        // First parameter is the number for the plural
+        // Second parameter is the formatted string to show
+        Text("account.label.followers \(viewModel.account.followersCount) \(viewModel.account.followersCount, format: .number.notation(.compactName))")
           .font(.scaledFootnote)
+
+        if let field = viewModel.account.fields.filter({ $0.verifiedAt != nil }).first {
+          HStack(spacing: 2) {
+            Image(systemName: "checkmark.seal")
+              .font(.scaledFootnote)
+              .foregroundColor(.green)
+
+            EmojiTextApp(field.value, emojis: viewModel.account.emojis)
+              .font(.scaledFootnote)
+              .emojiSize(Font.scaledFootnoteFont.emojiSize)
+              .emojiBaselineOffset(Font.scaledFootnoteFont.emojiBaselineOffset)
+              .environment(\.openURL, OpenURLAction { url in
+                routerPath.handle(url: url)
+              })
+          }
+        }
+
+        EmojiTextApp(viewModel.account.note, emojis: viewModel.account.emojis, lineLimit: 2)
+          .font(.scaledCaption)
           .emojiSize(Font.scaledFootnoteFont.emojiSize)
           .emojiBaselineOffset(Font.scaledFootnoteFont.emojiBaselineOffset)
-          .lineLimit(3)
           .environment(\.openURL, OpenURLAction { url in
             routerPath.handle(url: url)
           })
-
-        let fields = viewModel.account.fields.filter { $0.verifiedAt != nil }
-
-        if !fields.isEmpty {
-          Capsule()
-            .frame(height: 1)
-            .foregroundStyle(.regularMaterial)
-            .padding(.vertical, 5)
-            .padding(.horizontal)
-
-          ForEach(fields) { field in
-            HStack {
-              Image(systemName: "checkmark.seal")
-                .foregroundColor(.green)
-              EmojiTextApp(field.value, emojis: viewModel.account.emojis)
-                .font(.scaledFootnote)
-                .emojiSize(Font.scaledFootnoteFont.emojiSize)
-                .emojiBaselineOffset(Font.scaledFootnoteFont.emojiBaselineOffset)
-                .environment(\.openURL, OpenURLAction { url in
-                  routerPath.handle(url: url)
-                })
-            }
-            .padding(.top, 5)
-          }
-        }
 
         if isFollowRequest {
           FollowRequestButtons(account: viewModel.account,


### PR DESCRIPTION
Current issue:
- The account list row is not compact; it shows the bio entirely, that might take an entire screen!
- followers count is often a relevant information to get on that screen, to decide to follow back, or simply to see the impact of a boost.

Proposal:
- Followers count & verification link before bio
- bio limited to 2 lines
- Using footnote for the verified site ; and caption for the bio 

Before / After images
<img width="380" alt="Capture d’écran 2023-06-26 à 13 57 50" src="https://github.com/Dimillian/IceCubesApp/assets/8696821/04f0116b-04e8-4919-b879-aae7312909a7"> <img width="380" alt="Capture d’écran 2023-06-26 à 13 57 17" src="https://github.com/Dimillian/IceCubesApp/assets/8696821/31aa0cc5-f774-41c7-b0c4-77c303432277">
