### PR TITLE
Fix the "About" button's label in Accounts Selector view

### DIFF
--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -38590,7 +38590,7 @@
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Опис"
+            "value" : "Про застосунок"
           }
         },
         "zh-Hans" : {
@@ -38708,7 +38708,7 @@
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Іконка додатку"
+            "value" : "Іконка застосунку"
           }
         },
         "zh-Hans" : {
@@ -39300,7 +39300,7 @@
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Підтримати додаток"
+            "value" : "Підтримати застосунок"
           }
         },
         "zh-Hans" : {
@@ -49929,7 +49929,7 @@
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Додаток"
+            "value" : "Застосунок"
           }
         },
         "zh-Hans" : {
@@ -50047,7 +50047,7 @@
         "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Версія додатку: %@"
+            "value" : "Версія застосунку: %@"
           }
         },
         "zh-Hans" : {

--- a/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
+++ b/Packages/AppAccount/Sources/AppAccount/AppAccountsSelectorView.swift
@@ -174,7 +174,7 @@ public struct AppAccountsSelectorView: View {
         routerPath.presentedSheet = .about
       }
     } label: {
-      Label("account.edit.about", systemImage: "info.circle")
+      Label("settings.app.about", systemImage: "info.circle")
     }
   }
 


### PR DESCRIPTION
## Description
I noticed that the key used for the "About" button in Accounts Selector is `account.edit.about` instead of `settings.app.about`. 

Contextually `settings.app.about` works better here, and based on the languages I can read and somehow understand (Ukrainian, Polish, German, Belarusian), those labels are not the same as just "About" in English (i.e. "About me" vs. "About the application")

## Changelog
- changed the localization key for the "About" button
- replaced the word "Додаток" with "Застосунок" in Ukrainian. This term is more accurate for the word "Application" ([source](https://onlinecorrector.com.ua/uk/застосунок-програма/))