### PR TITLE
de: Update Localizable.stringsdict

### DIFF
--- a/IceCubesApp/Resources/Localization/Plurals/de.lproj/Localizable.stringsdict
+++ b/IceCubesApp/Resources/Localization/Plurals/de.lproj/Localizable.stringsdict
@@ -45,9 +45,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lld</string>
 			<key>one</key>
-			<string>%2$@ follower</string>
+			<string>%2$@ Follower</string>
 			<key>other</key>
-			<string>%2$@ followers</string>
+			<string>%2$@ Follower</string>
 		</dict>
 	</dict>
 	<key>timeline-new-posts %lld</key>


### PR DESCRIPTION
For some yet unknown reason, "follower" is "translated" as "Follower" in the standard German UI. So IceCubes will also get that...