### PR TITLE
shift the square.and.pencil icon so that the square is visually centered in the background rectangle

### DIFF
--- a/IceCubesApp/App/SideBarView.swift
+++ b/IceCubesApp/App/SideBarView.swift
@@ -67,6 +67,7 @@ struct SideBarView<Content: View>: View {
         .resizable()
         .aspectRatio(contentMode: .fit)
         .frame(width: 20, height: 30)
+        .offset(x: 2, y: -2)
     }
     .buttonStyle(.borderedProminent)
   }


### PR DESCRIPTION
before:
<img width="53" alt="before" src="https://github.com/Dimillian/IceCubesApp/assets/95387068/1c3f7d14-1b44-45d4-8825-1c2ef7fb0fa0">

after:
<img width="53" alt="after" src="https://github.com/Dimillian/IceCubesApp/assets/95387068/8792f1ec-a780-48f1-966c-554e350f8423">

Please accept, this is driving me a little nuts.  😊