### PR TITLE
Improve the display of replies

### DIFF
--- a/Packages/Env/Sources/Env/CustomEnvValues.swift
+++ b/Packages/Env/Sources/Env/CustomEnvValues.swift
@@ -25,8 +25,8 @@ private struct IsStatusFocused: EnvironmentKey {
   static let defaultValue: Bool = false
 }
 
-private struct IsStatusReplyToPrevious: EnvironmentKey {
-  static let defaultValue: Bool = false
+private struct IndentationLevel: EnvironmentKey {
+  static let defaultValue: UInt = 0
 }
 
 public extension EnvironmentValues {
@@ -60,8 +60,8 @@ public extension EnvironmentValues {
     set { self[IsStatusFocused.self] = newValue }
   }
 
-  var isStatusReplyToPrevious: Bool {
-    get { self[IsStatusReplyToPrevious.self] }
-    set { self[IsStatusReplyToPrevious.self] = newValue }
+  var indentationLevel: UInt {
+    get { self[IndentationLevel.self] }
+    set { self[IndentationLevel.self] = newValue }
   }
 }

--- a/Packages/Status/Sources/Status/Detail/StatusDetailView.swift
+++ b/Packages/Status/Sources/Status/Detail/StatusDetailView.swift
@@ -103,15 +103,15 @@ public struct StatusDetailView: View {
 
   private func makeStatusesListView(statuses: [Status]) -> some View {
     ForEach(statuses) { status in
-      let isReplyToPrevious = viewModel.isReplyToPreviousCache[status.id] ?? false
+      let indentationLevel = viewModel.getIndentationLevel(id: status.id)
       let viewModel: StatusRowViewModel = .init(status: status,
                                                 client: client,
                                                 routerPath: routerPath)
       let isFocused = self.viewModel.statusId == status.id
 
       StatusRowView(viewModel: viewModel)
-        .environment(\.extraLeadingInset, isReplyToPrevious ? 10 : 0)
-        .environment(\.isStatusReplyToPrevious, isReplyToPrevious)
+        .environment(\.extraLeadingInset, (indentationLevel > 0) ? 10 : 0)
+        .environment(\.indentationLevel, indentationLevel)
         .environment(\.isStatusFocused, isFocused)
         .overlay {
           if isFocused {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -15,7 +15,7 @@ public struct StatusRowView: View {
   @Environment(\.isCompact) private var isCompact: Bool
   @Environment(\.accessibilityVoiceOverEnabled) private var accessibilityVoiceOverEnabled
   @Environment(\.isStatusFocused) private var isFocused
-  @Environment(\.isStatusReplyToPrevious) private var isStatusReplyToPrevious
+  @Environment(\.indentationLevel) private var indentationLevel
 
   @Environment(QuickLook.self) private var quickLook
   @Environment(Theme.self) private var theme
@@ -32,11 +32,15 @@ public struct StatusRowView: View {
 
   public var body: some View {
     HStack(spacing: 0) {
-      if isStatusReplyToPrevious {
-        Rectangle()
-          .fill(theme.tintColor)
-          .frame(width: 2)
-          .accessibilityHidden(true)
+      HStack(spacing: 3) {
+        ForEach(0..<indentationLevel, id: \.self) {_ in
+          Rectangle()
+            .fill(theme.tintColor)
+            .frame(width: 2)
+            .accessibilityHidden(true)
+        }
+      }
+      if indentationLevel > 0 {
         Spacer(minLength: 8)
       }
       VStack(alignment: .leading) {


### PR DESCRIPTION
Threads/replies are now shown more clearly. Each reply has an indentation level (and therefore the number of vertical lines) one more than its direct parent. This leads to siblings having the same indentation level. It makes understanding somewhat complex thread structures way easier. Previously, a reply was only indented if it came directly after its parent. If a toot had more than one reply, the structure was nearly indecipherable, as it wasn't clear which the parent post of the second (or later) toot was. An example is "https://mastodon.social/@mhoye/110452462852364819" and all of its replies.