### PR TITLE
Fix a crash bug at AccountsListRow

### DIFF
--- a/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
+++ b/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
@@ -121,6 +121,8 @@ public struct AccountsListRow: View {
       .environment(theme)
       .environment(currentAccount)
       .environment(client)
+      .environment(QuickLook())
+      .environment(routerPath)
     }
   }
 }


### PR DESCRIPTION
I found another crash bug.

When you long tap a `AccountsListRow`, a `contextMenu` will be called, and then the app will be crashed. 
This happens because two environments are missing; `QuickLook` and `RouterPath`

<img width="500" alt="Screenshot 2023-10-02 at 11 13 00" src="https://github.com/Dimillian/IceCubesApp/assets/11143310/cb81cf62-8686-43f3-a9c5-80473152d7e6">

```
Fatal error: No Observable object of type QuickLook found. A View.environmentObject(_:) for QuickLook may be missing as an ancestor of this view.
```