### PR TITLE
Add feature to block or mute user directly from post

### DIFF
--- a/Packages/Status/Sources/Status/List/StatusesListView.swift
+++ b/Packages/Status/Sources/Status/List/StatusesListView.swift
@@ -9,6 +9,7 @@ public struct StatusesListView<Fetcher>: View where Fetcher: StatusesFetcher {
   @EnvironmentObject private var theme: Theme
 
   @ObservedObject private var fetcher: Fetcher
+  // Whether this status is on a remote local timeline (many actions are unavailable if so)
   private let isRemote: Bool
   private let routerPath: RouterPath
   private let client: Client

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -99,6 +99,11 @@ public struct StatusRowView: View {
     }
     .contextMenu {
       contextMenu
+        .onAppear {
+          Task {
+            await viewModel.loadAuthorRelationship()
+          }
+        }
     }
     .swipeActions(edge: .trailing) {
       // The actions associated with the swipes are exposed as custom accessibility actions and there is no way to remove them.

--- a/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowViewModel.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public class StatusRowViewModel: ObservableObject {
   let status: Status
   let isFocused: Bool
+  // Whether this status is on a remote local timeline (many actions are unavailable if so)
   let isRemote: Bool
   let showActions: Bool
   let textDisabled: Bool
@@ -32,6 +33,17 @@ public class StatusRowViewModel: ObservableObject {
   @Published var isLoadingRemoteContent: Bool = false
   @Published var localStatusId: String?
   @Published var localStatus: Status?
+  
+  // The relationship our user has to the author of this post, if available
+  @Published var authorRelationship: Relationship? {
+    didSet {
+      // if we are newly blocking or muting the author, force collapse post so it goes away
+      if let relationship = authorRelationship,
+         relationship.blocking || relationship.muting {
+        lineLimit = 0
+      }
+    }
+  }
 
   // used by the button to expand a collapsed post
   @Published var isCollapsed: Bool = true {
@@ -180,6 +192,11 @@ public class StatusRowViewModel: ObservableObject {
     } else {
       routerPath.navigate(to: .accountDetail(id: mention.id))
     }
+  }
+
+  func loadAuthorRelationship() async {
+    let relationships: [Relationship]? = try? await client.get(endpoint: Accounts.relationships(ids: [status.reblog?.account.id ?? status.account.id]))
+    authorRelationship = relationships?.first
   }
 
   private func embededStatusURL() -> URL? {

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowHeaderView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowHeaderView.swift
@@ -113,6 +113,11 @@ struct StatusRowHeaderView: View {
   private var contextMenuButton: some View {
     Menu {
       StatusRowContextMenu(viewModel: viewModel)
+        .onAppear {
+          Task {
+            await viewModel.loadAuthorRelationship()
+          }
+        }
     } label: {
       Image(systemName: "ellipsis")
         .frame(width: 40, height: 40)

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowHeaderView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowHeaderView.swift
@@ -115,7 +115,7 @@ struct StatusRowHeaderView: View {
       StatusRowContextMenu(viewModel: viewModel)
     } label: {
       Image(systemName: "ellipsis")
-        .frame(width: 20, height: 20)
+        .frame(width: 40, height: 40)
     }
     .menuStyle(.borderlessButton)
     .foregroundColor(.gray)


### PR DESCRIPTION
Inspired by a user commenting that the app doesn't have this feature: https://ioc.exchange/@shac/110645300514488847

To avoid calling the /accounts/relationships endpoint for every single status displayed, the relationships data is only loaded when the menu is activated.
When the API call comes back, the items are added to the menu (updating the view model appears to cause the menu to update, even while it is displayed)
Borrowed blocking & muting logic/menu items from AccountDetailContextMenu.

Addresses #616 