### PR TITLE
Limit height of images in previews to screen height

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
@@ -225,13 +225,14 @@ public struct StatusRowCardView: View {
 
 struct DefaultPreviewImage: View {
   @Environment(Theme.self) private var theme
+  @Environment(SceneDelegate.self) private var sceneDelegate
   
   let url: URL
   let originalWidth: CGFloat
   let originalHeight: CGFloat
 
   var body: some View {
-    _Layout(originalWidth: originalWidth, originalHeight: originalHeight) {
+    _Layout(originalWidth: originalWidth, originalHeight: min(originalHeight, sceneDelegate.windowHeight * 0.6)) {
       LazyResizableImage(url: url) { state, _ in
         Rectangle()
           .fill(theme.secondaryBackgroundColor)


### PR DESCRIPTION
limit available height to 60% of screen/window height so that the entire card would approximately fit

basically https://github.com/Dimillian/IceCubesApp/pull/1675, but for link previews instead of plain images.