### PR TITLE
Added a "Continues a thread" label to status rows

### DIFF
--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -65752,9 +65752,45 @@
     "status.row.is-thread" : {
       "extractionState" : "manual",
       "localizations" : {
+        "be" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Continues a thread"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continues a thread"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "eu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "Continues a thread"
           }
         },
@@ -65762,6 +65798,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Complète un fil"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continues a thread"
           }
         }
       }

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -65749,6 +65749,23 @@
         }
       }
     },
+    "status.row.is-thread" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continues a thread"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complète un fil"
+          }
+        }
+      }
+    },
     "status.row.was-boosted" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -65868,121 +65885,121 @@
         }
       }
     },
-    "status.row.was-reply" : {
+    "status.row.was-reply %@" : {
       "extractionState" : "manual",
       "localizations" : {
         "be" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Адказаў"
+            "value" : "Адказаў %@"
           }
         },
         "ca" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ha respost a"
+            "value" : "Ha respost a %@"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Antwort auf"
+            "value" : "Antwort auf %@"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Replied to"
+            "value" : "Replied to %@"
           }
         },
         "en-GB" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Replied to"
+            "value" : "Replied to %@"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respuesta a"
+            "value" : "Respuesta a %@"
           }
         },
         "eu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Honi erantzunez:"
+            "value" : "Honi erantzunez: %@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Répondu à"
+            "value" : "Répondu à %@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Risposta per"
+            "value" : "Risposta per %@"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "返信"
+            "value" : "返信 %@"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "답글:"
+            "value" : "답글: %@"
           }
         },
         "nb" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Svar til"
+            "value" : "Svar til %@"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geantwoord op"
+            "value" : "Geantwoord op %@"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Odpowiedział(a) do"
+            "value" : "Odpowiedział(a) do %@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Respondeu a"
+            "value" : "Respondeu a %@"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Şuna cevap verildi"
+            "value" : "Şuna cevap verildi %@"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Відповідь для"
+            "value" : "Відповідь для %@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "回复给"
+            "value" : "回复给 %@"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "回覆給"
+            "value" : "回覆給 %@"
           }
         }
       }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowReplyView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowReplyView.swift
@@ -5,26 +5,34 @@ struct StatusRowReplyView: View {
   let viewModel: StatusRowViewModel
 
   var body: some View {
-    if let accountId = viewModel.status.inReplyToAccountId,
-       let mention = viewModel.status.mentions.first(where: { $0.id == accountId })
-    {
-      HStack(spacing: 2) {
-        Image(systemName: "arrowshape.turn.up.left.fill")
-        Text("status.row.was-reply")
-        Text(mention.username)
-      }
-      .accessibilityElement(children: .combine)
-      .accessibilityLabel(
-        Text("status.row.was-reply")
-          + Text(" ")
-          + Text(mention.username)
-      )
-      .font(.scaledFootnote)
-      .foregroundColor(.gray)
-      .fontWeight(.semibold)
-      .onTapGesture {
-        viewModel.navigateToMention(mention: mention)
+    Group {
+      if let accountId = viewModel.status.inReplyToAccountId {
+        if let mention = viewModel.status.mentions.first(where: { $0.id == accountId }) {
+          HStack(spacing: 2) {
+            Image(systemName: "arrowshape.turn.up.left.fill")
+            Text("status.row.was-reply \(mention.username)")
+          }
+          .accessibilityElement(children: .combine)
+          .accessibilityLabel(
+            Text("status.row.was-reply \(mention.username)")
+          )
+          .onTapGesture {
+            viewModel.navigateToMention(mention: mention)
+          }
+        } else if viewModel.isThread && accountId == viewModel.status.account.id {
+          HStack(spacing: 2) {
+            Image(systemName: "quote.opening")
+            Text("status.row.is-thread")
+          }
+          .accessibilityElement(children: .combine)
+          .accessibilityLabel(
+            Text("status.row.is-thread")
+          )
+        }
       }
     }
+    .font(.scaledFootnote)
+    .foregroundColor(.gray)
+    .fontWeight(.semibold)
   }
 }


### PR DESCRIPTION
Just like "boosted by" and "replied to", I do think that thread label brings value when seeing a message that might be out of context in the timeline. This helps bringing context without having to press the message to check if there is a thread above. Pressing the message will do the same and allow to consult the whole thread at a glance.

<img width=393 src="https://github.com/Dimillian/IceCubesApp/assets/8696821/0d723ae4-e16b-4b88-98f4-564d7cc1d403" alt="IMG_D95FC98160A5-1">
