### PR TITLE
Bugfix 1459 - Escape ~ character as markdown

### DIFF
--- a/Packages/Models/Sources/Models/Alias/HTMLString.swift
+++ b/Packages/Models/Sources/Models/Alias/HTMLString.swift
@@ -37,10 +37,12 @@ public struct HTMLString: Codable, Equatable, Hashable, @unchecked Sendable {
 
     if !alreadyDecoded {
       // https://daringfireball.net/projects/markdown/syntax
-      // Pre-escape \ ` _ * and [ as these are the only
-      // characters the markdown parser used picks up
-      // when it renders to attributed text
-      main_regex = try? NSRegularExpression(pattern: "([\\*\\`\\[\\\\])", options: .caseInsensitive)
+      // Pre-escape \ ` _ * ~ and [ as these are the only
+      // characters the markdown parser uses when it renders
+      // to attributed text. Note that ~ for strikethrough is
+      // not documented in the syntax docs but is used by
+      // AttributedString.
+      main_regex = try? NSRegularExpression(pattern: "([\\*\\`\\~\\[\\\\])", options: .caseInsensitive)
       // don't escape underscores that are between colons, they are most likely custom emoji
       underscore_regex = try? NSRegularExpression(pattern: "(?!\\B:[^:]*)(_)(?![^:]*:\\B)", options: .caseInsensitive)
 

--- a/Packages/Models/Tests/ModelsTests/HTMLStringTests.swift
+++ b/Packages/Models/Tests/ModelsTests/HTMLStringTests.swift
@@ -81,5 +81,11 @@ final class HTMLStringTests: XCTestCase {
     XCTAssertEqual("This _is_ an :emoji_maybe:", htmlString.asRawText)
     XCTAssertEqual("<p>This _is_ an :emoji_maybe:</p>", htmlString.htmlValue)
     XCTAssertEqual("This \\_is\\_ an :emoji_maybe:", htmlString.asMarkdown)
+
+    let strikeContent = "\"<p>This ~is~ a\\n`test`</p>\""
+    htmlString = try decoder.decode(HTMLString.self, from: Data(strikeContent.utf8))
+    XCTAssertEqual("This ~is~ a\n`test`", htmlString.asRawText)
+    XCTAssertEqual("<p>This ~is~ a\n`test`</p>", htmlString.htmlValue)
+    XCTAssertEqual("This \\~is\\~ a \\`test\\`", htmlString.asMarkdown)
   }
 }

--- a/Packages/Models/Tests/ModelsTests/HTMLStringTests.swift
+++ b/Packages/Models/Tests/ModelsTests/HTMLStringTests.swift
@@ -19,7 +19,7 @@ final class HTMLStringTests: XCTestCase {
     
     let extendedCharQuery = URL(string: "http://test.com/blah/city?name=京都市", encodePath: true)
     XCTAssertEqual("http://test.com/blah/city?name=%E4%BA%AC%E9%83%BD%E5%B8%82", extendedCharQuery?.absoluteString)
-
+    
     // Double encoding will happen if you ask to encodePath on an already encoded string
     let alreadyEncodedPath = URL(string: "https://en.wikipedia.org/wiki/Elbbr%C3%BCcken_station", encodePath: true)
     XCTAssertEqual("https://en.wikipedia.org/wiki/Elbbr%25C3%25BCcken_station", alreadyEncodedPath?.absoluteString)
@@ -27,7 +27,7 @@ final class HTMLStringTests: XCTestCase {
   
   func testHTMLStringInit() throws {
     let decoder = JSONDecoder()
-
+    
     let basicContent = "\"<p>This is a test</p>\""
     var htmlString = try decoder.decode(HTMLString.self, from: Data(basicContent.utf8))
     XCTAssertEqual("This is a test", htmlString.asRawText)
@@ -35,7 +35,7 @@ final class HTMLStringTests: XCTestCase {
     XCTAssertEqual("This is a test", htmlString.asMarkdown)
     XCTAssertEqual(0, htmlString.statusesURLs.count)
     XCTAssertEqual(0, htmlString.links.count)
-
+    
     let basicLink = "\"<p>This is a <a href=\\\"https://test.com\\\">test</a></p>\""
     htmlString = try decoder.decode(HTMLString.self, from: Data(basicLink.utf8))
     XCTAssertEqual("This is a test", htmlString.asRawText)
@@ -45,7 +45,7 @@ final class HTMLStringTests: XCTestCase {
     XCTAssertEqual(1, htmlString.links.count)
     XCTAssertEqual("https://test.com", htmlString.links[0].url.absoluteString)
     XCTAssertEqual("test", htmlString.links[0].displayString)
-
+    
     let extendedCharLink = "\"<p>This is a <a href=\\\"https://test.com/goßëña\\\">test</a></p>\""
     htmlString = try decoder.decode(HTMLString.self, from: Data(extendedCharLink.utf8))
     XCTAssertEqual("This is a test", htmlString.asRawText)
@@ -55,7 +55,7 @@ final class HTMLStringTests: XCTestCase {
     XCTAssertEqual(1, htmlString.links.count)
     XCTAssertEqual("https://test.com/go%C3%9F%C3%AB%C3%B1a", htmlString.links[0].url.absoluteString)
     XCTAssertEqual("test", htmlString.links[0].displayString)
-
+    
     let alreadyEncodedLink = "\"<p>This is a <a href=\\\"https://test.com/go%C3%9F%C3%AB%C3%B1a\\\">test</a></p>\""
     htmlString = try decoder.decode(HTMLString.self, from: Data(alreadyEncodedLink.utf8))
     XCTAssertEqual("This is a test", htmlString.asRawText)
@@ -65,5 +65,21 @@ final class HTMLStringTests: XCTestCase {
     XCTAssertEqual(1, htmlString.links.count)
     XCTAssertEqual("https://test.com/go%C3%9F%C3%AB%C3%B1a", htmlString.links[0].url.absoluteString)
     XCTAssertEqual("test", htmlString.links[0].displayString)
+  }
+  
+  func testHTMLStringInit_markdownEscaping() throws {
+    let decoder = JSONDecoder()
+    
+    let stdMarkdownContent = "\"<p>This [*is*] `a`\\n**test**</p>\""
+    var htmlString = try decoder.decode(HTMLString.self, from: Data(stdMarkdownContent.utf8))
+    XCTAssertEqual("This [*is*] `a`\n**test**", htmlString.asRawText)
+    XCTAssertEqual("<p>This [*is*] `a`\n**test**</p>", htmlString.htmlValue)
+    XCTAssertEqual("This \\[\\*is\\*] \\`a\\` \\*\\*test\\*\\*", htmlString.asMarkdown)
+    
+    let underscoreContent = "\"<p>This _is_ an :emoji_maybe:</p>\""
+    htmlString = try decoder.decode(HTMLString.self, from: Data(underscoreContent.utf8))
+    XCTAssertEqual("This _is_ an :emoji_maybe:", htmlString.asRawText)
+    XCTAssertEqual("<p>This _is_ an :emoji_maybe:</p>", htmlString.htmlValue)
+    XCTAssertEqual("This \\_is\\_ an :emoji_maybe:", htmlString.asMarkdown)
   }
 }


### PR DESCRIPTION
While it isn't documented in the official markdown spec, the `~` character is often used to denote ~~strikethrough~~ formatting. This includes the AttributedString class. To address this, the `~` is now escaped along with the other markdown characters.

An example of two statuses, one processed before the change and one processed after the change:

<img width="332" alt="image" src="https://github.com/Dimillian/IceCubesApp/assets/22599622/16ba32fc-e580-4cb4-8f17-92f96ad2a47b">
