### PR TITLE
Feature request: Block user confirmation dialog

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
+++ b/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
@@ -8,7 +8,7 @@ public struct AccountDetailContextMenu: View {
   @Environment(CurrentInstance.self) private var currentInstance
   @Environment(UserPreferences.self) private var preferences
 
-  @EnvironmentObject private var blockConfirmation: BlockConfirmation
+  @Binding var showBlockConfirmation: Bool
   
   var viewModel: AccountDetailViewModel
 
@@ -44,7 +44,7 @@ public struct AccountDetailContextMenu: View {
             }
           } else {
             Button {
-              blockConfirmation.isPresentingBlockingConfirmation.toggle()
+              showBlockConfirmation.toggle()
             } label: {
               Label("account.action.block", systemImage: "person.crop.circle.badge.xmark")
             }

--- a/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
+++ b/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
@@ -8,6 +8,8 @@ public struct AccountDetailContextMenu: View {
   @Environment(CurrentInstance.self) private var currentInstance
   @Environment(UserPreferences.self) private var preferences
 
+  @EnvironmentObject private var blockConfirmation: BlockConfirmation
+  
   var viewModel: AccountDetailViewModel
 
   public var body: some View {
@@ -42,13 +44,7 @@ public struct AccountDetailContextMenu: View {
             }
           } else {
             Button {
-              Task {
-                do {
-                  viewModel.relationship = try await client.post(endpoint: Accounts.block(id: account.id))
-                } catch {
-                  print("Error while blocking: \(error.localizedDescription)")
-                }
-              }
+              blockConfirmation.isPresentingBlockingConfirmation.toggle()
             } label: {
               Label("account.action.block", systemImage: "person.crop.circle.badge.xmark")
             }

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -20,8 +20,7 @@ public struct AccountDetailView: View {
   @Environment(Client.self) private var client
   @Environment(RouterPath.self) private var routerPath
 
-  @StateObject private var blockConfirmation: BlockConfirmation = BlockConfirmation()
-  
+  @State private var showBlockConfirmation: Bool = false
   @State private var viewModel: AccountDetailViewModel
   @State private var isCurrentUser: Bool = false
   @State private var isCreateListAlertPresented: Bool = false
@@ -322,7 +321,7 @@ public struct AccountDetailView: View {
       }
 
       Menu {
-        AccountDetailContextMenu(viewModel: viewModel)
+        AccountDetailContextMenu(showBlockConfirmation: $showBlockConfirmation, viewModel: viewModel)
 
         if !viewModel.isCurrentUser {
           Button {
@@ -390,8 +389,7 @@ public struct AccountDetailView: View {
             LocalizedStringKey("accessibility.tabs.profile.options.inputLabel2"),
           ])
       }
-      .environmentObject(blockConfirmation)
-      .confirmationDialog("Block User", isPresented: $blockConfirmation.isPresentingBlockingConfirmation) {
+      .confirmationDialog("Block User", isPresented: $showBlockConfirmation) {
         if let account = viewModel.account {
           Button("Block \(account.username)", role: .destructive) {
             Task {
@@ -416,10 +414,6 @@ extension View {
       .listRowSeparator(.hidden)
       .listRowBackground(theme.primaryBackgroundColor)
   }
-}
-
-class BlockConfirmation: ObservableObject {
-  @Published var isPresentingBlockingConfirmation: Bool = false
 }
 
 struct AccountDetailView_Previews: PreviewProvider {

--- a/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
+++ b/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
@@ -30,6 +30,7 @@ public struct AccountsListRow: View {
   @State var viewModel: AccountsListRowViewModel
 
   @State private var isEditingRelationshipNote: Bool = false
+  @State private var showBlockConfirmation: Bool = false
 
   let isFollowRequest: Bool
   let requestUpdated: (() -> Void)?
@@ -107,7 +108,7 @@ public struct AccountsListRow: View {
       routerPath.navigate(to: .accountDetailWithAccount(account: viewModel.account))
     }
     .contextMenu {
-      AccountDetailContextMenu(viewModel: .init(account: viewModel.account))
+      AccountDetailContextMenu(showBlockConfirmation: $showBlockConfirmation, viewModel: .init(account: viewModel.account))
     } preview: {
       List {
         AccountDetailHeaderView(viewModel: .init(account: viewModel.account),


### PR DESCRIPTION
    - Creates and uses a new StateObject called BlockConfirmation which holds a value to signal when to show the confirmation dialog.
    - Moved the post request for blocking out of the ContextMenu since the Menu view within AccountDetailView will close as soon as one of it's items is clicked.

Note: The code I wrote does not specify thread priority or anything so I think the toggle of the `isPresentingBlockingConfirmation` bool could be done concurrently which may lead to unexpected behavior. Not sure if we want to mark the `BlockConfirmation` class as a MainActor for this.

This PR is in response to issue #1568 