### PR TITLE
Fix: media views don't resize when the window size (device orientation) changes

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/SceneDelegate.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/SceneDelegate.swift
@@ -1,16 +1,11 @@
 import Combine
 import UIKit
 
-@Observable public class SceneDelegate: NSObject, UIWindowSceneDelegate {
+@Observable
+public class SceneDelegate: NSObject, UIWindowSceneDelegate, Sendable {
   public var window: UIWindow?
-
-  public var windowWidth: CGFloat {
-    window?.bounds.size.width ?? UIScreen.main.bounds.size.width
-  }
-
-  public var windowHeight: CGFloat {
-    window?.bounds.size.height ?? UIScreen.main.bounds.size.height
-  }
+  public private(set) var windowWidth: CGFloat = UIScreen.main.bounds.size.width
+  public private(set) var windowHeight: CGFloat = UIScreen.main.bounds.size.height
 
   public func scene(_ scene: UIScene,
                     willConnectTo _: UISceneSession,
@@ -25,5 +20,37 @@ import UIKit
         titlebar.toolbar = nil
       }
     #endif
+  }
+
+  public override init() {
+    super.init()
+    self.windowWidth = self.window?.bounds.size.width ?? UIScreen.main.bounds.size.width
+    self.windowHeight = self.window?.bounds.size.height ?? UIScreen.main.bounds.size.height
+    Self.observedSceneDelegate.insert(self)
+    _ = Self.observer // just for activating the lazy static property
+  }
+
+  deinit {
+    Task { @MainActor in
+      Self.observedSceneDelegate.remove(self)
+    }
+  }
+
+  private static var observedSceneDelegate: Set<SceneDelegate> = []
+  private static let observer = Task {
+    while true {
+      try? await Task.sleep(for: .seconds(0.1))
+      for delegate in observedSceneDelegate {
+        let newWidth = delegate.window?.bounds.size.width ?? UIScreen.main.bounds.size.width
+        if delegate.windowWidth != newWidth {
+          delegate.windowWidth = newWidth
+        }
+
+        let newHeight = delegate.window?.bounds.size.height ?? UIScreen.main.bounds.size.height
+        if delegate.windowHeight != newHeight {
+          delegate.windowHeight = newHeight
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description

This PR fixes the media resizing bug for #1401 #1656  #1668.

The reason is because of `SceneDelegate`. Its properties `windowWidth` and `windowHeight` are not observable. They don't emit any change to observers(views).

So I fixed `SceneDelegate` only, I don't change any logic of the view. Any bug related to the view logic, if exists, should be fixed in other PRs.

### Demonstration

#### macOS

> You should wait a little bit for the GIF to be loaded.

![Resize-macOS--2023-11-28 at 22 13 30](https://github.com/Dimillian/IceCubesApp/assets/46838577/152f3686-d4d4-4d86-aa16-d35b50a9fd36)

#### iPadOS

> You should wait a little bit for the GIF to be loaded.

![Resize-iPadOS--2023-11-28 at 22 40 08](https://github.com/Dimillian/IceCubesApp/assets/46838577/35f62805-222e-4d0f-9fc1-80df670e1fa2)
