### PR TITLE
Draft: Listen for up/down arrow keys and scroll accordingly

### DIFF
--- a/Packages/Timeline/Sources/Timeline/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineView.swift
@@ -25,6 +25,8 @@ public struct TimelineView: View {
 
   @State private var wasBackgrounded: Bool = false
   @State private var collectionView: UICollectionView?
+  @FocusState private var focused: Bool
+  @State private var topVisibleItemIndex = 1
 
   @Binding var timeline: TimelineFilter
   @Binding var selectedTagGroup: TagGroup?
@@ -81,6 +83,7 @@ public struct TimelineView: View {
           collectionView.scrollToItem(at: .init(row: newValue, section: 0),
                                       at: .top,
                                       animated: viewModel.scrollToIndexAnimated)
+          topVisibleItemIndex = newValue
           viewModel.scrollToIndexAnimated = false
           viewModel.scrollToIndex = nil
         }
@@ -128,6 +131,18 @@ public struct TimelineView: View {
       }
     }
     .navigationBarTitleDisplayMode(.inline)
+    .focusable()
+    .focused($focused)
+    .onKeyPress(.upArrow) {
+        viewModel.scrollToIndexAnimated = true
+        viewModel.scrollToIndex = topVisibleItemIndex - 1
+        return .handled
+    }
+    .onKeyPress(.downArrow) {
+        viewModel.scrollToIndexAnimated = true
+        viewModel.scrollToIndex = topVisibleItemIndex + 1
+        return .handled
+    }
     .onAppear {
       viewModel.isTimelineVisible = true
 
@@ -136,6 +151,8 @@ public struct TimelineView: View {
       }
 
       viewModel.timeline = timeline
+
+      focused = true
     }
     .onDisappear {
       viewModel.isTimelineVisible = false


### PR DESCRIPTION
This PR adds the ability to press the up or down arrow key to scroll the timeline one item at a time.

I have tested this only on macOS via Xcode's "Designed for iPad" target.

To make this release-worthy several issues need to be worked out:
- Setting keyboard focus on the timeline at the right times (currently you have to tap/click in the right spot to avoid drilling into a post)
- Noticing non-keyboard scroll to determine the top visible item instead of keeping a @State variable.

If anyone has any pointers/advice on how to achieve either of those, I'm open to suggestions :)
