### PR TITLE
Improve display of HTML ul (bullet list) and ol (numbered list)

### DIFF
--- a/Packages/Models/Sources/Models/Alias/HTMLString.swift
+++ b/Packages/Models/Sources/Models/Alias/HTMLString.swift
@@ -183,6 +183,28 @@ public struct HTMLString: Codable, Equatable, Hashable, @unchecked Sendable {
         }
         // Strip newlines and line separators - they should be being sent as <br>s
         asMarkdown += txt.replacingOccurrences(of: "\n", with: "").replacingOccurrences(of: "\u{2028}", with: "")
+      } else if node.nodeName() == "ul" {
+        // Unordered (bulleted) list
+        // SwiftUI's Text won't display these in an AttributedString, but we can at least improve the appearance
+        asMarkdown += "\n\n"
+        for nn in node.getChildNodes() {
+          asMarkdown += "- "
+          handleNode(node: nn)
+          asMarkdown += "\n"
+        }
+        return
+      } else if node.nodeName() == "ol" {
+        // Ordered (numbered) list
+        // Same thing, won't display in a Text, but this is just an attempt to improve the appearance
+        asMarkdown += "\n\n"
+        var curNumber = 1
+        for nn in node.getChildNodes() {
+          asMarkdown += "\(curNumber). "
+          handleNode(node: nn)
+          asMarkdown += "\n"
+          curNumber += 1
+        }
+        return
       }
 
       for n in node.getChildNodes() {


### PR DESCRIPTION
While SwiftUI's `Text` view won't display these in an `AttributedString` even if they get parsed from Markdown (which would also require the use of the `.full` option instead of the `.inlineOnlyPreservingWhitespace` option), we can improve the appearance somewhat. 
Currently, list elements are clumped together with no spaces between them, and there's no indication whatsoever that the author indicated these to be a list. 
Change to insert Markdown list syntax with linebreaks and dashes, so users can at least understand there's a list there. Similar change for ordered lists.

This will still be broken for nested lists, but it didn't seem worth it to put a lot of effort into this (or other revamps, like making bold/italics/code work properly) because it seems like the current text handling in Ice Cubes is suboptimal and eventually slated for improvement (according to https://github.com/Dimillian/IceCubesApp/issues/1459#issuecomment-1638562657). 
So this is more designed to make lists "less broken" in some (many) cases, rather than be a comprehensive fix for all lists in all cases.