### PR TITLE
Feature: store selected notification filter (#1627)

### DIFF
--- a/Packages/Notifications/Sources/Notifications/NotificationsListView.swift
+++ b/Packages/Notifications/Sources/Notifications/NotificationsListView.swift
@@ -39,6 +39,7 @@ public struct NotificationsListView: View {
         }
       }
     }
+    .onAppear { viewModel.loadSelectedType(for: client) }
     .toolbar {
       ToolbarItem(placement: .principal) {
         let title = lockedType?.menuTitle() ?? viewModel.selectedType?.menuTitle() ?? "notifications.navigation-title"

--- a/Packages/Notifications/Sources/Notifications/NotificationsListView.swift
+++ b/Packages/Notifications/Sources/Notifications/NotificationsListView.swift
@@ -39,7 +39,7 @@ public struct NotificationsListView: View {
         }
       }
     }
-    .onAppear { viewModel.loadSelectedType(for: client) }
+    .onAppear { viewModel.loadSelectedType() }
     .toolbar {
       ToolbarItem(placement: .principal) {
         let title = lockedType?.menuTitle() ?? viewModel.selectedType?.menuTitle() ?? "notifications.navigation-title"

--- a/Packages/Notifications/Sources/Notifications/NotificationsViewModel.swift
+++ b/Packages/Notifications/Sources/Notifications/NotificationsViewModel.swift
@@ -39,13 +39,29 @@ import SwiftUI
   var state: State = .loading
   var selectedType: Models.Notification.NotificationType? {
     didSet {
-      if oldValue != selectedType {
-        consolidatedNotifications = []
-        Task {
-          await fetchNotifications()
-        }
+      guard oldValue != selectedType,
+            let id = client?.id
+      else { return }
+
+      UserDefaults.standard.set(selectedType?.rawValue ?? "", forKey: "notification-filter-\(id)")
+
+      consolidatedNotifications = []
+      Task {
+        await fetchNotifications()
       }
     }
+  }
+
+  func loadSelectedType(for client: Client) {
+    self.client = client
+    
+    guard let value = UserDefaults.standard.string(forKey: "notification-filter-\(client.id)")
+    else {
+      selectedType = nil
+      return
+    }
+
+    selectedType = .init(rawValue: value)
   }
 
   var scrollToTopVisible: Bool = false

--- a/Packages/Notifications/Sources/Notifications/NotificationsViewModel.swift
+++ b/Packages/Notifications/Sources/Notifications/NotificationsViewModel.swift
@@ -36,6 +36,7 @@ import SwiftUI
 
   var currentAccount: CurrentAccount?
 
+  private let filterKey = "notification-filter"
   var state: State = .loading
   var selectedType: Models.Notification.NotificationType? {
     didSet {
@@ -43,7 +44,7 @@ import SwiftUI
             let id = client?.id
       else { return }
 
-      UserDefaults.standard.set(selectedType?.rawValue ?? "", forKey: "notification-filter-\(id)")
+      UserDefaults.standard.set(selectedType?.rawValue ?? "", forKey: filterKey)
 
       consolidatedNotifications = []
       Task {
@@ -52,10 +53,10 @@ import SwiftUI
     }
   }
 
-  func loadSelectedType(for client: Client) {
+  func loadSelectedType() {
     self.client = client
     
-    guard let value = UserDefaults.standard.string(forKey: "notification-filter-\(client.id)")
+    guard let value = UserDefaults.standard.string(forKey: filterKey)
     else {
       selectedType = nil
       return


### PR DESCRIPTION
I implement the feature request in #1627. I follow the convention in `TimelineCache` that uses `UserDefaults.standard` to store data.