### PR TITLE
Replace profile navigation bar back button

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -12,6 +12,7 @@ public struct AccountDetailView: View {
   @Environment(\.openURL) private var openURL
   @Environment(\.redactionReasons) private var reasons
   @Environment(\.openWindow) private var openWindow
+    @Environment(\.dismiss) var dismiss
 
   @Environment(StreamWatcher.self) private var watcher
   @Environment(CurrentAccount.self) private var currentAccount
@@ -157,6 +158,7 @@ public struct AccountDetailView: View {
     })
     .edgesIgnoringSafeArea(.top)
     .navigationBarTitleDisplayMode(.inline)
+    .navigationBarBackButtonHidden(true)
     .toolbar {
       toolbarContent
     }
@@ -316,6 +318,20 @@ public struct AccountDetailView: View {
 
   @ToolbarContentBuilder
   private var toolbarContent: some ToolbarContent {
+      if !viewModel.isCurrentUser {
+          ToolbarItem(placement: .topBarLeading) {
+              Button(action: {
+                  dismiss()
+              }) {
+                  HStack {
+                      Image(systemName: "chevron.left")
+                          .bold()
+                      Text("Back")
+                  }
+              }
+          }
+      }
+      
     ToolbarItem(placement: .principal) {
       if let account = viewModel.account, displayTitle {
         VStack {


### PR DESCRIPTION
How do you feel about a consistent back button on the profile?

Before:
![RocketSim_Screenshot_iPhone_15_6 1_2024-01-08_07 06 49](https://github.com/Dimillian/IceCubesApp/assets/15333030/be5f9e95-d906-4102-8ade-1ae9df8fc6b5)

After:
![RocketSim_Screenshot_iPhone_15_6 1_2024-01-08_07 11 01](https://github.com/Dimillian/IceCubesApp/assets/15333030/3eb02783-e39b-404d-a155-0afbf38a184a)
