### PR TITLE
Display the Pending/Unread button at the bottom of the screen

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
@@ -197,13 +197,13 @@ struct DisplaySettingsView: View {
           Text(buttonStyle.description).tag(buttonStyle)
         }
       }
-
       Picker("settings.display.status.media-style", selection: $theme.statusDisplayStyle) {
         ForEach(Theme.StatusDisplayStyle.allCases, id: \.rawValue) { buttonStyle in
           Text(buttonStyle.description).tag(buttonStyle)
         }
       }
       Toggle("settings.display.translate-button", isOn: $userPreferences.showTranslateButton)
+      Toggle("settings.display.pending-at-bottom", isOn: $userPreferences.pendingShownAtBottom)
     }
     .listRowBackground(theme.primaryBackgroundColor)
   }

--- a/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/be.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.display.status.action-buttons" = "Кнопкі дзеянняў стану";
 "settings.display.status.media-style" = "Медыястыль статусу";
 "settings.display.translate-button" = "Паказаць кнопку перакладу";
+"settings.display.pending-at-bottom" = "Кнопка «Паказаць непрачытаныя» ўнізе экрана";
 "settings.display.theme.background" = "Колер фону";
 "settings.display.theme.secondary-background" = "Другасны колер фону";
 "settings.display.theme.text-color" = "Text Color";

--- a/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ca.lproj/Localizable.strings
@@ -85,6 +85,7 @@
 "settings.display.status.action-buttons" = "Botons d'acció";
 "settings.display.status.media-style" = "Estil del contingut multimèdia";
 "settings.display.translate-button" = "Mostra el botó de traducció";
+"settings.display.pending-at-bottom" = "Mostra el botó no llegit a la part inferior de la pantalla";
 "settings.display.theme.background" = "Color de fons";
 "settings.display.theme.secondary-background" = "Color de fons secundari";
 "settings.display.theme.text-color" = "Text Color";

--- a/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/de.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "Status Aktions-Buttons";
 "settings.display.status.media-style" = "Status Medien";
 "settings.display.translate-button" = "Übersetzen-Button anzeigen";
+"settings.display.pending-at-bottom" = "Ungelesene-Button am unteren Rand anzeigen";
 "settings.display.theme.background" = "Hintergrundfarbe";
 "settings.display.theme.secondary-background" = "Sekundäre Hintergrundfarbe";
 "settings.display.theme.text-color" = "Textfarbe";

--- a/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.display.status.action-buttons" = "Status Action Buttons";
 "settings.display.status.media-style" = "Status Media Style";
 "settings.display.translate-button" = "Show Translate Button";
+"settings.display.pending-at-bottom" = "Show Pending Button at Bottom";
 "settings.display.theme.background" = "Background Colour";
 "settings.display.theme.secondary-background" = "Secondary Background Colour";
 "settings.display.theme.text-color" = "Text Color";

--- a/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/en.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.display.status.action-buttons" = "Status Action Buttons";
 "settings.display.status.media-style" = "Status Media Style";
 "settings.display.translate-button" = "Show Translate Button";
+"settings.display.pending-at-bottom" = "Show Pending Button at Bottom";
 "settings.display.theme.background" = "Background Color";
 "settings.display.theme.secondary-background" = "Secondary Background Color";
 "settings.display.theme.text-color" = "Text Color";

--- a/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/es.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "Botones de acción";
 "settings.display.status.media-style" = "Estilo del contenido multimedia";
 "settings.display.translate-button" = "Mostrar botón para traducir";
+"settings.display.pending-at-bottom" = "Mostrar el botón de no leído en la parte inferior de la pantalla";
 "settings.display.theme.background" = "Color de fondo";
 "settings.display.theme.secondary-background" = "Color de fondo secundario";
 "settings.display.theme.text-color" = "Color del texto";

--- a/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/eu.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "Bidalketen ekintza botoiak";
 "settings.display.status.media-style" = "Bidalketen multimediaren itxura";
 "settings.display.translate-button" = "Erakutsi itzulpen botoia";
+"settings.display.pending-at-bottom" = "Erakutsi irakurri gabeko botoia pantailaren behealdean";
 "settings.display.theme.background" = "Hondoaren kolorea";
 "settings.display.theme.secondary-background" = "Bigarren mailako hondoaren kolorea";
 "settings.display.theme.text-color" = "Testuaren kolorea";

