### PR TITLE
I removed "Done" button in setting tab on iPhone

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -12,7 +12,6 @@ import Timeline
 
 @MainActor
 struct SettingsTabs: View {
-  @Environment(\.dismiss) private var dismiss
   @Environment(\.modelContext) private var context
 
   @Environment(PushNotificationsService.self) private var pushNotifications
@@ -48,15 +47,6 @@ struct SettingsTabs: View {
       .navigationBarTitleDisplayMode(.inline)
       .toolbarBackground(theme.primaryBackgroundColor.opacity(0.50), for: .navigationBar)
       .toolbar {
-        if UIDevice.current.userInterfaceIdiom == .phone {
-          ToolbarItem {
-            Button {
-              dismiss()
-            } label: {
-              Text("action.done").bold()
-            }
-          }
-        }
         if UIDevice.current.userInterfaceIdiom == .pad, !preferences.showiPadSecondaryColumn {
           SecondaryColumnToolbarItem()
         }


### PR DESCRIPTION
I removed the "Done" button because it has no effect since "Setting" is a separate tab (on iPhone). The reason is that the `@Environment(\.dismiss)` action is only meant to be used for:
- Dismiss a modal presentation, like a sheet or a popover.
- Pop the current view from a [NavigationStack](https://developer.apple.com/documentation/swiftui/navigationstack).
- Close a window that you create with [WindowGroup](https://developer.apple.com/documentation/swiftui/windowgroup) or [Window](https://developer.apple.com/documentation/swiftui/window).