### PR TITLE
Use default frame for preview image that API returns incorrect size (width: 0, height: 0)

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
@@ -197,9 +197,7 @@ struct DefaultPreviewImage: View {
     }
 
     private func calculateSize(_ proposal: ProposedViewSize) -> CGSize {
-      guard originalWidth > 0 else { return CGSize.zero }
-
-      return switch (proposal.width, proposal.height) {
+      switch (proposal.width, proposal.height) {
       case (nil, nil):
         CGSize(width: originalWidth, height: originalWidth)
       case let (nil, .some(height)):
@@ -207,7 +205,11 @@ struct DefaultPreviewImage: View {
       case (0, _):
         CGSize.zero
       case let (.some(width), _):
-        CGSize(width: width, height: width / originalWidth * originalHeight)
+        if originalWidth == 0 {
+          CGSize(width: width, height: width / 2)
+        } else {
+          CGSize(width: width, height: width / originalWidth * originalHeight)
+        }
       }
     }
   }


### PR DESCRIPTION
When investigating the crash problem at #1913 I discovered a problem at this [post](https://mastodon.social/@mkreutzfeldt/111795583554357452). The card has an image URL but an incorrect size `(width: 0, height: 0)` that makes the image hidden. I am not sure if it relates to #1913 or not. But in all the “no image” preview cards I tried, this post is the only one that has an image (and with incorrect size `(0, 0)`), all others truly have no image.