### PR TITLE
Fix a crash bug at `Client.makeURL`

### DIFF
--- a/Packages/Env/Sources/Env/StreamWatcher.swift
+++ b/Packages/Env/Sources/Env/StreamWatcher.swift
@@ -40,9 +40,14 @@ import Observation
   }
 
   private func connect() {
-    guard let client else { return }
-    task = client.makeWebSocketTask(endpoint: Streaming.streaming, instanceStreamingURL: instanceStreamingURL)
-    task?.resume()
+    guard let task = try? client?.makeWebSocketTask(
+      endpoint: Streaming.streaming,
+      instanceStreamingURL: instanceStreamingURL
+    ) else {
+      return
+    }
+    self.task = task
+    self.task?.resume()
     receiveMessage()
   }
 


### PR DESCRIPTION
## Issue

The crash will happen when you type something unexpected instance URL.

<img width="1029" alt="Screenshot 2023-10-01 at 22 02 26" src="https://github.com/Dimillian/IceCubesApp/assets/11143310/1326543b-1def-4188-876d-148b2004c8e5">

Example
```swift
let server = "test.com/"

var components = URLComponents()
components.scheme = "https"
components.host = server
components.path = "/api/v1/instance"
components.url! // 💥 error: Execution was interrupted, reason: EXC_BREAKPOINT (code=1, subcode=0x18c986650).
```


## Solution
Throwing an error instead of doing force unwrap.