### PR TITLE
Improve media selection on the status editor.

### DIFF
--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -59,7 +59,9 @@ struct StatusEditorAccessoryView: View {
             .photosPicker(isPresented: $isPhotosPickerPresented,
                           selection: $viewModel.selectedMedias,
                           maxSelectionCount: 4,
-                          matching: .any(of: [.images, .videos]))
+                          matching: .any(of: [.images, .videos]),
+                          photoLibrary: .shared()
+            )
             .fileImporter(isPresented: $isFileImporterPresented,
                           allowedContentTypes: [.image, .video],
                           allowsMultipleSelection: true)

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorAccessoryView.swift
@@ -57,7 +57,7 @@ struct StatusEditorAccessoryView: View {
               }
             }
             .photosPicker(isPresented: $isPhotosPickerPresented,
-                          selection: $viewModel.selectedMedias,
+                          selection: $viewModel.mediaPickers,
                           maxSelectionCount: 4,
                           matching: .any(of: [.images, .videos]),
                           photoLibrary: .shared()

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaContainer.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaContainer.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import UIKit
 
 struct StatusEditorMediaContainer: Identifiable {
-  let id = UUID().uuidString
+  let id: String
   let image: UIImage?
   let movieTransferable: MovieFileTranseferable?
   let gifTransferable: GifFileTranseferable?

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
@@ -21,20 +21,21 @@ struct StatusEditorMediaView: View {
           Menu {
             makeImageMenu(container: container)
           } label: {
-            ZStack(alignment: .bottomTrailing) {
-              if let attachement = container.mediaAttachment {
-                makeLazyImage(mediaAttachement: attachement)
-              } else if container.image != nil {
-                makeLocalImage(container: container)
-              } else if container.movieTransferable != nil || container.gifTransferable != nil {
-                makeVideoAttachement(container: container)
-              } else if let error = container.error as? ServerError {
-                makeErrorView(error: error)
-              }
-              if container.mediaAttachment?.description?.isEmpty == false {
-                altMarker
-              }
+            if let attachement = container.mediaAttachment {
+              makeLazyImage(mediaAttachement: attachement)
+            } else if container.image != nil {
+              makeLocalImage(container: container)
+            } else if container.movieTransferable != nil || container.gifTransferable != nil {
+              makeVideoAttachement(container: container)
+            } else if let error = container.error as? ServerError {
+              makeErrorView(error: error)
             }
+          }
+          .overlay(alignment: .bottomTrailing) {
+            makeAltMarker(container: container)
+          }
+          .overlay(alignment: .topTrailing) {
+            makeDiscardMarker(container: container)
           }
         }
       }
@@ -141,14 +142,32 @@ struct StatusEditorMediaView: View {
     }
   }
 
-  private var altMarker: some View {
-    Button {} label: {
+  private func makeAltMarker(container: StatusEditorMediaContainer) -> some View {
+    Button {
+      editingContainer = container
+    } label: {
       Text("status.image.alt-text.abbreviation")
         .font(.caption2)
     }
     .padding(4)
     .background(.thinMaterial)
     .cornerRadius(8)
+    .padding(4)
+  }
+
+  private func makeDiscardMarker(container: StatusEditorMediaContainer) -> some View {
+    Button(role: .destructive) {
+      withAnimation {
+        viewModel.mediasImages.removeAll(where: { $0.id == container.id })
+      }
+    } label: {
+      Image(systemName: "xmark")
+        .font(.caption2)
+        .foregroundStyle(.tint)
+        .padding(4)
+        .background(Circle().fill(.thinMaterial))
+    }
+    .padding(4)
   }
 
   private var placeholderView: some View {

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
@@ -17,7 +17,7 @@ struct StatusEditorMediaView: View {
   var body: some View {
     ScrollView(.horizontal, showsIndicators: false) {
       HStack(spacing: 8) {
-        ForEach(viewModel.mediasImages) { container in
+        ForEach(viewModel.mediaContainers) { container in
           Menu {
             makeImageMenu(container: container)
           } label: {
@@ -123,7 +123,7 @@ struct StatusEditorMediaView: View {
 
     Button(role: .destructive) {
       withAnimation {
-        viewModel.selectedMedias.removeAll(where: {
+        viewModel.mediaPickers.removeAll(where: {
           if let id = $0.itemIdentifier {
             return id == container.id
           }
@@ -164,7 +164,7 @@ struct StatusEditorMediaView: View {
   private func makeDiscardMarker(container: StatusEditorMediaContainer) -> some View {
     Button(role: .destructive) {
       withAnimation {
-        viewModel.selectedMedias.removeAll(where: {
+        viewModel.mediaPickers.removeAll(where: {
           if let id = $0.itemIdentifier {
             return id == container.id
           }

--- a/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
+++ b/Packages/Status/Sources/Status/Editor/Components/StatusEditorMediaView.swift
@@ -123,7 +123,13 @@ struct StatusEditorMediaView: View {
 
     Button(role: .destructive) {
       withAnimation {
-        viewModel.mediasImages.removeAll(where: { $0.id == container.id })
+        viewModel.selectedMedias.removeAll(where: {
+          if let id = $0.itemIdentifier {
+            return id == container.id
+          }
+          return false
+        })
+
       }
     } label: {
       Label("action.delete", systemImage: "trash")
@@ -158,7 +164,12 @@ struct StatusEditorMediaView: View {
   private func makeDiscardMarker(container: StatusEditorMediaContainer) -> some View {
     Button(role: .destructive) {
       withAnimation {
-        viewModel.mediasImages.removeAll(where: { $0.id == container.id })
+        viewModel.selectedMedias.removeAll(where: {
+          if let id = $0.itemIdentifier {
+            return id == container.id
+          }
+          return false
+        })
       }
     } label: {
       Image(systemName: "xmark")

--- a/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
+++ b/Packages/Status/Sources/Status/Editor/StatusEditorViewModel.swift
@@ -563,18 +563,18 @@ import SwiftUI
   func prepareToPost(for pickerItem: PhotosPickerItem) {
     Task(priority: .high) {
       if let container = await makeMediaContainer(from: pickerItem) {
-        await MainActor.run { self.mediaContainers.append(container) }
+        self.mediaContainers.append(container)
         await upload(container: container)
-        await MainActor.run { self.isMediasLoading = false }
+        self.isMediasLoading = false
       }
     }
   }
 
   func prepareToPost(for container: StatusEditorMediaContainer) {
     Task(priority: .high) {
-      await MainActor.run { self.mediaContainers.append(container) }
+      self.mediaContainers.append(container)
       await upload(container: container)
-      await MainActor.run { self.isMediasLoading = false }
+      self.isMediasLoading = false
     }
   }
 


### PR DESCRIPTION
### Description

This change doesn't affect the existing media menu.

There are issues with the media selection in the status editor, which negatively impacts the app's user experience and may hinder its success in the current AI trend.

#### Performance and logical problems

- lagging UI when showing media after selecting because preparing tasks (creating containers, uploading media) don't run in parallel
- not removing photo pickers (not deselecting on the photo app) when removing media on the post editor
- pickers don't have identifiers after being selected
- re-preparing(creating containers, uploading media) the whole media list every time adding new ones

#### UI problems

![image](https://github.com/Dimillian/IceCubesApp/assets/46838577/cfa95daf-9741-4220-9ce5-4325ea48dc09)

- lack of a menu button (delete, alt) directly on the media item may be counter-intuitive in comparison to the current trend of UI design
- the alt button only appears when the alt-text is not empty, but it does nothing, confusing users. It now always shows up and will lead users to the "Edit Media" view

### Miscellaneous

- I leave the measurement code for creating containers at 2bc49fbe54dd37b1009380f28fa4f054db3dc13c. It is now at least 6 times faster.