### PR TITLE
Handle edge cases for `StatusRowCardView`

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
@@ -234,13 +234,11 @@ struct DefaultPreviewImage: View {
   var body: some View {
     _Layout(originalWidth: originalWidth, originalHeight: originalHeight) {
       LazyResizableImage(url: url) { state, _ in
-        Rectangle()
-          .fill(theme.secondaryBackgroundColor)
-          .overlay {
-            if let image = state.image {
-              image.resizable().scaledToFill()
-            }
-          }
+        if let image = state.image?.resizable() {
+          Rectangle().fill(theme.secondaryBackgroundColor)
+            .overlay { image.scaledToFill().blur(radius: 50) }
+            .overlay { image.scaledToFit() }
+        }
       }
       .accessibilityHidden(true) // This image is decorative
       .clipped()
@@ -264,7 +262,7 @@ struct DefaultPreviewImage: View {
     }
 
     private func calculateSize(_ proposal: ProposedViewSize) -> CGSize {
-      switch (proposal.width, proposal.height) {
+      var size = switch (proposal.width, proposal.height) {
       case (nil, nil):
         CGSize(width: originalWidth, height: originalWidth)
       case let (nil, .some(height)):
@@ -278,6 +276,9 @@ struct DefaultPreviewImage: View {
           CGSize(width: width, height: width / originalWidth * originalHeight)
         }
       }
+
+      size.height = min(size.height, 450)
+      return size
     }
   }
 }


### PR DESCRIPTION
### Problem

I am trying to solve the problem at #1967. I don't limit the preview image height in the first place (#1904) because I don't know how to handle its display. Two critical aspects of `StatusRowCardView` are __card layout__ and __preview content.__

- Fill Image: keep the card layout but cut off the content
- Fit Image: keep the content but break the card layout with two dangling spaces (left/right)

### Solution

1. Using a Fit Image to keep the content of __intentionally well-designed__ preview images
2. Use a blurred Fill Image in the background to:
    - keep the card layout
    - give spaces nuance colors to keep the card display __coherent__
3. max height is `450` (same as media max height)

_(high resolution image, you should zoom in to see the details)_
![image](https://github.com/Dimillian/IceCubesApp/assets/46838577/df7f9fdd-567a-432b-83a3-d82ad60544be)