### PR TITLE
Fix #1885 blank options on profile page on macos

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
+++ b/Packages/Account/Sources/Account/AccountDetailContextMenu.swift
@@ -28,7 +28,9 @@ public struct AccountDetailContextMenu: View {
             Label("account.action.message", systemImage: "tray.full")
           }
 
-          Divider()
+            #if !targetEnvironment(macCatalyst)
+            Divider()
+            #endif
 
           if viewModel.relationship?.blocking == true {
             Button {
@@ -143,7 +145,9 @@ public struct AccountDetailContextMenu: View {
             }
           }
 
-          Divider()
+            #if !targetEnvironment(macCatalyst)
+            Divider()
+            #endif
         }
 
         if let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier {
@@ -173,7 +177,9 @@ public struct AccountDetailContextMenu: View {
           }
         }
 
+        #if !targetEnvironment(macCatalyst)
         Divider()
+        #endif
       }
     }
   }


### PR DESCRIPTION
### Environment:

- OS: macOS 14.2.1
- IceCubesApp version: 1.10.21
- issue #1885

### Issue:
This pull request addresses problem #1885. In the `AccountDetailView`, when a user taps on the profile options button, a menu is displayed. However, on the macCatalyst app, blank rows are observed for certain options.

### Causes:
The issue of blank rows arises when attempting to utilize a `Divider` within the `Menu` list, specifically when it is nested inside a `Section`. The root cause may be related to the implementation of SwiftUI views.
```swift
Menu {
    Section {
        Button("Option 1") { }
        Divider()
        Button("Option 2") { }
    }
}
```

### Solution:
To resolve this issue, I introduced a conditional compilation block that ensures the compilation of the `Divider` function only occurs when the current operating system is not macOS.

| Before           | After  |
|:-------------:| -----:|
| ![1](https://github.com/Dimillian/IceCubesApp/assets/23383207/793cc170-939d-463a-a8ac-fbb4c1419d6b) | <img width="365" alt="2" src="https://github.com/Dimillian/IceCubesApp/assets/23383207/19816558-595f-429a-95c9-645609dba2bc"> |

