### PR TITLE
"Poll close in …" : Fixing missing space in some locales

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -487,7 +487,7 @@
 "status.poll.n-votes %lld" = "%lld галасоў";
 "status.poll.n-votes-voters %lld %lld" = "%lld галасоў ад %lld удзельнікаў";
 "status.poll.closed" = "Зачынены";
-"status.poll.closes-in" = "Зачыніцца праз ";
+"status.poll.closes-in %@" = "Зачыніцца праз %@";
 "status.poll.duration" = "Працягласць апытання";
 "status.poll.frequency" = "Частата апытання";
 "status.poll.option-n %lld" = "Варыянт %lld";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -481,7 +481,7 @@
 "status.poll.n-votes %lld" = "%lld vots";
 "status.poll.n-votes-voters %lld %lld" = "%lld votes from %lld voters";
 "status.poll.closed" = "Finalitzada";
-"status.poll.closes-in" = "Finalitza en";
+"status.poll.closes-in %@" = "Finalitza en %@";
 "status.poll.duration" = "Durada de l'enquesta";
 "status.poll.frequency" = "Freqüència de l'enquesta";
 "status.poll.option-n %lld" = "Opció %lld";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -474,7 +474,7 @@
 "status.media.contextmenu.view-browser" = "Im Browser anzeigen";
 "status.media.sensitive.show" = "Sensiblen Inhalt zeigen";
 "status.poll.closed" = "Beendet";
-"status.poll.closes-in" = "Endet in ";
+"status.poll.closes-in %@" = "Endet in %@";
 "status.poll.duration" = "Umfragedauer";
 "status.poll.frequency" = "Auswahlmöglichkeiten";
 "status.poll.option-n %lld" = "Option %lld";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -482,7 +482,7 @@
 "status.poll.n-votes %lld" = "%lld votes";
 "status.poll.n-votes-voters %lld %lld" = "%lld votes from %lld voters";
 "status.poll.closed" = "Closed";
-"status.poll.closes-in" = "Closes in ";
+"status.poll.closes-in %@" = "Closes in %@";
 "status.poll.duration" = "Poll Duration";
 "status.poll.frequency" = "Polling Frequency";
 "status.poll.option-n %lld" = "Option %lld";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -483,7 +483,7 @@
 "status.poll.n-votes %lld" = "%lld votes";
 "status.poll.n-votes-voters %lld %lld" = "%lld votes from %lld voters";
 "status.poll.closed" = "Closed";
-"status.poll.closes-in" = "Closes in ";
+"status.poll.closes-in %@" = "Closes in %@";
 "status.poll.duration" = "Poll Duration";
 "status.poll.frequency" = "Polling Frequency";
 "status.poll.option-n %lld" = "Option %lld";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -483,7 +483,7 @@
 "status.poll.n-votes %lld" = "%lld votos";
 "status.poll.n-votes-voters %lld %lld" = "%lld votos de %lld participantes";
 "status.poll.closed" = "Cerrada";
-"status.poll.closes-in" = "Acaba en ";
+"status.poll.closes-in %@" = "Acaba en %@";
 "status.poll.duration" = "Duración de la encuesta";
 "status.poll.frequency" = "Frecuencia de la encuesta";
 "status.poll.option-n %lld" = "Opción %lld";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -475,7 +475,7 @@
 "status.media.sensitive.show" = "Erakutsi eduki hunkigarria";
 "status.poll.n-votes %lld" = "%lld boto";
 "status.poll.closed" = "Amaituta";
-"status.poll.closes-in" = "Epemuga: ";
+"status.poll.closes-in %@" = "Epemuga: %@";
 "status.poll.duration" = "Bozketaren iraupena";
 "status.poll.frequency" = "Bozketaren maiztasuna";
 "status.poll.option-n %lld" = "%lld. aukera";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -478,7 +478,7 @@
 "status.poll.n-votes %lld" = "%lld votes";
 "status.poll.n-votes-voters %lld %lld" = "%lld votes de %lld voteurs";
 "status.poll.closed" = "Fermé";
-"status.poll.closes-in" = "Ferme dans";
+"status.poll.closes-in %@" = "Ferme dans %@";
 "status.poll.duration" = "Durée du sondage";
 "status.poll.frequency" = "Fréquence de sondage";
 "status.poll.option-n %lld" = "Option %lld";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -484,7 +484,7 @@
 "status.poll.n-votes %lld" = "%lld voti";
 "status.poll.n-votes-voters %lld %lld" = "%lld voti da %lld persone";
 "status.poll.closed" = "Chiuso";
-"status.poll.closes-in" = "Si chiude in ";
+"status.poll.closes-in %@" = "Si chiude in %@";
 "status.poll.duration" = "Durata del sondaggio";
 "status.poll.frequency" = "Frequenza di voto";
 "status.poll.option-n %lld" = "Opzione %lld";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -481,7 +481,7 @@
 "status.poll.n-votes %lld" = "%lld 投票";
 "status.poll.n-votes-voters %lld %lld" = "%lld 票 %lld からの投票";
 "status.poll.closed" = "投票終了";
-"status.poll.closes-in" = "投票終了まで ";
+"status.poll.closes-in %@" = "投票終了まで %@";
 "status.poll.duration" = "投票期間";
 "status.poll.frequency" = "投票頻度";
 "status.poll.option-n %lld" = "オプション %lld";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -485,7 +485,7 @@
 "status.poll.n-votes %lld" = "%lld표";
 "status.poll.n-votes-voters %lld %lld" = "%lld표 (%lld명)";
 "status.poll.closed" = "종료됨";
