### PR TITLE
Add hint if the server post options are overridden

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/AccountSettingView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AccountSettingView.swift
@@ -98,6 +98,7 @@ struct AccountSettingsView: View {
     }
     .sheet(isPresented: $isEditingAccount, content: {
       EditAccountView()
+            .environment(\.contentSettingsFactory, AnyView(ContentSettingsView()))
     })
     .sheet(isPresented: $isEditingFilters, content: {
       FiltersListView()

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -12723,6 +12723,23 @@
         }
       }
     },
+    "account.edit.post-settings.content-settings-reference" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Achtung: Diese Optionen werden durch die globalen Inhaltseinstellungen überschrieben"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warning: These settings are overwritten by the global content settings"
+          }
+        }
+      }
+    },
     "account.edit.post-settings.privacy" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/Account/Package.swift
+++ b/Packages/Account/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     .package(name: "Network", path: "../Network"),
     .package(name: "Models", path: "../Models"),
     .package(name: "Status", path: "../Status"),
+    .package(name: "Env", path: "../Env"),
   ],
   targets: [
     .target(
@@ -27,6 +28,7 @@ let package = Package(
         .product(name: "Network", package: "Network"),
         .product(name: "Models", package: "Models"),
         .product(name: "Status", package: "Status"),
+        .product(name: "Env", package: "Env"),
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency"),

--- a/Packages/Account/Sources/Account/Edit/EditAccountView.swift
+++ b/Packages/Account/Sources/Account/Edit/EditAccountView.swift
@@ -1,6 +1,7 @@
 import DesignSystem
 import Models
 import Network
+import Env
 import SwiftUI
 
 @MainActor
@@ -8,8 +9,11 @@ public struct EditAccountView: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(Client.self) private var client
   @Environment(Theme.self) private var theme
+  @Environment(UserPreferences.self) private var userPrefs
+  @Environment(\.contentSettingsFactory) private var contentSettings
 
   @State private var viewModel = EditAccountViewModel()
+  @State private var showContentSettings = false
 
   public init() {}
 
@@ -72,6 +76,19 @@ public struct EditAccountView: View {
 
   private var postSettingsSection: some View {
     Section("account.edit.post-settings.section-title") {
+      if !userPrefs.useInstanceContentSettings {
+        HStack {
+          Button("account.edit.post-settings.content-settings-reference") {showContentSettings.toggle()}
+            .buttonStyle(.plain)
+            .navigationDestination(isPresented: $showContentSettings) {
+              contentSettings
+            }
+          Spacer()
+          Image(systemName: "chevron.right")
+            .font(.caption)
+        }
+        .foregroundStyle(Color.accentColor)
+      }
       Picker(selection: $viewModel.postPrivacy) {
         ForEach(Models.Visibility.supportDefault, id: \.rawValue) { privacy in
           Text(privacy.title).tag(privacy)

--- a/Packages/Env/Sources/Env/CustomEnvValues.swift
+++ b/Packages/Env/Sources/Env/CustomEnvValues.swift
@@ -29,6 +29,10 @@ private struct IndentationLevel: EnvironmentKey {
   static let defaultValue: UInt = 0
 }
 
+private struct ContentSettingsFactory: EnvironmentKey {
+  static let defaultValue: AnyView = AnyView(EmptyView())
+}
+
 public extension EnvironmentValues {
   var isSecondaryColumn: Bool {
     get { self[SecondaryColumnKey.self] }
@@ -63,5 +67,10 @@ public extension EnvironmentValues {
   var indentationLevel: UInt {
     get { self[IndentationLevel.self] }
     set { self[IndentationLevel.self] = newValue }
+  }
+  
+  var contentSettingsFactory: AnyView {
+    get { self[ContentSettingsFactory.self] }
+    set { self[ContentSettingsFactory.self] = newValue }
   }
 }


### PR DESCRIPTION
If the content settings specify their own post settings and override the instance settings, a hint (and link to the content settings) is added to the instance settings (infos) since that setting might introduce confusion (As happened in #1677).