### PR TITLE
Allow specifying the default reply visibility

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -110,7 +110,7 @@ struct ContentSettingsView: View {
   }
 }
 
-extension View {
+fileprivate extension View {
   func onChange(of: some Equatable, _ perform: @escaping () -> Void) -> some View {
     if #available(iOS 17, macOS 14, *) {
       return onChange(of: of) { oldValue, newValue in

--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -92,7 +92,7 @@ struct ContentSettingsView: View {
             }
           }
         }
-        .onChange(of: userPreferences.postVisibility) { newValue in
+        .onChange(of: userPreferences.postVisibility) {
           userPreferences.conformReplyVisibilityConstraints()
         }
         
@@ -107,5 +107,19 @@ struct ContentSettingsView: View {
     .navigationTitle("settings.content.navigation-title")
     .scrollContentBackground(.hidden)
     .background(theme.secondaryBackgroundColor)
+  }
+}
+
+extension View {
+  func onChange(of: some Equatable, _ perform: @escaping () -> Void) -> some View {
+    if #available(iOS 17, macOS 14, *) {
+      return onChange(of: of) { oldValue, newValue in
+        perform()
+      }
+    } else {
+      return onChange(of: of) { value in
+        perform()
+      }
+    }
   }
 }

--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -83,7 +83,19 @@ struct ContentSettingsView: View {
           }
         }
         .disabled(userPreferences.useInstanceContentSettings)
-
+        
+        Picker("settings.content.default-reply-visibility", selection: $userPreferences.appDefaultReplyVisibility) {
+          ForEach(Visibility.allCases, id: \.rawValue) { vis in
+            if UserPreferences.getIntOfVisibility(vis) <=
+                UserPreferences.getIntOfVisibility(userPreferences.postVisibility) {
+              Text(vis.title).tag(vis)
+            }
+          }
+        }
+        .onChange(of: userPreferences.postVisibility) { newValue in
+          userPreferences.conformReplyVisibilityConstraints()
+        }
+        
         Toggle(isOn: $userPreferences.appDefaultPostsSensitive) {
           Text("settings.content.default-sensitive")
         }

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "settings.content.expand-media" = "Паказ медыя";
 "settings.content.default-sensitive" = "Заўсёды адзначаць медыя як уражлівыя";
 "settings.content.default-visibility" = "Бачнасць допісаў";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Медыя";
 "settings.content.media.show.alt" = "Паказваць альт. тэкст";
 "settings.content.reading" = "Чытанне";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 "settings.content.expand-media" = "Visibilitat del contingut multimèdia";
 "settings.content.default-sensitive" = "Marca sempre el contingut com a sensible";
 "settings.content.default-visibility" = "Visibilitat de les publicacions";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Media";
 "settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Llegint";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -162,6 +162,7 @@
 "settings.content.expand-media" = "Medienansicht";
 "settings.content.default-sensitive" = "Medien immer als sensibel kennzeichnen";
 "settings.content.default-visibility" = "Sichtbarkeit Beiträge";
