### PR TITLE
Remove "Translate with DeepL"-option

### DIFF
--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -412,7 +412,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Перакласці";
-"status.action.translate-with-deepl" = "Translate with DeepL";
 "status.action.translated-label-%@" = "Пераклад з дапамогай %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Закладка";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -406,7 +406,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tradueix";
-"status.action.translate-with-deepl" = "Translate with DeepL";
 "status.action.translated-label-%@" = "Traduït amb %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Afegeix als marcadors";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -401,7 +401,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Übersetzen";
-"status.action.translate-with-deepl" = "Mit DeepL übersetzen";
 "status.action.translated-label-%@" = "Übersetzt mit %@";
 "status.action.translated-label-from-%@-%@" = "Aus %@ mit %@ übersetzt";
 "status.action.bookmark" = "Lesezeichen setzen";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -409,7 +409,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
-"status.action.translate-with-deepl" = "Translate with DeepL";
 "status.action.translated-label-%@" = "Translated using %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Bookmark";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -408,7 +408,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Translate";
-"status.action.translate-with-deepl" = "Translate with DeepL";
 "status.action.translated-label-%@" = "Translated using %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Bookmark";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -408,7 +408,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traducir";
-"status.action.translate-with-deepl" = "Traducir con DeepL";
 "status.action.translated-label-%@" = "Traducido usando %@";
 "status.action.translated-label-from-%@-%@" = "Traducido desde %@ usando %@";
 "status.action.bookmark" = "Añadir a marcadores";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -401,7 +401,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Itzuli";
-"status.action.translate-with-deepl" = "Itzuli DeepL erabiliz";
 "status.action.translated-label-%@" = "%@ erabiliz itzulia";
 "status.action.translated-label-from-%@-%@" = "%@(e)tik %@ erabiliz itzulia";
 "status.action.bookmark" = "Jarri laster-marka";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -403,7 +403,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduire";
-"status.action.translate-with-deepl" = "Translate with DeepL";
 "status.action.translated-label-%@" = "Traduit avec %@";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Marquer";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -409,7 +409,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduci";
-"status.action.translate-with-deepl" = "Traduci con DeepL";
 "status.action.translated-label-%@" = "Tradotto usando %@";
 "status.action.translated-label-from-%@-%@" = "Tradotto da %@ usando %@";
 "status.action.bookmark" = "Salva nei segnalibri";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -407,7 +407,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻訳";
-"status.action.translate-with-deepl" = "DeepLを使用して翻訳";
 "status.action.translated-label-%@" = "%@ を使用して翻訳";
 "status.action.translated-label-from-%@-%@" = "%@ から %@ を使用して翻訳";
 "status.action.bookmark" = "ブックマーク";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -410,7 +410,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "번역";
-"status.action.translate-with-deepl" = "DeepL 번역";
 "status.action.translated-label-%@" = "%@ 서비스를 통해 번역됨";
 "status.action.translated-label-from-%@-%@" = "%2$@ 서비스를 통해 %1$@에서 번역됨";
 "status.action.bookmark" = "보관함에 추가";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -407,7 +407,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Oversett";
-"status.action.translate-with-deepl" = "Oversett med DeepL";
 "status.action.translated-label-%@" = "Oversatt ved hjelp av %@";
 "status.action.translated-label-from-%@-%@" = "Oversatt fra %@ ved å bruke %@";
 "status.action.bookmark" = "Bokmerk";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -401,7 +401,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Vertaal";
-"status.action.translate-with-deepl" = "Vertaal met DeepL";
 "status.action.translated-label-%@" = "Vertaald met %@";
 "status.action.translated-label-from-%@-%@" = "Vertaald uit het %@ met %@";
 "status.action.bookmark" = "Voeg bladwijzer toe";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -403,7 +403,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Przetłumacz";
-"status.action.translate-with-deepl" = "Przetłumacz za pomocą DeepL";
 "status.action.translated-label-%@" = "Przetłumaczono za pomocą %@";
 "status.action.translated-label-from-%@-%@" = "Tekst %@ przetłumaczono za pomocą %@";
 "status.action.bookmark" = "Dodaj zakładkę";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -407,7 +407,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Traduzir";
-"status.action.translate-with-deepl" = "Traduzir com DeepL";
 "status.action.translated-label-%@" = "Traduzir usando %@";
 "status.action.translated-label-from-%@-%@" = "Traduzido de %@ usando %@";
 "status.action.bookmark" = "Salvar";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -403,7 +403,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Tercüme et";
-"status.action.translate-with-deepl" = "Translate with DeepL";
 "status.action.translated-label-%@" = "%@ tarafından tercüme edildi";
 "status.action.translated-label-from-%@-%@" = "Translated from %@ using %@";
 "status.action.bookmark" = "Yer İmi Ekle";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -408,7 +408,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "Перекласти";
-"status.action.translate-with-deepl" = "Перекласти з допомогою DeepL";
 "status.action.translated-label-%@" = "Переклад з допомогою %@";
 "status.action.translated-label-from-%@-%@" = "Переклад з %@ з допомогою %@";
 "status.action.bookmark" = "У закладки";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -406,7 +406,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻译";
-"status.action.translate-with-deepl" = "由 DeepL 翻译";
 "status.action.translated-label-%@" = "由 %@ 翻译";
 "status.action.translated-label-from-%@-%@" = "翻译自 %@，使用 %@";
 "status.action.bookmark" = "书签";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -409,7 +409,6 @@
 
 // MARK: Package: Status
 "status.action.translate" = "翻譯";
-"status.action.translate-with-deepl" = "以 DeepL 翻譯";
 "status.action.translated-label-%@" = "翻譯服務 %@";
 "status.action.translated-label-from-%@-%@" = "從 %@ 以 %@ 翻譯";
 "status.action.bookmark" = "書籤";

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -137,16 +137,6 @@ struct StatusRowContextMenu: View {
       } label: {
         Label("status.action.translate", systemImage: "captions.bubble")
       }
-
-      if !viewModel.alwaysTranslateWithDeepl {
-        Button {
-          Task {
-            await viewModel.translateWithDeepL(userLang: lang)
-          }
-        } label: {
-          Label("status.action.translate-with-deepl", systemImage: "captions.bubble")
-        }
-      }
     }
 
     if account.account?.id == viewModel.status.reblog?.account.id ?? viewModel.status.account.id {


### PR DESCRIPTION
The "Translate with DeepL"-option is removed to make the app better understandable for the average user. A person who wants to use DeepL can still insert their own API key to always use DeepL.

Fixes #1583