### PR TITLE
Update EmojiText to 3.2.0

### DIFF
--- a/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IceCubesApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/divadretlaw/EmojiText",
       "state" : {
-        "revision" : "65b570ea0b0d9fc89a000900691a73a16c0baa54",
-        "version" : "3.0.2"
+        "revision" : "4b08e28898ef3de175280d453ccb62d0a82beb7e",
+        "version" : "3.2.0"
       }
     },
     {

--- a/Packages/DesignSystem/Package.swift
+++ b/Packages/DesignSystem/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     .package(name: "Env", path: "../Env"),
     .package(url: "https://github.com/markiv/SwiftUI-Shimmer", exact: "1.1.0"),
     .package(url: "https://github.com/kean/Nuke", from: "12.0.0"),
-    .package(url: "https://github.com/divadretlaw/EmojiText", from: "3.0.0"),
+    .package(url: "https://github.com/divadretlaw/EmojiText", from: "3.2.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Fixes #1738

Tested with iPhone 11, iOS 17.2 (oldest iPhone I have available at the moment) and with the mentioned posts in #1738 it doesn't crash anymore.