### PR TITLE
Photo view ignores bottom edge of safe area

### DIFF
--- a/Packages/MediaUI/Sources/MediaUI/MediaUIView.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIView.swift
@@ -17,10 +17,12 @@ public struct MediaUIView: View, @unchecked Sendable {
             DisplayView(data: $0)
               .containerRelativeFrame([.horizontal, .vertical])
               .id($0)
+              .safeAreaPadding($0.type == .av ? [.bottom] : [])
           }
         }
         .scrollTargetLayout()
       }
+      .ignoresSafeArea(.all, edges: .bottom)
       .focusable()
       .focused($isFocused)
       .focusEffectDisabled()


### PR DESCRIPTION
- Photo view ignores bottom safe area edge.
- Video view/control unaffected.

![image](https://github.com/Dimillian/IceCubesApp/assets/46838577/45436903-f477-4625-b313-2b2675f7a17c)