-"status.poll.closes-in" = "종료까지 ";
+"status.poll.closes-in %@" = "종료까지 %@";
 "status.poll.duration" = "투표 기간";
 "status.poll.frequency" = "투표 선택 옵션";
 "status.poll.option-n %lld" = "선택지 %lld";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -482,7 +482,7 @@
 "status.poll.n-votes %lld" = "%lld stemmer";
 "status.poll.n-votes-voters %lld %lld" = "%lld stemmer fra %lld velgere";
 "status.poll.closed" = "Lukket";
-"status.poll.closes-in" = "Lukkes om ";
+"status.poll.closes-in %@" = "Lukkes om %@";
 "status.poll.duration" = "Avstemningens varighet";
 "status.poll.frequency" = "Avstemningsfrekvens";
 "status.poll.option-n %lld" = "Valg %lld";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -476,7 +476,7 @@
 "status.poll.n-votes %lld" = "%lld stemmen";
 "status.poll.n-votes-voters %lld %lld" = "%lld stemmen van %lld stemmers";
 "status.poll.closed" = "Beëindigd";
-"status.poll.closes-in" = "Eindigt over ";
+"status.poll.closes-in %@" = "Eindigt over %@";
 "status.poll.duration" = "Pollduur";
 "status.poll.frequency" = "Pollingfrequentie";
 "status.poll.option-n %lld" = "Optie %lld";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -476,7 +476,7 @@
 "status.media.contextmenu.view-browser" = "Zobacz w przeglądarce";
 "status.media.sensitive.show" = "Pokaż wrażliwą zawartość";
 "status.poll.closed" = "Zamknięty";
-"status.poll.closes-in" = "Zostanie zakończony za ";
+"status.poll.closes-in %@" = "Zostanie zakończony za %@";
 "status.poll.duration" = "Czas trwania sondażu";
 "status.poll.frequency" = "Częstotliwość odpytywania";
 "status.poll.option-n %lld" = "Opcja %lld";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -482,7 +482,7 @@
 "status.poll.n-votes %lld" = "%lld votos";
 "status.poll.n-votes-voters %lld %lld" = "%lld votos de %lld votantes";
 "status.poll.closed" = "Encerrado";
-"status.poll.closes-in" = "Encerrado em ";
+"status.poll.closes-in %@" = "Encerrado em %@";
 "status.poll.duration" = "Duração da votação";
 "status.poll.frequency" = "Frequência da votação";
 "status.poll.option-n %lld" = "Opção %lld";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -478,7 +478,7 @@
 "status.poll.n-votes %lld" = "%lld oy";
 "status.poll.n-votes-voters %lld %lld" = "%lld votes from %lld voters";
 "status.poll.closed" = "Kapandı";
-"status.poll.closes-in" = "Kapanacak ";
+"status.poll.closes-in %@" = "Kapanacak %@";
 "status.poll.duration" = "Anket Süresi";
 "status.poll.frequency" = "Anket Sıklığı";
 "status.poll.option-n %lld" = "Seçenek %lld";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -483,7 +483,7 @@
 "status.poll.n-votes %lld" = "%lld голосів";
 "status.poll.n-votes-voters %lld %lld" = "%lld голосів від %lld опитаних";
 "status.poll.closed" = "Закрито";
-"status.poll.closes-in" = "Завершується в ";
+"status.poll.closes-in %@" = "Завершується в %@";
 "status.poll.duration" = "Тривалість опитування";
 "status.poll.frequency" = "Частота опитування";
 "status.poll.option-n %lld" = "Варіант %lld";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -481,7 +481,7 @@
 "status.poll.n-votes %lld" = "%lld 票";
 "status.poll.n-votes-voters %lld %lld" = "%lld 票来自 %lld 个投票者";
 "status.poll.closed" = "已关闭";
-"status.poll.closes-in" = "关闭于 ";
+"status.poll.closes-in %@" = "关闭于 %@";
 "status.poll.duration" = "投票持续时间";
 "status.poll.frequency" = "投票频率";
 "status.poll.option-n %lld" = "%lld 选项";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -484,7 +484,7 @@
 "status.poll.n-votes %lld" = "%lld 票";
 "status.poll.n-votes-voters %lld %lld" = "%lld 票，%lld 位投票者";
 "status.poll.closed" = "已關閉";
-"status.poll.closes-in" = "關閉於 ";
+"status.poll.closes-in %@" = "關閉於 %@";
 "status.poll.duration" = "投票時限";
 "status.poll.frequency" = "投票頻率";
 "status.poll.option-n %lld" = "選項 %lld";

--- a/Packages/Status/Sources/Status/Poll/StatusPollView.swift
+++ b/Packages/Status/Sources/Status/Poll/StatusPollView.swift
@@ -139,8 +139,7 @@ public struct StatusPollView: View {
       if viewModel.poll.expired {
         Text("status.poll.closed")
       } else if let date = viewModel.poll.expiresAt.value?.asDate {
-        Text("status.poll.closes-in")
-        Text(date, style: .timer)
+        Text("status.poll.closes-in \(date, style: .timer)")
       }
     }
     .font(.scaledFootnote)


### PR DESCRIPTION
In French, and Catalan specifically, the space was missing between the text & the timer.

Instead, using a translation with a replacement token (%@) so that is won't happen again (and give freedom to translators to put the timer anywhere else in the string)