### PR TITLE
de: Update Localizable.xcstrings

### DIFF
--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -65174,7 +65174,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tag zu Tabgruppen hinzufügen oder entfernen"
+            "value" : "Tag zu Taggruppen hinzufügen oder entfernen"
           }
         },
         "en" : {

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -16776,7 +16776,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tag Group Icon (SFSymbol name)"
+            "value" : "Taggruppensymbol (SFSymbol-Name)"
           }
         },
         "en" : {
@@ -16894,7 +16894,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Add tags to the group"
+            "value" : "Tags der Gruppe hinzufügen"
           }
         },
         "en" : {
@@ -17131,7 +17131,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tag Group Title"
+            "value" : "Taggruppentitel"
           }
         },
         "en" : {
@@ -65174,7 +65174,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Add or remove tag from tag groups"
+            "value" : "Tag zu Tabgruppen hinzufügen oder entfernen"
           }
         },
         "en" : {


### PR DESCRIPTION
Added tag group translations.

*NOTE:* The switch to a string catalog has a few significant disadvantages: 1) no granularity (all translators must submit a complete localization file - enjoy merge conflicts :p), 2) it has become very hard to maintain a translation in a simple text editor (Xcode is probably the least annoying option now).