### PR TITLE
Feature: Use tagGroup icon in timeline quick access feature

### DIFF
--- a/IceCubesApp/App/Tabs/Timeline/TimelineTab.swift
+++ b/IceCubesApp/App/Tabs/Timeline/TimelineTab.swift
@@ -94,7 +94,7 @@ struct TimelineTab: View {
         lastTimelineFilter = newValue
       }
       switch newValue {
-      case let .tagGroup(title, _):
+      case let .tagGroup(title, _, _):
         if let group = tagGroups.first(where: { $0.title == title}) {
           selectedTagGroup = group
         }
@@ -297,7 +297,7 @@ struct TimelineTab: View {
     Menu("timeline.filter.tag-groups") {
       ForEach(tagGroups) { group in
         Button {
-          timeline = .tagGroup(title: group.title, tags: group.tags)
+          timeline = .tagGroup(title: group.title, tags: group.tags, symbolName: group.symbolName)
         } label: {
           VStack {
             let icon = group.symbolName.isEmpty ? "number" : group.symbolName

--- a/Packages/Timeline/Sources/Timeline/TimelineFilter.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineFilter.swift
@@ -33,7 +33,7 @@ public enum TimelineFilter: Hashable, Equatable, Identifiable {
   
   case home, local, federated, trending
   case hashtag(tag: String, accountId: String?)
-  case tagGroup(title: String, tags: [String])
+  case tagGroup(title: String, tags: [String], symbolName: String)
   case list(list: Models.List)
   case remoteLocal(server: String, filter: RemoteTimelineFilter)
   case latest
@@ -81,7 +81,7 @@ public enum TimelineFilter: Hashable, Equatable, Identifiable {
       "Home"
     case let .hashtag(tag, _):
       "#\(tag)"
-    case let .tagGroup(title, _):
+    case let .tagGroup(title, _, _):
       title
     case let .list(list):
       list.title
@@ -106,7 +106,7 @@ public enum TimelineFilter: Hashable, Equatable, Identifiable {
       "timeline.home"
     case let .hashtag(tag, _):
       "#\(tag)"
-    case let .tagGroup(title, _):
+    case let .tagGroup(title, _, _):
       LocalizedStringKey(title) // ?? not sure since this can't be localized.
     case let .list(list):
       LocalizedStringKey(list.title)
@@ -133,8 +133,8 @@ public enum TimelineFilter: Hashable, Equatable, Identifiable {
       "list.bullet"
     case .remoteLocal:
       "dot.radiowaves.right"
-    case .tagGroup:
-      "tag"
+    case let .tagGroup(_, _, symbolName):
+        symbolName
     case .hashtag:
       "number"
     }
@@ -164,7 +164,7 @@ public enum TimelineFilter: Hashable, Equatable, Identifiable {
       } else {
         return Timelines.hashtag(tag: tag, additional: nil, maxId: maxId, minId: minId)
       }
-    case let .tagGroup(_, tags):
+    case let .tagGroup(_, tags, _):
       var tags = tags
       if !tags.isEmpty {
         let tag = tags.removeFirst()
@@ -214,9 +214,11 @@ extension TimelineFilter: Codable {
       var nestedContainer = try container.nestedUnkeyedContainer(forKey: .tagGroup)
       let title = try nestedContainer.decode(String.self)
       let tags = try nestedContainer.decode([String].self)
+      let symbolName = try nestedContainer.decode(String.self)
       self = .tagGroup(
         title: title,
-        tags: tags
+        tags: tags,
+        symbolName: symbolName
       )
     case .list:
       let list = try container.decode(
@@ -259,10 +261,11 @@ extension TimelineFilter: Codable {
       var nestedContainer = container.nestedUnkeyedContainer(forKey: .hashtag)
       try nestedContainer.encode(tag)
       try nestedContainer.encode(accountId)
-    case let .tagGroup(title, tags):
+    case let .tagGroup(title, tags, symbolName):
       var nestedContainer = container.nestedUnkeyedContainer(forKey: .tagGroup)
       try nestedContainer.encode(title)
       try nestedContainer.encode(tags)
+      try nestedContainer.encode(symbolName)
     case let .list(list):
       try container.encode(list, forKey: .list)
     case let .remoteLocal(server, filter):

--- a/Packages/Timeline/Sources/Timeline/TimelineFilter.swift
+++ b/Packages/Timeline/Sources/Timeline/TimelineFilter.swift
@@ -33,7 +33,7 @@ public enum TimelineFilter: Hashable, Equatable, Identifiable {
   
   case home, local, federated, trending
   case hashtag(tag: String, accountId: String?)
-  case tagGroup(title: String, tags: [String], symbolName: String)
+  case tagGroup(title: String, tags: [String], symbolName: String?)
   case list(list: Models.List)
   case remoteLocal(server: String, filter: RemoteTimelineFilter)
   case latest
@@ -134,7 +134,7 @@ public enum TimelineFilter: Hashable, Equatable, Identifiable {
     case .remoteLocal:
       "dot.radiowaves.right"
     case let .tagGroup(_, _, symbolName):
-        symbolName
+        symbolName ?? "tag"
     case .hashtag:
       "number"
     }
@@ -214,7 +214,7 @@ extension TimelineFilter: Codable {
       var nestedContainer = try container.nestedUnkeyedContainer(forKey: .tagGroup)
       let title = try nestedContainer.decode(String.self)
       let tags = try nestedContainer.decode([String].self)
-      let symbolName = try nestedContainer.decode(String.self)
+      let symbolName = try? nestedContainer.decode(String.self)
       self = .tagGroup(
         title: title,
         tags: tags,
@@ -265,7 +265,7 @@ extension TimelineFilter: Codable {
       var nestedContainer = container.nestedUnkeyedContainer(forKey: .tagGroup)
       try nestedContainer.encode(title)
       try nestedContainer.encode(tags)
-      try nestedContainer.encode(symbolName)
+      try? nestedContainer.encode(symbolName)
     case let .list(list):
       try container.encode(list, forKey: .list)
     case let .remoteLocal(server, filter):

--- a/Packages/Timeline/Sources/Timeline/View/TimelineTagGroupheaderView.swift
+++ b/Packages/Timeline/Sources/Timeline/View/TimelineTagGroupheaderView.swift
@@ -28,7 +28,7 @@ struct TimelineTagGroupheaderView: View {
           .scrollIndicators(.hidden)
           Button("status.action.edit") {
             routerPath.presentedSheet = .editTagGroup(tagGroup: group, onSaved: { group in
-              timeline = .tagGroup(title: group.title, tags: group.tags)
+              timeline = .tagGroup(title: group.title, tags: group.tags, symbolName: group.symbolName)
             })
           }
           .buttonStyle(.bordered)


### PR DESCRIPTION
I love the new timeline quick access feature and use it all the time.
Until now, tagGroups used a generic tag symbol, even though they have their own symbol. 
Before: 
<img src='https://github.com/Dimillian/IceCubesApp/assets/39119695/658fe746-f8d0-492d-81b4-afa778f94847' width='200'>

After:
<img src='https://github.com/Dimillian/IceCubesApp/assets/39119695/cfd089d4-aaff-43f6-9b84-d4c4a93a7813' width='200'>

What do you think? 