### PR TITLE
Feature request: Block user confirmation dialog

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
+++ b/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
@@ -7,6 +7,8 @@ public struct AccountDetailContextMenu: View {
   @Environment(RouterPath.self) private var routerPath
   @Environment(CurrentInstance.self) private var currentInstance
   @Environment(UserPreferences.self) private var preferences
+  
+  @Binding var showBlockConfirmation: Bool
 
   var viewModel: AccountDetailViewModel
 
@@ -42,13 +44,7 @@ public struct AccountDetailContextMenu: View {
             }
           } else {
             Button {
-              Task {
-                do {
-                  viewModel.relationship = try await client.post(endpoint: Accounts.block(id: account.id))
-                } catch {
-                  print("Error while blocking: \(error.localizedDescription)")
-                }
-              }
+              showBlockConfirmation.toggle()
             } label: {
               Label("account.action.block", systemImage: "person.crop.circle.badge.xmark")
             }

--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -24,6 +24,7 @@ public struct AccountDetailView: View {
   @State private var isCurrentUser: Bool = false
   @State private var isCreateListAlertPresented: Bool = false
   @State private var createListTitle: String = ""
+  @State private var showBlockConfirmation: Bool = false
 
   @State private var isEditingAccount: Bool = false
   @State private var isEditingFilters: Bool = false
@@ -320,7 +321,7 @@ public struct AccountDetailView: View {
       }
 
       Menu {
-        AccountDetailContextMenu(viewModel: viewModel)
+        AccountDetailContextMenu(showBlockConfirmation: $showBlockConfirmation, viewModel: viewModel)
 
         if !viewModel.isCurrentUser {
           Button {
@@ -387,6 +388,21 @@ public struct AccountDetailView: View {
             LocalizedStringKey("accessibility.tabs.profile.options.inputLabel1"),
             LocalizedStringKey("accessibility.tabs.profile.options.inputLabel2"),
           ])
+      }
+      .confirmationDialog("Block User", isPresented: $showBlockConfirmation) {
+        if let account = viewModel.account {
+          Button("Block \(account.username)", role: .destructive) {
+            Task {
+              do {
+                viewModel.relationship = try await client.post(endpoint: Accounts.block(id: account.id))
+              } catch {
+                print("Error while blocking: \(error.localizedDescription)")
+              }
+            }
+          }
+        }
+      } message: {
+        Text("Do you want to block this user?")
       }
     }
   }

--- a/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
+++ b/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
@@ -30,6 +30,7 @@ public struct AccountsListRow: View {
   @State var viewModel: AccountsListRowViewModel
 
   @State private var isEditingRelationshipNote: Bool = false
+  @State private var showBlockConfirmation: Bool = false
 
   let isFollowRequest: Bool
   let requestUpdated: (() -> Void)?
@@ -107,7 +108,7 @@ public struct AccountsListRow: View {
       routerPath.navigate(to: .accountDetailWithAccount(account: viewModel.account))
     }
     .contextMenu {
-      AccountDetailContextMenu(viewModel: .init(account: viewModel.account))
+      AccountDetailContextMenu(showBlockConfirmation: $showBlockConfirmation, viewModel: .init(account: viewModel.account))
     } preview: {
       List {
         AccountDetailHeaderView(viewModel: .init(account: viewModel.account),


### PR DESCRIPTION
- Using State property and Binding between ContextMenu and AccountDetailView to show a confirmation dialog when the block button is pressed.

Closed previous PR to clean up my forked repo and create a feature branch.

This PR addresses issue #1597 