### PR TITLE
Fix text field bottom padding in EditorView

### DIFF
--- a/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorView.swift
@@ -66,7 +66,10 @@ public struct StatusEditorView: View {
           }
           .padding(.top, 8)
           .padding(.bottom, 40)
-        }.accessibilitySortPriority(1) // Ensure that all elements inside the `ScrollView` occur earlier than the accessory views
+        }
+        .accessibilitySortPriority(1) // Ensure that all elements inside the `ScrollView` occur earlier than the accessory views
+        .padding(.top, 1) // hacky fix for weird SwiftUI scrollView bug when adding padding
+        .padding(.bottom, 48)
         VStack(alignment: .leading, spacing: 0) {
           StatusEditorAutoCompleteView(viewModel: viewModel)
           StatusEditorAccessoryView(isSpoilerTextFocused: $isSpoilerTextFocused,


### PR DESCRIPTION
Even though this might not seem like a "crucial" fix, I took it upon myself to do it anyway. I have some free time these days and decided to do some open source work, and I have been following your journey with building this app for a while now and I am really impressed. So I decided I would jump in to help. 

This is just a first PR that would help me get more familiar with the codebase.
__________

It was mentioned in this issue #337 that the text view doesn't scroll when you are typing and reached the bottom. This was mainly because the ScrollView for the text view has a safe area for the keyboard, but it doesn't account for the extra space for the `StatusEditorAccessoryView`, which made the text fall behind the `StatusEditorAccessoryView` when it reached the bottom.
_________
The straight forward answer would be to add a bottom padding for the scroll view, and it's true. But this resulted in some very weird bug. The scroll view would ignore the navigation bar safe area. See the video 👇🏼

https://github.com/Dimillian/IceCubesApp/assets/54270105/36cacdeb-03ed-4565-8503-22142ca4082f

And apparently, the extra top padding (even for 1) fixes it 👇🏼

https://github.com/Dimillian/IceCubesApp/assets/54270105/5ef7bea3-7a59-45a4-aa5c-3b6e19b537e7


The only down side is that we lose the navigation bar appearance configuration for scrolling.
