### PR TITLE
Update Explore trending links to use value-based NavigationLink

### DIFF
--- a/IceCubesApp/App/AppRegistry.swift
+++ b/IceCubesApp/App/AppRegistry.swift
@@ -55,6 +55,8 @@ extension View {
                      selectedTagGroup: .constant(nil),
                      scrollToTopSignal: .constant(0),
                      canFilterTimeline: false)
+      case let .trendingLinks(cards):
+        CardsListView(cards: cards)
       case let .tagsList(tags):
         TagsListView(tags: tags)
       }

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -21,6 +21,7 @@ public enum RouterDestination: Hashable {
   case rebloggedBy(id: String)
   case accountsList(accounts: [Account])
   case trendingTimeline
+  case trendingLinks(cards: [Card])
   case tagsList(tags: [Tag])
 }
 

--- a/Packages/Explore/Sources/Explore/CardsListView.swift
+++ b/Packages/Explore/Sources/Explore/CardsListView.swift
@@ -1,0 +1,29 @@
+import DesignSystem
+import Models
+import Status
+import SwiftUI
+
+public struct CardsListView: View {
+  @Environment(Theme.self) private var theme
+
+  let cards: [Card]
+  
+  public init(cards: [Card]) {
+    self.cards = cards
+  }
+  
+  public var body: some View {
+    List {
+      ForEach(cards) { card in
+        StatusRowCardView(card: card)
+          .listRowBackground(theme.primaryBackgroundColor)
+          .padding(.vertical, 8)
+      }
+    }
+    .scrollContentBackground(.hidden)
+    .background(theme.primaryBackgroundColor)
+    .listStyle(.plain)
+    .navigationTitle("explore.section.trending.links")
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}

--- a/Packages/Explore/Sources/Explore/ExploreView.swift
+++ b/Packages/Explore/Sources/Explore/ExploreView.swift
@@ -226,20 +226,8 @@ public struct ExploreView: View {
           .listRowBackground(theme.primaryBackgroundColor)
           .padding(.vertical, 8)
       }
-      NavigationLink {
-        List {
-          ForEach(viewModel.trendingLinks) { card in
-            StatusRowCardView(card: card)
-              .listRowBackground(theme.primaryBackgroundColor)
-              .padding(.vertical, 8)
-          }
-        }
-        .scrollContentBackground(.hidden)
-        .background(theme.primaryBackgroundColor)
-        .listStyle(.plain)
-        .navigationTitle("explore.section.trending.links")
-        .navigationBarTitleDisplayMode(.inline)
-      } label: {
+      
+      NavigationLink(value: RouterDestination.trendingLinks(cards: viewModel.trendingLinks)) {
         Text("see-more")
           .foregroundColor(theme.tintColor)
       }


### PR DESCRIPTION
Fixes trending links "see more" not getting added to navigation path, which means pop to root using tab bar doesn't work here.
- Partially addresses #1588 