### PR TITLE
Fix quote button not showing for unlisted posts

### DIFF
--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -11,7 +11,7 @@ public struct StatusRowView: View {
   @Environment(\.isInCaptureMode) private var isInCaptureMode: Bool
   @Environment(\.redactionReasons) private var reasons
   @Environment(\.isCompact) private var isCompact: Bool
-  @Environment(\.accessibilityEnabled) private var accessibilityEnabled
+  @Environment(\.accessibilityVoiceOverEnabled) private var accessibilityVoiceOverEnabled
 
   @EnvironmentObject private var quickLook: QuickLook
   @EnvironmentObject private var theme: Theme
@@ -107,13 +107,13 @@ public struct StatusRowView: View {
     }
     .swipeActions(edge: .trailing) {
       // The actions associated with the swipes are exposed as custom accessibility actions and there is no way to remove them.
-      if !isCompact, accessibilityEnabled == false {
+      if !isCompact, accessibilityVoiceOverEnabled == false {
         StatusRowSwipeView(viewModel: viewModel, mode: .trailing)
       }
     }
     .swipeActions(edge: .leading) {
       // The actions associated with the swipes are exposed as custom accessibility actions and there is no way to remove them.
-      if !isCompact, accessibilityEnabled == false {
+      if !isCompact, accessibilityVoiceOverEnabled == false {
         StatusRowSwipeView(viewModel: viewModel, mode: .leading)
       }
     }
@@ -123,7 +123,7 @@ public struct StatusRowView: View {
                          bottom: 12,
                          trailing: .layoutPadding))
     .accessibilityElement(children: viewModel.isFocused ? .contain : .combine)
-    .accessibilityLabel(viewModel.isFocused == false && accessibilityEnabled
+    .accessibilityLabel(viewModel.isFocused == false && accessibilityVoiceOverEnabled
       ? CombinedAccessibilityLabel(viewModel: viewModel).finalLabel() : Text(""))
     .accessibilityHidden(viewModel.filter?.filter.filterAction == .hide)
     .accessibilityAction {
@@ -181,6 +181,7 @@ public struct StatusRowView: View {
       HapticManager.shared.fireHaptic(of: .notification(.success))
       viewModel.routerPath.presentedSheet = .quoteStatusEditor(status: viewModel.status)
     }
+    .disabled(viewModel.status.visibility == .direct || viewModel.status.visibility == .priv)
 
     if viewModel.finalStatus.mediaAttachments.isEmpty == false {
       Button("accessibility.status.media-viewer-action.label") {

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -54,14 +54,12 @@ struct StatusRowContextMenu: View {
       } label: {
         Label("status.action.reply", systemImage: "arrowshape.turn.up.left")
       }
-    }
-
-    if viewModel.status.visibility == .pub, !viewModel.isRemote {
       Button {
         viewModel.routerPath.presentedSheet = .quoteStatusEditor(status: viewModel.status)
       } label: {
         Label("status.action.quote", systemImage: "quote.bubble")
       }
+      .disabled(viewModel.status.visibility == .direct || viewModel.status.visibility == .priv)
     }
 
     Divider()

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowSwipeView.swift
@@ -60,6 +60,7 @@ struct StatusRowSwipeView: View {
       makeSwipeButtonForRouterPath(action: action, destination: .replyToStatusEditor(status: viewModel.status))
     case .quote:
       makeSwipeButtonForRouterPath(action: action, destination: .quoteStatusEditor(status: viewModel.status))
+      .disabled(viewModel.status.visibility == .direct || viewModel.status.visibility == .priv)
     case .favorite:
       makeSwipeButtonForTask(action: action) {
         await statusDataController.toggleFavorite(remoteStatus: nil)


### PR DESCRIPTION
### Changes
- Allow quoting unlisted posts (which previously was only available on public posts)
- When unavailable, disable the quote button in the context menu instead of hiding it, making it consistent with the boost button
- Hide the quote button from swipe actions unless the post visibility is set to public or unlisted
- Replace `accessibilityEnabled` which includes Voice Control, with `accessibilityVoiceOverEnabled`, enabling swipe actions even when Voice Control is on.

I guess I found out why some people including me couldn't find their quote buttons.