### PR TITLE
separator should extend to leading margin

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/DisplaySettingsView.swift
@@ -216,6 +216,9 @@ struct DisplaySettingsView: View {
           Text("settings.display.max-reply-indentation-\(String(userPreferences.maxReplyIndentation))")
             .font(.scaledBody)
         }
+        .alignmentGuide(.listRowSeparatorLeading) { d in
+          d[.leading]
+        }
       }
       Toggle("settings.display.show-account-popover", isOn: $userPreferences.showAccountPopover)
     }


### PR DESCRIPTION
fixes:

<img width="950" alt="截圖 2023-12-18 下午3 26 07" src="https://github.com/Dimillian/IceCubesApp/assets/95387068/1b362231-2093-4c7b-be0c-6343927fd418">

where the separator is aligned with "Max"