+"settings.content.default-reply-visibility" = "Sichtbarkeit Antworten";
 "settings.content.media" = "Medien";
 "settings.content.media.show.alt" = "ALT-Texte zeigen";
 "settings.content.reading" = "Lesen";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -127,6 +127,7 @@
 "settings.content.expand-media" = "Media Display";
 "settings.content.default-sensitive" = "Always Mark Media as Sensitive";
 "settings.content.default-visibility" = "Posting Visibility";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Media";
 "settings.content.media.show.alt" = "Show ALT Texts";
 "settings.content.reading" = "Reading";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "settings.content.expand-media" = "Media Display";
 "settings.content.default-sensitive" = "Always Mark Media as Sensitive";
 "settings.content.default-visibility" = "Posting Visibility";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Media";
 "settings.content.media.show.alt" = "Show ALT Texts";
 "settings.content.reading" = "Reading";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -162,6 +162,7 @@
 "settings.content.expand-media" = "Mostrar el contenido multimedia";
 "settings.content.default-sensitive" = "Marcar siempre el contenido multimedia como sensible";
 "settings.content.default-visibility" = "Publicar visibilidad";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Multimedia";
 "settings.content.media.show.alt" = "Mostrar texto ALT";
 "settings.content.reading" = "Leyendo";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -162,6 +162,7 @@
 "settings.content.expand-media" = "Multimedia erakusteko hobespenak";
 "settings.content.default-sensitive" = "Markatu eduki guztia hunkigarri gisa";
 "settings.content.default-visibility" = "Edukiaren irismena";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Multimedia";
 "settings.content.media.show.alt" = "Erakutsi deskribapenak";
 "settings.content.reading" = "Irakurtzean";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 "settings.content.expand-media" = "Affichage des médias";
 "settings.content.default-sensitive" = "Toujours marquer les médias comme sensibles";
 "settings.content.default-visibility" = "Visibilité des publications";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Média";
 "settings.content.media.show.alt" = "Montrer les textes ALT";
 "settings.content.reading" = "Lecture";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "settings.content.expand-media" = "Visualizzazione dei media";
 "settings.content.default-sensitive" = "Segnala sempre i contenuti come sensibili";
 "settings.content.default-visibility" = "Visibilità del post";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Media";
 "settings.content.media.show.alt" = "Mostra i testi alternativi";
 "settings.content.reading" = "Lettura";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "settings.content.expand-media" = "メディア表示";
 "settings.content.default-sensitive" = "常にメディアをセンシティブなものとしてマークする";
 "settings.content.default-visibility" = "投稿の可視化";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "メディア";
 "settings.content.media.show.alt" = "注釈を表示";
 "settings.content.reading" = "リーディング";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 "settings.content.expand-media" = "표시할 미디어";
 "settings.content.default-sensitive" = "내 미디어 항상 민감함으로 표시";
 "settings.content.default-visibility" = "글 기본 공개 범위";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "미디어";
 "settings.content.media.show.alt" = "미디어 설명 버튼 표시";
 "settings.content.reading" = "읽을 때";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "settings.content.expand-media" = "Medievisning";
 "settings.content.default-sensitive" = "Marker alltid medier som sensitive";
 "settings.content.default-visibility" = "Innleggssynlighet";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Media";
 "settings.content.media.show.alt" = "Vis ALT-tekster";
 "settings.content.reading" = "Lesing";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -162,6 +162,7 @@
 "settings.content.expand-media" = "Mediaweergave";
 "settings.content.default-sensitive" = "Markeer media standaard als gevoelig";
 "settings.content.default-visibility" = "Standaard postzichtbaarheid";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Media";
 "settings.content.media.show.alt" = "Toon ALT-teksten";
 "settings.content.reading" = "Lezen";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 "settings.content.expand-media" = "Multimedia";
 "settings.content.default-sensitive" = "Oznaczaj media jako wrażliwe";
 "settings.content.default-visibility" = "Widoczność postów";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Media";
 "settings.content.media.show.alt" = "Pokazuj alternatywny tekst";
 "settings.content.reading" = "Czytanie postów";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 "settings.content.expand-media" = "Exibição de mídia";
 "settings.content.default-sensitive" = "Sempre marcar mídias como sensíveis";
 "settings.content.default-visibility" = "Visibilidade da postagem";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Mídia";
 "settings.content.media.show.alt" = "Mostrar textos ALT";
 "settings.content.reading" = "Lendo";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -121,6 +121,7 @@
 "settings.content.expand-media" = "Media display";
 "settings.content.default-sensitive" = "Always mark media as sensitive";
 "settings.content.default-visibility" = "Posting visibility";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Media";
 "settings.content.media.show.alt" = "Show ALT texts";
 "settings.content.reading" = "Reading";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "settings.content.expand-media" = "Відображення медіа";
 "settings.content.default-sensitive" = "Завжди позначати медія як делікатні";
 "settings.content.default-visibility" = "Видимість допису";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "Медіа";
 "settings.content.media.show.alt" = "Показати ALT тексти";
 "settings.content.reading" = "Читання";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -163,6 +163,7 @@
 "settings.content.expand-media" = "媒体显示";
 "settings.content.default-sensitive" = "始终将媒体标为敏感内容";
 "settings.content.default-visibility" = "默认发布内容可见性";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "媒体";
 "settings.content.media.show.alt" = "显示图片描述";
 "settings.content.reading" = "阅读设置";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "settings.content.expand-media" = "媒體顯示";
 "settings.content.default-sensitive" = "媒體一概標示為敏感";
 "settings.content.default-visibility" = "嘟文能見度";
