### PR TITLE
Fix reply indentation when the post has pictures

### DIFF
--- a/Packages/Status/Sources/Status/Detail/StatusDetailView.swift
+++ b/Packages/Status/Sources/Status/Detail/StatusDetailView.swift
@@ -12,6 +12,7 @@ public struct StatusDetailView: View {
   @Environment(StreamWatcher.self) private var watcher
   @Environment(Client.self) private var client
   @Environment(RouterPath.self) private var routerPath
+  @Environment(\.isCompact) private var isCompact: Bool
 
   @State private var viewModel: StatusDetailViewModel
 
@@ -103,15 +104,15 @@ public struct StatusDetailView: View {
 
   private func makeStatusesListView(statuses: [Status]) -> some View {
     ForEach(statuses) { status in
-      let indentationLevel = viewModel.getIndentationLevel(id: status.id)
+      let (indentationLevel, extraInsets) = viewModel.getIndentationLevel(id: status.id)
       let viewModel: StatusRowViewModel = .init(status: status,
                                                 client: client,
                                                 routerPath: routerPath)
       let isFocused = self.viewModel.statusId == status.id
 
       StatusRowView(viewModel: viewModel)
-        .environment(\.extraLeadingInset, (indentationLevel > 0) ? 10 : 0)
-        .environment(\.indentationLevel, indentationLevel)
+        .environment(\.extraLeadingInset, !isCompact ? extraInsets : 0)
+        .environment(\.indentationLevel, !isCompact ? indentationLevel : 0)
         .environment(\.isStatusFocused, isFocused)
         .overlay {
           if isFocused {

--- a/Packages/Status/Sources/Status/Detail/StatusDetailViewModel.swift
+++ b/Packages/Status/Sources/Status/Detail/StatusDetailViewModel.swift
@@ -139,7 +139,13 @@ import SwiftUI
     }
   }
   
-  func getIndentationLevel(id: String) -> UInt {
-    min(indentationLevelPreviousCache[id] ?? 0, Self.maxIndent)
+  func getIndentationLevel(id: String) -> (indentationLevel: UInt, extraInset: Double) {
+    let level = min(indentationLevelPreviousCache[id] ?? 0, Self.maxIndent)
+    
+    let barSize = Double(level) * 2
+    let spaceBetween = (Double(level) - 1) * 3
+    let size = barSize + spaceBetween + 8
+    
+    return (level, size)
   }
 }

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -32,18 +32,16 @@ public struct StatusRowView: View {
 
   public var body: some View {
     HStack(spacing: 0) {
-      if !isCompact {
-        HStack(spacing: 3) {
-          ForEach(0..<indentationLevel, id: \.self) {_ in
-            Rectangle()
-              .fill(theme.tintColor)
-              .frame(width: 2)
-              .accessibilityHidden(true)
-          }
+      HStack(spacing: 3) {
+        ForEach(0..<indentationLevel, id: \.self) {_ in
+          Rectangle()
+            .fill(theme.tintColor)
+            .frame(width: 2)
+            .accessibilityHidden(true)
         }
-        if indentationLevel > 0 {
-          Spacer(minLength: 8)
-        }
+      }
+      if indentationLevel > 0 {
+        Spacer(minLength: 8)
       }
       VStack(alignment: .leading) {
         if viewModel.isFiltered, let filter = viewModel.filter {


### PR DESCRIPTION
The size of the image is now set correctly to prevent the shifting of the vertical bars. The handling of the compact view (regarding the indentation) is now centrally handled in StatusDetailView.