### PR TITLE
Show all symbols when adding a tag group

### DIFF
--- a/IceCubesApp.xcodeproj/project.pbxproj
+++ b/IceCubesApp.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		9FFF6784299B7D4400FE700A /* LRUCache in Frameworks */ = {isa = PBXBuildFile; productRef = 9FFF6783299B7D4400FE700A /* LRUCache */; };
 		C9B22677297F6C2E001F9EFE /* ContentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B22676297F6C2E001F9EFE /* ContentSettingsView.swift */; };
 		D08A9C3529956CFA00204A4A /* SwipeActionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08A9C3429956CFA00204A4A /* SwipeActionsSettingsView.swift */; };
+		DA0B24FB2A6876D50045BDD7 /* SFSafeSymbols in Frameworks */ = {isa = PBXBuildFile; productRef = DA0B24FA2A6876D50045BDD7 /* SFSafeSymbols */; };
 		E92817FA298443D600875FD1 /* Models in Frameworks */ = {isa = PBXBuildFile; productRef = E92817F9298443D600875FD1 /* Models */; };
 		E92817FC298443D600875FD1 /* Network in Frameworks */ = {isa = PBXBuildFile; productRef = E92817FB298443D600875FD1 /* Network */; };
 		E92817FE29844DB700875FD1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E92817FD29844DB700875FD1 /* Assets.xcassets */; };
@@ -332,6 +333,7 @@
 				9F5E581929545BE700A53960 /* Env in Frameworks */,
 				9F2A540A29699705009B2D7C /* ReceiptParser in Frameworks */,
 				9F35DB44294F9A7D00B3281A /* Status in Frameworks */,
+				DA0B24FB2A6876D50045BDD7 /* SFSafeSymbols in Frameworks */,
 				9F295540292B6C3400E0E81B /* Timeline in Frameworks */,
 				9F35DB4A29506FA100B3281A /* Notifications in Frameworks */,
 			);
@@ -649,6 +651,7 @@
 				9F2A540B29699705009B2D7C /* RevenueCat */,
 				9FE3DB56296FEFCA00628CB0 /* AppAccount */,
 				065FA1FD29866CD600012EA0 /* LRUCache */,
+				DA0B24FA2A6876D50045BDD7 /* SFSafeSymbols */,
 			);
 			productName = IceCubesApp;
 			productReference = 9FBFE639292A715500C250E9 /* IceCubesApp.app */;
@@ -730,6 +733,7 @@
 				9FAE4ACC29379A5A00772766 /* XCRemoteSwiftPackageReference "keychain-swift" */,
 				9F2A540829699705009B2D7C /* XCRemoteSwiftPackageReference "purchases-ios" */,
 				065FA1FC29866CD600012EA0 /* XCRemoteSwiftPackageReference "LRUCache" */,
+				DA0B24F92A6876D40045BDD7 /* XCRemoteSwiftPackageReference "SFSafeSymbols" */,
 			);
 			productRefGroup = 9FBFE63A292A715500C250E9 /* Products */;
 			projectDirPath = "";
@@ -1439,6 +1443,14 @@
 				kind = branch;
 			};
 		};
+		DA0B24F92A6876D40045BDD7 /* XCRemoteSwiftPackageReference "SFSafeSymbols" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SFSafeSymbols/SFSafeSymbols";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.1.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1577,6 +1589,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 065FA1FC29866CD600012EA0 /* XCRemoteSwiftPackageReference "LRUCache" */;
 			productName = LRUCache;
+		};
+		DA0B24FA2A6876D50045BDD7 /* SFSafeSymbols */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DA0B24F92A6876D40045BDD7 /* XCRemoteSwiftPackageReference "SFSafeSymbols" */;
+			productName = SFSafeSymbols;
 		};
 		E92817F9298443D600875FD1 /* Models */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -55,6 +55,15 @@
       }
     },
     {
+      "identity" : "sfsafesymbols",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SFSafeSymbols/SFSafeSymbols",
+      "state" : {
+        "revision" : "7cca2d60925876b5953a2cf7341cd80fbeac983c",
+        "version" : "4.1.1"
+      }
+    },
+    {
       "identity" : "sqlite.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",

--- a/IceCubesApp/App/Tabs/Settings/AboutView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AboutView.swift
@@ -75,6 +75,8 @@ struct AboutView: View {
         • [SwiftUI-Introspect](https://github.com/siteline/SwiftUI-Introspect)
 
         • [RevenueCat](https://github.com/RevenueCat/purchases-ios)
+        
+        • [SFSafeSymbols](https://github.com/SFSafeSymbols/SFSafeSymbols)
         """)
         .multilineTextAlignment(.leading)
         .font(.scaledSubheadline)

--- a/IceCubesApp/App/Tabs/Timeline/Symbols.swift
+++ b/IceCubesApp/App/Tabs/Timeline/Symbols.swift
@@ -6,13 +6,8 @@
 //
 
 import Foundation
+import SFSafeSymbols
 
-let allSymbols: [String] = {
-  if let bundle = Bundle(identifier: "com.apple.CoreGlyphs"),
-     let resourcePath = bundle.path(forResource: "symbol_search", ofType: "plist"),
-     let plist = NSDictionary(contentsOfFile: resourcePath)
-  {
-    return plist.allKeys as? [String] ?? []
-  }
-  return []
-}()
+let allSymbols: [String] = SFSymbol.allSymbols.map { symbol in
+    symbol.rawValue
+}


### PR DESCRIPTION
All the SFSymbols are shown when adding a tag group, the list is taken from SFSafeSymbols. This includes symbols such as "swift" and "apple.logo", as seen in https://mastodon.social/@alexito4/110742407894134083.