### PR TITLE
Update Korean localization

### DIFF
--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -29992,7 +29992,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "새 글"
           }
         },
@@ -30111,7 +30111,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "New Window"
+            "value" : "새 창"
           }
         },
         "nb" : {
@@ -40448,6 +40448,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show Pending Button on the Left"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽지 않은 글 수를 왼쪽에 표시"
           }
         }
       }


### PR DESCRIPTION
- Adds new translations for the new strings
	- `New Window`
	- `Show Pending Button on the Left`
- Marks `New Post` as translated

By the way, I think it would be better to have just one `Picker` with 4 options(top right/top left/bottom right/bottom left) regarding the position of the pending post button rather than two different toggles. Maybe I should open an issue...