### PR TITLE
Add Select Status Text Action

### DIFF
--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -57846,9 +57846,117 @@
     "status.action.select-text" : {
       "extractionState" : "manual",
       "localizations" : {
+        "be" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Select Text"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "eu" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner le texte"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Select Text"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "Select Text"
           }
         }

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -57843,6 +57843,17 @@
         }
       }
     },
+    "status.action.select-text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Text"
+          }
+        }
+      }
+    },
     "status.action.share" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/Status/Sources/Status/Row/StatusRowView.swift
+++ b/Packages/Status/Sources/Status/Row/StatusRowView.swift
@@ -22,13 +22,14 @@ public struct StatusRowView: View {
   @Environment(Theme.self) private var theme
 
   @State private var viewModel: StatusRowViewModel
+  @State private var showSelectableText: Bool = false
 
   public init(viewModel: StatusRowViewModel) {
     _viewModel = .init(initialValue: viewModel)
   }
 
   var contextMenu: some View {
-    StatusRowContextMenu(viewModel: viewModel)
+    StatusRowContextMenu(viewModel: viewModel, showTextForSelection: $showSelectableText)
   }
 
   public var body: some View {
@@ -195,6 +196,10 @@ public struct StatusRowView: View {
     })
     .alignmentGuide(.listRowSeparatorLeading) { _ in
       -100
+    }
+    .sheet(isPresented: $showSelectableText) {
+      let content = viewModel.status.reblog?.content.asSafeMarkdownAttributedString ?? viewModel.status.content.asSafeMarkdownAttributedString
+      SelectTextView(content: content)
     }
     .environment(
       StatusDataControllerProvider.shared.dataController(for: viewModel.finalStatus,

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -18,6 +18,7 @@ struct StatusRowContextMenu: View {
   @Environment(QuickLook.self) private var quickLook
 
   var viewModel: StatusRowViewModel
+  @Binding var showTextForSelection: Bool
 
   var boostLabel: some View {
     if viewModel.status.visibility == .priv, viewModel.status.account.id == account.account?.id {
@@ -130,6 +131,12 @@ struct StatusRowContextMenu: View {
       UIPasteboard.general.string = viewModel.status.reblog?.content.asRawText ?? viewModel.status.content.asRawText
     } label: {
       Label("status.action.copy-text", systemImage: "doc.on.doc")
+    }
+
+    Button {
+      showTextForSelection = true
+    } label: {
+      Label("status.action.select-text", systemImage: "selection.pin.in.out")
     }
 
     Button {
@@ -270,4 +277,48 @@ struct ActivityView: UIViewControllerRepresentable {
   }
 
   func updateUIViewController(_: UIActivityViewController, context _: UIViewControllerRepresentableContext<ActivityView>) {}
+}
+
+struct SelectTextView: View {
+  @Environment(\.dismiss) private var dismiss
+  let content: AttributedString
+
+  var body: some View {
+    NavigationStack {
+      SelectableText(content: content)
+        .padding()
+        .toolbar {
+          ToolbarItem(placement: .navigationBarTrailing) {
+            Button {
+              dismiss()
+            } label: {
+              Text("action.done").bold()
+            }
+          }
+        }
+        .navigationTitle("status.action.select-text")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+  }
+}
+
+struct SelectableText: UIViewRepresentable {
+  let content: AttributedString
+
+  func makeUIView(context: Context) -> UITextView {
+    let attributedText = NSMutableAttributedString(content)
+    attributedText.addAttribute(
+      .font,
+      value: Font.scaledBodyFont,
+      range: NSRange(location: 0, length: content.characters.count)
+    )
+
+    let textView = UITextView()
+    textView.isEditable = false
+    textView.attributedText = attributedText
+    return textView
+  }
+
+  func updateUIView(_ uiView: UITextView, context: Context) {}
+  func makeCoordinator() -> Void {}
 }

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowContextMenu.swift
@@ -296,6 +296,7 @@ struct SelectTextView: View {
             }
           }
         }
+        .background(Color.primaryBackground)
         .navigationTitle("status.action.select-text")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -316,6 +317,8 @@ struct SelectableText: UIViewRepresentable {
     let textView = UITextView()
     textView.isEditable = false
     textView.attributedText = attributedText
+    textView.textColor = UIColor(Color.label)
+    textView.backgroundColor = UIColor(Color.primaryBackground)
     return textView
   }
 

--- a/Packages/Status/Sources/Status/Row/Subviews/StatusRowHeaderView.swift
+++ b/Packages/Status/Sources/Status/Row/Subviews/StatusRowHeaderView.swift
@@ -11,6 +11,7 @@ struct StatusRowHeaderView: View {
   @Environment(Theme.self) private var theme
 
   let viewModel: StatusRowViewModel
+  @State private var showTextForSelection: Bool = false
 
   var body: some View {
     HStack(alignment: .center) {
@@ -26,6 +27,10 @@ struct StatusRowHeaderView: View {
         contextMenuButton
       }
     }
+    .sheet(isPresented: $showTextForSelection) {
+      let content = viewModel.status.reblog?.content.asSafeMarkdownAttributedString ?? viewModel.status.content.asSafeMarkdownAttributedString
+      SelectTextView(content: content)
+    }
     .accessibilityElement(children: .combine)
     .accessibilityLabel(Text("\(viewModel.finalStatus.account.safeDisplayName)") + Text(", ") + Text(viewModel.finalStatus.createdAt.relativeFormatted))
     .accessibilityAction {
@@ -33,7 +38,7 @@ struct StatusRowHeaderView: View {
     }
     .accessibilityActions {
       if isFocused {
-        StatusRowContextMenu(viewModel: viewModel)
+        StatusRowContextMenu(viewModel: viewModel, showTextForSelection: $showTextForSelection)
       }
     }
   }
@@ -120,7 +125,7 @@ struct StatusRowHeaderView: View {
 
   private var contextMenuButton: some View {
     Menu {
-      StatusRowContextMenu(viewModel: viewModel)
+      StatusRowContextMenu(viewModel: viewModel, showTextForSelection: $showTextForSelection)
         .onAppear {
           Task {
             await viewModel.loadAuthorRelationship()


### PR DESCRIPTION
I just added the select text action, existing actions are unchanged.

- follow the current theme convention
- support attributed string to give the same text appearance as status
- already localized (English)
- tested on both iOS and macOS

(video)

https://github.com/Dimillian/IceCubesApp/assets/46838577/d888d4ac-3173-4e74-8255-42412f37ec5d

