### PR TITLE
Resolve #359 Optional Missing Alt-Text warning

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/ContentSettingsView.swift
@@ -59,6 +59,7 @@ struct ContentSettingsView: View {
           userPreferences.appAutoExpandMedia = userPreferences.autoExpandMedia
           userPreferences.appDefaultPostsSensitive = userPreferences.postIsSensitive
           userPreferences.appDefaultPostVisibility = userPreferences.postVisibility
+          userPreferences.appRequireAltText = userPreferences.appRequireAltText
         }
       }
 
@@ -112,6 +113,10 @@ struct ContentSettingsView: View {
           Text("settings.content.default-sensitive")
         }
         .disabled(userPreferences.useInstanceContentSettings)
+          
+        Toggle(isOn: $userPreferences.appRequireAltText) {
+          Text("settings.content.require-alt-text")
+        }
       }
       #if !os(visionOS)
       .listRowBackground(theme.primaryBackgroundColor)

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -41563,7 +41563,115 @@
     },
     "settings.content.require-alt-text" : {
       "localizations" : {
+        "be" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "eu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Require Alt Text to Post"
@@ -66068,7 +66176,115 @@
     "status.error.no-alt-text" : {
       "extractionState" : "manual",
       "localizations" : {
+        "be" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "eu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Your settings require alt text on all media before posting"

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -41561,6 +41561,16 @@
         }
       }
     },
+    "settings.content.require-alt-text" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Require Alt Text to Post"
+          }
+        }
+      }
+    },
     "settings.content.sharing" : {
       "localizations" : {
         "be" : {
@@ -66051,6 +66061,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "嘟文上下文發生錯誤，請再試一次。"
+          }
+        }
+      }
+    },
+    "status.error.no-alt-text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your settings require alt text on all media before posting"
           }
         }
       }

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -22,6 +22,7 @@ import SwiftUI
     @AppStorage("app_default_post_visibility") public var appDefaultPostVisibility: Models.Visibility = .pub
     @AppStorage("app_default_reply_visibility") public var appDefaultReplyVisibility: Models.Visibility = .pub
     @AppStorage("app_default_posts_sensitive") public var appDefaultPostsSensitive = false
+    @AppStorage("app_require_alt_text") public var appRequireAltText = false
     @AppStorage("autoplay_video") public var autoPlayVideo = true
     @AppStorage("mute_video") public var muteVideo = true
     @AppStorage("always_use_deepl") public var alwaysUseDeepl = false
@@ -161,6 +162,12 @@ import SwiftUI
   public var appDefaultPostsSensitive: Bool {
     didSet {
       storage.appDefaultPostsSensitive = appDefaultPostsSensitive
+    }
+  }
+    
+  public var appRequireAltText: Bool {
+    didSet {
+      storage.appRequireAltText = appRequireAltText
     }
   }
 
@@ -466,6 +473,7 @@ import SwiftUI
     appDefaultPostVisibility = storage.appDefaultPostVisibility
     appDefaultReplyVisibility = storage.appDefaultReplyVisibility
     appDefaultPostsSensitive = storage.appDefaultPostsSensitive
+    appRequireAltText = storage.appRequireAltText
     autoPlayVideo = storage.autoPlayVideo
     alwaysUseDeepl = storage.alwaysUseDeepl
     userDeeplAPIFree = storage.userDeeplAPIFree

--- a/Packages/Models/Sources/Models/PostError.swift
+++ b/Packages/Models/Sources/Models/PostError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum PostError: Error {
+    // Throw when any attached media is missing media description (alt text)
+    case missingAltText
+}
+
+extension PostError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .missingAltText:
+            return NSLocalizedString("status.error.no-alt-text", comment: "media does not have media description")
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/Dimillian/IceCubesApp/issues/359

- Add toggle in settings to require alt text (default off)
- If setting is enabled, posting show an error if any attached media is missing alt text

Design decisions:
- Chose to surface an error instead of disabling posting, to make it obvious why the post is failing. A tooltip goes against current design decisions and isn't clear on all platforms.
- The setting is default off to minimise impact to existing users.

<img width="288" alt="Setting in content settings" src="https://github.com/Dimillian/IceCubesApp/assets/4389995/8789e694-db5f-4f39-8359-82d976d53d4d">

Toggle setting in content settings

<img width="163" alt="Error displayed to user if attempting to post without all the necessary alt text" src="https://github.com/Dimillian/IceCubesApp/assets/4389995/16865c37-d447-41c1-9da6-334041acb82c">

Error displayed to user if attempting to post without all the necessary alt text (if setting is toggled on)

Tested on:
- iPadOS Simulator with photos and videos