+"settings.content.default-reply-visibility" = "Reply Visibility";
 "settings.content.media" = "媒體";
 "settings.content.media.show.alt" = "顯示圖片描述";
 "settings.content.reading" = "閱讀";

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -25,6 +25,7 @@ public class UserPreferences: ObservableObject {
   @AppStorage("app_auto_expand_spoilers") public var appAutoExpandSpoilers = false
   @AppStorage("app_auto_expand_media") public var appAutoExpandMedia: ServerPreferences.AutoExpandMedia = .hideSensitive
   @AppStorage("app_default_post_visibility") public var appDefaultPostVisibility: Models.Visibility = .pub
+  @AppStorage("app_default_reply_visibility") public var appDefaultReplyVisibility: Models.Visibility = .unlisted
   @AppStorage("app_default_posts_sensitive") public var appDefaultPostsSensitive = false
   @AppStorage("autoplay_video") public var autoPlayVideo = true
   @AppStorage("always_use_deepl") public var alwaysUseDeepl = false
@@ -88,7 +89,26 @@ public class UserPreferences: ObservableObject {
       return appDefaultPostVisibility
     }
   }
-
+  
+  public func conformReplyVisibilityConstraints() {
+    appDefaultReplyVisibility = getReplyVisibility()
+  }
+  
+  private func getReplyVisibility() -> Models.Visibility {
+    getMinVisibility(postVisibility, appDefaultReplyVisibility)
+  }
+  
+  public func getReplyVisibility(of status: Status) -> Models.Visibility {
+    getMinVisibility(getReplyVisibility(), status.visibility)
+  }
+  
+  private func getMinVisibility(_ vis1: Models.Visibility, _ vis2: Models.Visibility) -> Models.Visibility {
+    let no1 = Self.getIntOfVisibility(vis1)
+    let no2 = Self.getIntOfVisibility(vis2)
+    
+    return no1 < no2 ? vis1 : vis2
+  }
+  
   public var postIsSensitive: Bool {
     if useInstanceContentSettings {
       return serverPreferences?.postIsSensitive ?? false
@@ -153,5 +173,18 @@ public class UserPreferences: ObservableObject {
     }
     copy.insert(isoCode, at: 0)
     recentlyUsedLanguages = Array(copy.prefix(3))
+  }
+  
+  public static func getIntOfVisibility(_ vis: Models.Visibility) -> Int {
+    switch vis {
+      case .direct:
+        return 0
+      case .priv:
+        return 1
+      case .unlisted:
+        return 2
+      case .pub:
+        return 3
+    }
   }
 }

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -254,7 +254,7 @@ public class StatusEditorViewModel: NSObject, ObservableObject {
         mentionString += " "
       }
       replyToStatus = status
-      visibility = status.visibility
+      visibility = UserPreferences.shared.getReplyVisibility(of: status)
       statusText = .init(string: mentionString)
       selectedRange = .init(location: mentionString.utf16.count, length: 0)
       if !mentionString.isEmpty {


### PR DESCRIPTION
Replies can now have their own default visibility. This visibility is always at
least as restrictive as the default post visibility. When posting a reply, the
visibility is pre-populated with the more restrictive out of the default visibility and
the visibility of the original post.
Closes #1490