--- a/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/fr.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "Boutons d'action de statut";
 "settings.display.status.media-style" = "Style de média de statut";
 "settings.display.translate-button" = "Afficher le bouton de traduction";
+"settings.display.pending-at-bottom" = "Afficher le bouton des toots non lus en bas de l'écran";
 "settings.display.theme.background" = "Couleur de fond";
 "settings.display.theme.secondary-background" = "Couleur de fond secondaire";
 "settings.display.theme.text-color" = "Couleur du texte";

--- a/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/it.lproj/Localizable.strings
@@ -85,6 +85,7 @@
 "settings.display.status.action-buttons" = "Pulsanti di azione";
 "settings.display.status.media-style" = "Stile dei media";
 "settings.display.translate-button" = "Mostra pulsante per la traduzione";
+"settings.display.pending-at-bottom" = "Visualizzare non letto nella parte inferiore dello schermo";
 "settings.display.theme.background" = "Colore sfondo principale";
 "settings.display.theme.secondary-background" = "Colore sfondo secondario";
 "settings.display.theme.text-color" = "Colore del testo";

--- a/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ja.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.display.status.action-buttons" = "アクションボタン";
 "settings.display.status.media-style" = "メディアスタイル";
 "settings.display.translate-button" = "翻訳ボタンの表示";
+"settings.display.pending-at-bottom" = "画面下に未読ボタンを表示する";
 "settings.display.theme.background" = "バックグラウンドカラー";
 "settings.display.theme.secondary-background" = "アクセントカラー";
 "settings.display.theme.text-color" = "テキストカラー";

--- a/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/ko.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "글 동작 버튼";
 "settings.display.status.media-style" = "글 미디어 크기";
 "settings.display.translate-button" = "번역 버튼 표시";
+"settings.display.pending-at-bottom" = "화면 하단에 읽지 않은 버튼 표시";
 "settings.display.theme.background" = "배경 색상";
 "settings.display.theme.secondary-background" = "보조 배경 색상";
 "settings.display.theme.text-color" = "글자 색상";

--- a/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nb.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.display.status.action-buttons" = "Status handlingsknapper";
 "settings.display.status.media-style" = "Status mediestil";
 "settings.display.translate-button" = "Vis oversettelsesknapp";
+"settings.display.pending-at-bottom" = "Vis ulest-knappen nederst på skjermen";
 "settings.display.theme.background" = "Bakgrunnsfarge";
 "settings.display.theme.secondary-background" = "Sekundær bakgrunnsfarge";
 "settings.display.theme.text-color" = "Tekstfarge";

--- a/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/nl.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "Actieknoppen";
 "settings.display.status.media-style" = "Mediastijl";
 "settings.display.translate-button" = "Toon vertaalknop";
+"settings.display.pending-at-bottom" = "De knop Ongelezen onder aan het scherm weergeven";
 "settings.display.theme.background" = "Achtergrondkleur";
 "settings.display.theme.secondary-background" = "Secundaire achtergrondkleur";
 "settings.display.theme.text-color" = "Tekstkleur";

--- a/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pl.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "Przyciski akcji";
 "settings.display.status.media-style" = "Treści multimedialne";
 "settings.display.translate-button" = "Pokazuj przycisk tłumaczenia";
+"settings.display.pending-at-bottom" = "Wyświetlanie przycisku nieprzeczytanych u dołu ekranu";
 "settings.display.theme.background" = "Kolor tła";
 "settings.display.theme.secondary-background" = "Dodatkowy kolor tła";
 "settings.display.theme.text-color" = "Kolor tekstu";

--- a/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "Botões de ação de status";
 "settings.display.status.media-style" = "Estilo de mídia de status";
 "settings.display.translate-button" = "Exibir botão de tradução";
+"settings.display.pending-at-bottom" = "Exibir o botão não lido na parte inferior da tela";
 "settings.display.theme.background" = "Cor de fundo";
 "settings.display.theme.secondary-background" = "Cor de fundo secundária";
 "settings.display.theme.text-color" = "Cor do texto";

--- a/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/tr.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "Durum Aksiyon Butonları";
 "settings.display.status.media-style" = "Durum Medya Stili";
 "settings.display.translate-button" = "Çeviri Butonunu Göster";
