### PR TITLE
Refactor `StatusRowMediaPreviewView`

### DIFF
--- a/Packages/Models/Sources/Models/MediaAttachement.swift
+++ b/Packages/Models/Sources/Models/MediaAttachement.swift
@@ -50,7 +50,7 @@ public struct MediaAttachment: Codable, Identifiable, Hashable, Equatable {
           type: "image",
           url: url,
           previewUrl: url,
-          description: nil,
+          description: "demo alt text here",
           meta: nil)
   }
 }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -301,9 +301,16 @@ struct BlurOverLay: View {
               }
             } label: {
               if isTextExpanded {
-                HStack {
+                ViewThatFits(in: .horizontal) {
+                  HStack {
+                    Image(systemName: "eye")
+                    Text(sensitive ? "status.media.sensitive.show" : "status.media.content.show" )
+                  }
+                  HStack {
+                    Image(systemName: "eye")
+                    Text("Show")
+                  }
                   Image(systemName: "eye")
-                  Text(sensitive ? "status.media.sensitive.show" : "status.media.content.show" )
                 }
                 .lineLimit(1)
                 .foregroundColor(theme.labelColor)

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -62,32 +62,18 @@ public struct StatusRowMediaPreviewView: View {
 
   public var body: some View {
     Group {
-      if attachments.count == 1, let attachment = attachments.first {
+      if attachments.count == 1 {
         FeaturedImagePreView(
-          attachment: attachment,
+          attachment: attachments[0],
           imageMaxHeight: imageMaxHeight,
           sensitive: sensitive,
           appLayoutWidth: appLayoutWidth,
           availableWidth: availableWidth
         )
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Self.accessibilityLabel(for: attachment))
+        .accessibilityLabel(Self.accessibilityLabel(for: attachments[0]))
         .accessibilityAddTraits([.isButton, .isImage])
-        .onTapGesture {
-          if ProcessInfo.processInfo.isMacCatalystApp {
-            openWindow(
-              value: WindowDestination.mediaViewer(
-                attachments: attachments,
-                selectedAttachment: attachment
-              )
-            )
-          } else {
-            quickLook.prepareFor(
-              selectedMediaAttachment: attachment,
-              mediaAttachments: attachments
-            )
-          }
-        }
+        .onTapGesture { tabAction(for: 0) }
       } else {
         if isCompact || theme.statusDisplayStyle == .compact {
           HStack {
@@ -120,21 +106,23 @@ public struct StatusRowMediaPreviewView: View {
         imageMaxHeight: imageMaxHeight,
         attachment: attachments[index]
       )
-      .onTapGesture {
-        if ProcessInfo.processInfo.isMacCatalystApp {
-          openWindow(
-            value: WindowDestination.mediaViewer(
-              attachments: attachments,
-              selectedAttachment: attachments[index]
-            )
-          )
-        } else {
-          quickLook.prepareFor(
-            selectedMediaAttachment: attachments[index],
-            mediaAttachments: attachments
-          )
-        }
-      }
+      .onTapGesture { tabAction(for: index) }
+    }
+  }
+
+  private func tabAction(for index: Int) {
+    if ProcessInfo.processInfo.isMacCatalystApp {
+      openWindow(
+        value: WindowDestination.mediaViewer(
+          attachments: attachments,
+          selectedAttachment: attachments[index]
+        )
+      )
+    } else {
+      quickLook.prepareFor(
+        selectedMediaAttachment: attachments[index],
+        mediaAttachments: attachments
+      )
     }
   }
 

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -9,11 +9,8 @@ import SwiftUI
 @MainActor
 public struct StatusRowMediaPreviewView: View {
   @Environment(\.openWindow) private var openWindow
-  @Environment(\.isSecondaryColumn) private var isSecondaryColumn: Bool
   @Environment(\.extraLeadingInset) private var extraLeadingInset: CGFloat
-  @Environment(\.isInCaptureMode) private var isInCaptureMode: Bool
   @Environment(\.isCompact) private var isCompact: Bool
-
   @Environment(SceneDelegate.self) private var sceneDelegate
   @Environment(UserPreferences.self) private var preferences
   @Environment(QuickLook.self) private var quickLook
@@ -66,39 +63,39 @@ public struct StatusRowMediaPreviewView: View {
     return attachments.count > 2 ? 150 : 200
   }
 
-  private func size(for media: MediaAttachment) -> CGSize? {
-    if let width = media.meta?.original?.width,
-       let height = media.meta?.original?.height
-    {
-      return .init(width: CGFloat(width), height: CGFloat(height))
-    }
-    return nil
-  }
-
-  private func imageSize(from: CGSize, newWidth: CGFloat) -> CGSize {
-    if isCompact || theme.statusDisplayStyle == .compact || isSecondaryColumn {
-      return .init(width: imageMaxHeight, height: imageMaxHeight)
-    }
-    let ratio = newWidth / from.width
-    let newHeight = from.height * ratio
-    return .init(width: newWidth, height: newHeight)
-  }
-
   public var body: some View {
     Group {
       if attachments.count == 1, let attachment = attachments.first {
-        makeFeaturedImagePreview(attachment: attachment)
-          .onTapGesture {
-            if ProcessInfo.processInfo.isMacCatalystApp {
-              openWindow(value: WindowDestination.mediaViewer(attachments: attachments,
-                                                              selectedAttachment: attachment))
-            } else {
-              quickLook.prepareFor(selectedMediaAttachment: attachment, mediaAttachments: attachments)
-            }
+        FeaturedImagePreView(
+          attachment: attachment,
+          imageMaxHeight: imageMaxHeight,
+          sensitive: sensitive,
+          isCompact: isCompact,
+          appLayoutWidth: appLayoutWidth,
+          availableWidth: availableWidth,
+          preferences: preferences,
+          isHidingMedia: $isHidingMedia,
+          altTextDisplayed: altTextDisplayed,
+          isAltAlertDisplayed: isAltAlertDisplayed
+        )
+        .onTapGesture {
+          if ProcessInfo.processInfo.isMacCatalystApp {
+            openWindow(
+              value: WindowDestination.mediaViewer(
+                attachments: attachments,
+                selectedAttachment: attachment
+              )
+            )
+          } else {
+            quickLook.prepareFor(
+              selectedMediaAttachment: attachment,
+              mediaAttachments: attachments
+            )
           }
-          .accessibilityElement(children: .ignore)
-          .accessibilityLabel(Self.accessibilityLabel(for: attachment))
-          .accessibilityAddTraits([.isButton, .isImage])
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Self.accessibilityLabel(for: attachment))
+        .accessibilityAddTraits([.isButton, .isImage])
       } else {
         if isCompact || theme.statusDisplayStyle == .compact {
           HStack {
@@ -122,10 +119,12 @@ public struct StatusRowMediaPreviewView: View {
       }
     }
     .overlay {
-      if isHidingMedia {
-        sensitiveMediaOverlay
-          .transition(.opacity)
-      }
+      MediaOverLay(
+        isCompact: isCompact,
+        sensitive: sensitive,
+        labelColor: theme.labelColor,
+        isHidingMedia: isHidingMedia
+      )
     }
     .alert("status.editor.media.image-description",
            isPresented: $isAltAlertDisplayed)
@@ -148,70 +147,59 @@ public struct StatusRowMediaPreviewView: View {
   @ViewBuilder
   private func makeAttachmentView(for index: Int) -> some View {
     if attachments.count > index {
-      makePreview(attachment: attachments[index])
-    }
-  }
-
-  @ViewBuilder
-  private func makeFeaturedImagePreview(attachment: MediaAttachment) -> some View {
-    ZStack(alignment: .bottomLeading) {
-      let size: CGSize = size(for: attachment) ?? .init(width: imageMaxHeight, height: imageMaxHeight)
-      let newSize = imageSize(from: size, newWidth: availableWidth - appLayoutWidth)
-      switch attachment.supportedType {
-      case .image:
-        LazyImage(url: attachment.url) { state in
-          if let image = state.image {
-            image
-              .resizable()
-              .aspectRatio(contentMode: .fill)
-              .frame(width: newSize.width, height: newSize.height)
-              .clipped()
-              .cornerRadius(4)
-              .overlay(
-                RoundedRectangle(cornerRadius: 4)
-                  .stroke(.gray.opacity(0.35), lineWidth: 1)
-              )
-          } else {
-            RoundedRectangle(cornerRadius: 4)
-              .fill(Color.gray)
-              .frame(width: newSize.width, height: newSize.height)
-          }
+      MediaPreview(
+        isCompact: isCompact,
+        sensitive: sensitive,
+        imageMaxHeight: imageMaxHeight,
+        attachment: attachments[index], 
+        preferences: preferences, 
+        altTextDisplayed: altTextDisplayed,
+        isAltAlertDisplayed: isAltAlertDisplayed,
+        isHidingMedia: $isHidingMedia
+      )
+      .onTapGesture {
+        if ProcessInfo.processInfo.isMacCatalystApp {
+          openWindow(
+            value: WindowDestination.mediaViewer(
+              attachments: attachments,
+              selectedAttachment: attachments[index]
+            )
+          )
+        } else {
+          quickLook.prepareFor(
+            selectedMediaAttachment: attachments[index],
+            mediaAttachments: attachments
+          )
         }
-        .processors([.resize(size: newSize)])
-        .frame(width: newSize.width, height: newSize.height)
-
-      case .gifv, .video, .audio:
-        if let url = attachment.url {
-          MediaUIAttachmentVideoView(viewModel: .init(url: url))
-            .frame(width: newSize.width, height: newSize.height)
-        }
-      case .none:
-        EmptyView()
-      }
-      if !isInCaptureMode, sensitive {
-        cornerSensitiveButton
-      }
-      if !isInCaptureMode, let alt = attachment.description, !alt.isEmpty, !isCompact, preferences.showAltTextForMedia {
-        Group {
-          Button {
-            altTextDisplayed = alt
-            isAltAlertDisplayed = true
-          } label: {
-            Text("status.image.alt-text.abbreviation")
-              .font(theme.statusDisplayStyle == .compact ? .footnote : .body)
-          }
-          .buttonStyle(.borderless)
-          .padding(4)
-          .background(.thinMaterial)
-          .cornerRadius(4)
-        }
-        .padding(theme.statusDisplayStyle == .compact ? 0 : 10)
       }
     }
   }
 
-  @ViewBuilder
-  private func makePreview(attachment: MediaAttachment) -> some View {
+  private static func accessibilityLabel(for attachment: MediaAttachment) -> Text {
+    if let altText = attachment.description {
+      Text("accessibility.image.alt-text-\(altText)")
+    } else if let typeDescription = attachment.localizedTypeDescription {
+      Text(typeDescription)
+    } else {
+      Text("accessibility.tabs.profile.picker.media")
+    }
+  }
+}
+
+private struct MediaPreview: View {
+  let isCompact: Bool
+  let sensitive: Bool
+  let imageMaxHeight: CGFloat
+  let attachment: MediaAttachment
+  let preferences: UserPreferences
+
+  @Environment(\.isInCaptureMode) private var isInCaptureMode: Bool
+
+  @State var altTextDisplayed: String?
+  @State var isAltAlertDisplayed: Bool
+  @Binding var isHidingMedia: Bool
+
+  var body: some View {
     if let type = attachment.supportedType, !isInCaptureMode {
       Group {
         GeometryReader { proxy in
@@ -224,8 +212,7 @@ public struct StatusRowMediaPreviewView: View {
                   image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .frame(maxWidth: width)
-                    .frame(maxHeight: imageMaxHeight)
+                    .frame(maxWidth: width, maxHeight: imageMaxHeight)
                     .clipped()
                     .cornerRadius(4)
                     .overlay(
@@ -235,12 +222,8 @@ public struct StatusRowMediaPreviewView: View {
                 } else if state.isLoading {
                   RoundedRectangle(cornerRadius: 4)
                     .fill(Color.gray)
-                    .frame(maxHeight: imageMaxHeight)
-                    .frame(maxWidth: width)
+                    .frame(maxWidth: width, maxHeight: imageMaxHeight)
                 }
-              }
-              if sensitive, !isInCaptureMode {
-                cornerSensitiveButton
               }
               if !isInCaptureMode,
                  let alt = attachment.description,
@@ -275,68 +258,189 @@ public struct StatusRowMediaPreviewView: View {
       }
       // #965: do not create overlapping tappable areas, when multiple images are shown
       .contentShape(Rectangle())
-      .onTapGesture {
-        if ProcessInfo.processInfo.isMacCatalystApp {
-          openWindow(value: WindowDestination.mediaViewer(attachments: attachments,
-                                                          selectedAttachment: attachment))
-        } else {
-          quickLook.prepareFor(selectedMediaAttachment: attachment, mediaAttachments: attachments)
-        }
-      }
       .accessibilityElement(children: .ignore)
-      .accessibilityLabel(Self.accessibilityLabel(for: attachment))
+      .accessibilityLabel(accessibilityLabel)
       .accessibilityAddTraits(attachment.supportedType == .image ? [.isImage, .isButton] : .isButton)
     }
   }
 
-  private var sensitiveMediaOverlay: some View {
-    ZStack {
-      Rectangle()
-        .foregroundColor(.clear)
-        .background(.ultraThinMaterial)
-      if !isCompact {
-        Button {
-          withAnimation {
-            isHidingMedia = false
-          }
-        } label: {
-          Group {
-            if sensitive {
-              Label("status.media.sensitive.show", systemImage: "eye")
-            } else {
-              Label("status.media.content.show", systemImage: "eye")
-            }
-          }
-          .foregroundColor(theme.labelColor)
-        }
-        .buttonStyle(.borderedProminent)
-      }
-    }
-  }
-
-  private var cornerSensitiveButton: some View {
-    HStack {
-      Button {
-        withAnimation {
-          isHidingMedia = true
-        }
-      } label: {
-        Image(systemName: "eye.slash")
-          .frame(minHeight: 21) // Match the alt button in case it is also present
-      }
-      .padding(10)
-      .buttonStyle(.borderedProminent)
-      Spacer()
-    }
-  }
-
-  private static func accessibilityLabel(for attachment: MediaAttachment) -> Text {
+  private var accessibilityLabel: Text {
     if let altText = attachment.description {
       Text("accessibility.image.alt-text-\(altText)")
     } else if let typeDescription = attachment.localizedTypeDescription {
       Text(typeDescription)
     } else {
       Text("accessibility.tabs.profile.picker.media")
+    }
+  }
+}
+
+private struct FeaturedImagePreView: View {
+  let attachment: MediaAttachment
+  let imageMaxHeight: CGFloat
+  let sensitive: Bool
+  let isCompact: Bool
+  let appLayoutWidth: CGFloat
+  let availableWidth: CGFloat
+  let preferences: UserPreferences
+
+//  @Environment(UserPreferences.self) private var preferences
+  @Environment(\.isSecondaryColumn) private var isSecondaryColumn: Bool
+  @Environment(Theme.self) private var theme
+  @Environment(\.isInCaptureMode) private var isInCaptureMode: Bool
+
+  @Binding var isHidingMedia: Bool
+  @State var altTextDisplayed: String?
+  @State var isAltAlertDisplayed: Bool = false
+
+  var body: some View {
+    ZStack(alignment: .bottomLeading) {
+      let size: CGSize = size(for: attachment) ?? .init(width: imageMaxHeight, height: imageMaxHeight)
+      let newSize = imageSize(from: size, newWidth: availableWidth - appLayoutWidth)
+      switch attachment.supportedType {
+      case .image:
+        LazyImage(url: attachment.url) { state in
+          if let image = state.image {
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+              .frame(width: newSize.width, height: newSize.height)
+              .clipped()
+              .cornerRadius(4)
+              .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                  .stroke(.gray.opacity(0.35), lineWidth: 1)
+              )
+          } else {
+            RoundedRectangle(cornerRadius: 4)
+              .fill(Color.gray)
+              .frame(width: newSize.width, height: newSize.height)
+          }
+        }
+        .processors([.resize(size: newSize)])
+        .frame(width: newSize.width, height: newSize.height)
+
+      case .gifv, .video, .audio:
+        if let url = attachment.url {
+          MediaUIAttachmentVideoView(viewModel: .init(url: url))
+            .frame(width: newSize.width, height: newSize.height)
+        }
+      case .none:
+        EmptyView()
+      }
+      if !isInCaptureMode,
+          let alt = attachment.description,
+         !alt.isEmpty,
+         !isCompact,
+         preferences.showAltTextForMedia
+      {
+        Group {
+          Button {
+            altTextDisplayed = alt
+            isAltAlertDisplayed = true
+          } label: {
+            Text("status.image.alt-text.abbreviation")
+              .font(theme.statusDisplayStyle == .compact ? .footnote : .body)
+          }
+          .buttonStyle(.borderless)
+          .padding(4)
+          .background(.thinMaterial)
+          .cornerRadius(4)
+        }
+        .padding(theme.statusDisplayStyle == .compact ? 0 : 10)
+      }
+    }
+  }
+
+  private func size(for media: MediaAttachment) -> CGSize? {
+    if let width = media.meta?.original?.width,
+       let height = media.meta?.original?.height
+    {
+      return .init(width: CGFloat(width), height: CGFloat(height))
+    }
+    return nil
+  }
+
+  private func imageSize(from: CGSize, newWidth: CGFloat) -> CGSize {
+    if isCompact || theme.statusDisplayStyle == .compact || isSecondaryColumn {
+      return .init(width: imageMaxHeight, height: imageMaxHeight)
+    }
+    let ratio = newWidth / from.width
+    let newHeight = from.height * ratio
+    return .init(width: newWidth, height: newHeight)
+  }
+}
+
+@MainActor
+struct MediaOverLay: View {
+  let isCompact: Bool
+  let sensitive: Bool
+  let labelColor: Color
+  let isHidingMedia: Bool
+
+  @State private var isFrameExpanded = true
+  @State private var isTextExpanded = true
+  @Environment(\.isInCaptureMode) private var isInCaptureMode: Bool
+  @Environment(UserPreferences.self) private var preferences
+  @Namespace var buttonSpace
+
+  var body: some View {
+    if hasOverlay {
+      ZStack {
+        Rectangle()
+          .foregroundColor(.clear)
+          .background(.ultraThinMaterial)
+          .frame(
+            width: isFrameExpanded ? nil : 0,
+            height: isFrameExpanded ? nil : 0)
+        if !isCompact {
+          Button {
+            withAnimation(.spring(duration: 0.2)) {
+              isTextExpanded.toggle()
+            } completion: {
+              withAnimation(.spring(duration: 0.3)) {
+                isFrameExpanded.toggle()
+              }
+            }
+          } label: {
+            if isTextExpanded {
+              Group {
+                if sensitive {
+                  Label("status.media.sensitive.show", systemImage: "eye")
+                } else {
+                  Label("status.media.content.show", systemImage: "eye")
+                }
+              }
+              .foregroundColor(labelColor)
+              .matchedGeometryEffect(id: "text", in: buttonSpace)
+            } else {
+              Image(systemName: "eye.slash")
+                .matchedGeometryEffect(id: "text", in: buttonSpace)
+            }
+          }
+          .foregroundColor(labelColor)
+          .buttonStyle(.borderedProminent)
+          .padding(10)
+        }
+      }
+      .frame(
+        maxWidth: .infinity,
+        maxHeight: .infinity,
+        alignment: isFrameExpanded ? .center : .bottomLeading
+      )
+    } else {
+      EmptyView()
+    }
+  }
+
+  private var hasOverlay: Bool {
+    switch (sensitive, preferences.autoExpandMedia) {
+    case (_, .hideAll), (true, .hideSensitive):
+      switch isInCaptureMode {
+      case true: false
+      case false: true
+      }
+    default: false
     }
   }
 }


### PR DESCRIPTION
### 1. I made the overlay animation smoother and more logical.

It may sound funny when the animation needs to be logical but it is important for user experience. New Animation avoids abrupt experience and helps users know where the button goes.

- each media item now has an independent overlay

### 2. I fixed the alt text button

- it now has a consistent potion in the media frame, `.bottomTrailling`
- and appropriate size in comparison to show/hide content button

### 3. I also refactored some subviews to make the animation easier to understand and fix.

- narrow down the data dependency of views
- fix their logic code
- these buttons now always disappear in the capture mode
- add preview code

### Demonstration and testing

#### Before

![Hiding-Sensitive-Before--Nov-02-2023 14-32-39](https://github.com/Dimillian/IceCubesApp/assets/46838577/7f608f83-5594-4b30-8b0f-1b340956611d)


#### After

https://github.com/Dimillian/IceCubesApp/assets/46838577/45014e76-71d2-4151-86ec-e30e9ff01e92


### Code for Preview

1. select the `Status` scheme
2. add the dependency for the `Status` package in its `Package.swift` (I will create **a separate PR** for this if you want)
```swift
dependencies: [
    ...
    .package(url: "https://github.com/nicklockwood/LRUCache.git", .upToNextMinor(from: "1.0.0")),
],
targets: [
  ...
  dependencies: [
	...
	.product(name: "LRUCache", package: "LRUCache"),
],
```
3. manually replace some related localized strings because I can not make the localization work in the preview canvas
4. run preview canvas (preview code already there)