### PR TITLE
Hide context indicator for statuses inside `StatusDetailView`

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Detail/StatusDetailView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Detail/StatusDetailView.swift
@@ -123,7 +123,7 @@ public struct StatusDetailView: View {
                                                 scrollToId: $viewModel.scrollToId)
       let isFocused = self.viewModel.statusId == status.id
 
-      StatusRowView(viewModel: viewModel)
+      StatusRowView(viewModel: viewModel, context: .detail)
         .id(status.id + (status.editedAt?.asDate.description ?? ""))
         .environment(\.extraLeadingInset, !isCompact ? extraInsets : 0)
         .environment(\.indentationLevel, !isCompact ? indentationLevel : 0)

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -23,8 +23,12 @@ public struct StatusRowView: View {
   @State private var viewModel: StatusRowViewModel
   @State private var showSelectableText: Bool = false
 
-  public init(viewModel: StatusRowViewModel) {
-    _viewModel = .init(initialValue: viewModel)
+  public enum Context { case timeline, detail }
+  private let context: Context
+
+  public init(viewModel: StatusRowViewModel, context: Context = .timeline) {
+    self._viewModel = .init(initialValue: viewModel)
+    self.context = context
   }
 
   var contextMenu: some View {
@@ -56,7 +60,7 @@ public struct StatusRowView: View {
             EmptyView()
           }
         } else {
-          if !isCompact {
+          if !isCompact && context != .detail {
             Group {
               StatusRowTagView(viewModel: viewModel)
               StatusRowReblogView(viewModel: viewModel)


### PR DESCRIPTION
The context within the `StatusDetailView` is obvious. So I've removed the indicators.

![image](https://github.com/Dimillian/IceCubesApp/assets/46838577/499c2335-86c8-4f9b-b32d-ce2164f498ce)