+"settings.display.pending-at-bottom" = "Ekranın alt kısmında okunmamış düğmesini görüntüleyin";
 "settings.display.theme.background" = "Arka Plan Rengi";
 "settings.display.theme.secondary-background" = "İkincil Arka Plan Rengi";
 "settings.display.theme.text-color" = "Text Color";

--- a/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/uk.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.display.status.action-buttons" = "Кнопки дій статуса";
 "settings.display.status.media-style" = "Стиль медія статуса";
 "settings.display.translate-button" = "Відображати кнопку перекладу";
+"settings.display.pending-at-bottom" = "Показати непрочитану кнопку внизу екрана";
 "settings.display.theme.background" = "Колір фону";
 "settings.display.theme.secondary-background" = "Додатковий колір фону";
 "settings.display.theme.text-color" = "Колір тексту";

--- a/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.display.status.action-buttons" = "操作栏样式";
 "settings.display.status.media-style" = "媒体内容排列";
 "settings.display.translate-button" = "显示翻译按钮";
+"settings.display.pending-at-bottom" = "在屏幕底部显示未读按钮";
 "settings.display.theme.background" = "背景颜色";
 "settings.display.theme.secondary-background" = "二级背景颜色";
 "settings.display.theme.text-color" = "文本颜色";

--- a/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/IceCubesApp/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.display.status.action-buttons" = "狀態列按鈕";
 "settings.display.status.media-style" = "狀態媒體式樣";
 "settings.display.translate-button" = "顯示翻譯按紐";
+"settings.display.pending-at-bottom" = "在螢幕底部顯示未讀按鈕";
 "settings.display.theme.background" = "背景顏色";
 "settings.display.theme.secondary-background" = "第二背景顏色";
 "settings.display.theme.text-color" = "本文顏色";

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -9,6 +9,7 @@ import SwiftUI
   class Storage {
     @AppStorage("preferred_browser") public var preferredBrowser: PreferredBrowser = .inAppSafari
     @AppStorage("show_translate_button_inline") public var showTranslateButton: Bool = true
+    @AppStorage("show_pending_at_bottom") public var pendingShownAtBottom: Bool = false
     @AppStorage("is_open_ai_enabled") public var isOpenAIEnabled: Bool = true
     
     @AppStorage("recently_used_languages") public var recentlyUsedLanguages: [String] = []
@@ -70,6 +71,11 @@ import SwiftUI
   public var showTranslateButton: Bool {
     didSet {
       storage.showTranslateButton = showTranslateButton
+    }
+  }
+  public var pendingShownAtBottom : Bool {
+    didSet {
+        storage.pendingShownAtBottom = pendingShownAtBottom
     }
   }
   public var isOpenAIEnabled: Bool {
@@ -392,5 +398,6 @@ import SwiftUI
     requestedReview = storage.requestedReview
     collapseLongPosts = storage.collapseLongPosts
     shareButtonBehavior = storage.shareButtonBehavior
+    pendingShownAtBottom = storage.pendingShownAtBottom
   }
 }

--- a/Packages/Timeline/Sources/Timeline/PendingStatusesObserver.swift
+++ b/Packages/Timeline/Sources/Timeline/PendingStatusesObserver.swift
@@ -29,7 +29,7 @@ import SwiftUI
 
 struct PendingStatusesObserverView: View {
   @State var observer: PendingStatusesObserver
-
+  @Environment(UserPreferences.self) private var preferences
   var body: some View {
     if observer.pendingStatusesCount > 0 {
       HStack(spacing: 6) {
@@ -48,6 +48,7 @@ struct PendingStatusesObserverView: View {
         .cornerRadius(8)
       }
       .padding(12)
+      .frame(maxHeight: .infinity, alignment: preferences.pendingShownAtBottom ? .bottom : .top )
     }
   }
 }


### PR DESCRIPTION
Since I have a big screen and smaller hands, having the Pending/Unread toots at the top of the screen is more comfortable at the bottom of the screen for a single-handed use.

This PR enables toggling such behavior.

I also added translation for the settings screens (using automated translation tools, hence some maybe iffy wording in the languages I don't know).

Please let me know if it would be useful to have the ability to locate the Pending/Unread button in the all four corners of the screen.