### PR TITLE
Hide settings link on macos

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -159,10 +159,12 @@ struct SettingsTabs: View {
       NavigationLink(destination: TranslationSettingsView()) {
         Label("settings.general.translate", systemImage: "captions.bubble")
       }
+      #if !targetEnvironment(macCatalyst)
       Link(destination: URL(string: UIApplication.openSettingsURLString)!) {
         Label("settings.system", systemImage: "gear")
       }
       .tint(theme.labelColor)
+      #endif
     }
     .listRowBackground(theme.primaryBackgroundColor)
   }


### PR DESCRIPTION
As stated in https://github.com/Dimillian/IceCubesApp/issues/1647, the link is not needed on macOS, so I hid it