### PR TITLE
Fix `StatusRowCardView` layout.

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
@@ -64,9 +64,9 @@ public struct StatusRowCardView: View {
         #else
         .background(theme.secondaryBackgroundColor)
         #endif
-        .cornerRadius(16)
+        .cornerRadius(10)
         .overlay(
-          RoundedRectangle(cornerRadius: 16)
+          RoundedRectangle(cornerRadius: 10)
             .stroke(.gray.opacity(0.35), lineWidth: 1)
         )
         .contextMenu {
@@ -113,13 +113,13 @@ public struct StatusRowCardView: View {
       .accessibilityHidden(true)
       .frame(height: imageHeight)
     }
-    VStack(alignment: .leading, spacing: 6) {
+    VStack(alignment: .leading, spacing: 4) {
       Text(title)
         .font(.scaledHeadline)
-        .lineLimit(3)
+        .lineLimit(1)
       if let description = card.description, !description.isEmpty {
         Text(description)
-          .font(.scaledBody)
+          .font(.scaledFootnote)
           .foregroundStyle(.secondary)
           .lineLimit(3)
       }
@@ -129,7 +129,8 @@ public struct StatusRowCardView: View {
         .lineLimit(1)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(16)
+    .padding(.horizontal, 10)
+    .padding(.bottom, 10)
   }
 
   private func iconLinkPreview(_ title: String, _ url: URL) -> some View {


### PR DESCRIPTION
I've fixed the layout to make it more tidy, balanced and consistent:
- make the description font equal to the URL font
- use conventional numbers of avatar's configs for padding and corner radius
- set the title's line limit to 1

![image](https://github.com/Dimillian/IceCubesApp/assets/46838577/ec673b0b-9420-43dd-9738-5e443b3ca4e3)


