### PR TITLE
Fix settings done button logic

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -53,7 +53,7 @@ struct SettingsTabs: View {
       .navigationBarTitleDisplayMode(.inline)
       .toolbarBackground(theme.primaryBackgroundColor.opacity(0.50), for: .navigationBar)
       .toolbar {
-        if UIDevice.current.userInterfaceIdiom == .phone || isModal {
+        if isModal {
           ToolbarItem {
             Button {
               dismiss()

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -62,7 +62,7 @@ struct SettingsTabs: View {
             }
           }
         }
-        if UIDevice.current.userInterfaceIdiom == .pad, !preferences.showiPadSecondaryColumn {
+        if UIDevice.current.userInterfaceIdiom == .pad, !preferences.showiPadSecondaryColumn, !isModal {
           SecondaryColumnToolbarItem()
         }
       }


### PR DESCRIPTION
With the new customizable tab bar, "Settings" can be rendered directly as the root view of a tab bar entry instead of as a "modal" presented from the root view. The "Done" button to dismiss the modal should be hidden if `isModal` is `false`.

### Steps to reproduce the bug

- Open "Settings > Tab Customizations", change one of the tab to "Settings"
- Switch to "Settings" tab

### Before fix

![before](https://github.com/Dimillian/IceCubesApp/assets/6780049/df9cd5cc-fd5f-47b9-833b-94cd5f687fe8)

### After fix

![after](https://github.com/Dimillian/IceCubesApp/assets/6780049/7bbff0f7-a619-437c-bba0-70b57f9913d2)


