### PR TITLE
Cancel header edit #1956

### DIFF
--- a/Packages/Account/Sources/Account/Edit/EditAccountView.swift
+++ b/Packages/Account/Sources/Account/Edit/EditAccountView.swift
@@ -104,16 +104,14 @@ public struct EditAccountView: View {
             if let previewAvatarData = viewModel.temporaryAvatarData {
               if let uiImage = UIImage(data: previewAvatarData) {
                 let config = AvatarView.FrameConfig.account
-                // Corner radius taken from AvatarView.FrameConfig.account, and
-                // put here because can't have internal access.
-                // Image instead of LazyImage with resize processor, because don't have URL.
+                // Image from data because don't have URL.
                 Image(uiImage: uiImage)
                   .resizable()
                   .aspectRatio(contentMode: .fill)
                   .frame(width: config.width, height: config.height)
-                  .clipShape(RoundedRectangle(cornerRadius: config.width/2))
+                  .clipShape(RoundedRectangle(cornerRadius: config.width / 2))
                   .overlay(
-                    RoundedRectangle(cornerRadius: config.width/2)
+                    RoundedRectangle(cornerRadius: config.width / 2)
                       .stroke(.primary.opacity(0.25), lineWidth: 1)
                   )
               }

--- a/Packages/Account/Sources/Account/Edit/EditAccountView.swift
+++ b/Packages/Account/Sources/Account/Edit/EditAccountView.swift
@@ -101,7 +101,25 @@ public struct EditAccountView: View {
         }
         if let avatar = viewModel.avatar {
           ZStack(alignment: .bottomLeading) {
-            AvatarView(avatar, config: .account)
+            if let previewAvatarData = viewModel.temporaryAvatarData {
+              if let uiImage = UIImage(data: previewAvatarData) {
+                let config = AvatarView.FrameConfig.account
+                // Corner radius taken from AvatarView.FrameConfig.account, and
+                // put here because can't have internal access.
+                // Image instead of LazyImage with resize processor, because don't have URL.
+                Image(uiImage: uiImage)
+                  .resizable()
+                  .aspectRatio(contentMode: .fill)
+                  .frame(width: config.width, height: config.height)
+                  .clipShape(RoundedRectangle(cornerRadius: config.width/2))
+                  .overlay(
+                    RoundedRectangle(cornerRadius: config.width/2)
+                      .stroke(.primary.opacity(0.25), lineWidth: 1)
+                  )
+              }
+            } else {
+              AvatarView(avatar, config: .account)
+            }
             Menu {
               Button("account.edit.avatar") {
                 viewModel.isChangingAvatar = true

--- a/Packages/Account/Sources/Account/Edit/EditAccountView.swift
+++ b/Packages/Account/Sources/Account/Edit/EditAccountView.swift
@@ -79,9 +79,6 @@ public struct EditAccountView: View {
                   .clipShape(RoundedRectangle(cornerRadius: 8))
                   .clipped()
                   .frame(height: 150)
-                  .onAppear() {
-                      print("Showing preview")
-                  }
               }
             } else {
               LazyImage(url: header) { state in
@@ -141,11 +138,6 @@ public struct EditAccountView: View {
                   maxSelectionCount: 1,
                   matching: .any(of: [.images]),
                   photoLibrary: .shared())
-    .onAppear() {
-        if let header = viewModel.header {
-            print("Header URL is: \(header)")
-        }
-    }
   }
 
   @ViewBuilder

--- a/Packages/Account/Sources/Account/Edit/EditAccountView.swift
+++ b/Packages/Account/Sources/Account/Edit/EditAccountView.swift
@@ -70,21 +70,36 @@ public struct EditAccountView: View {
       ZStack(alignment: .center) {
         if let header = viewModel.header {
           ZStack(alignment: .topLeading) {
-            LazyImage(url: header) { state in
-              if let image = state.image {
-                image
+            if let previewHeaderData = viewModel.temporaryHeaderData {
+              if let uiImage = UIImage(data: previewHeaderData) {
+                Image(uiImage: uiImage)
                   .resizable()
                   .aspectRatio(contentMode: .fill)
                   .frame(height: 150)
                   .clipShape(RoundedRectangle(cornerRadius: 8))
                   .clipped()
-              } else {
-                RoundedRectangle(cornerRadius: 8)
-                  .foregroundStyle(theme.primaryBackgroundColor)
                   .frame(height: 150)
+                  .onAppear() {
+                      print("Showing preview")
+                  }
               }
+            } else {
+              LazyImage(url: header) { state in
+                if let image = state.image {
+                  image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 150)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .clipped()
+                } else {
+                  RoundedRectangle(cornerRadius: 8)
+                    .foregroundStyle(theme.primaryBackgroundColor)
+                    .frame(height: 150)
+                }
+              }
+              .frame(height: 150)
             }
-            .frame(height: 150)
           }
         }
         if let avatar = viewModel.avatar {
@@ -126,6 +141,11 @@ public struct EditAccountView: View {
                   maxSelectionCount: 1,
                   matching: .any(of: [.images]),
                   photoLibrary: .shared())
+    .onAppear() {
+        if let header = viewModel.header {
+            print("Header URL is: \(header)")
+        }
+    }
   }
 
   @ViewBuilder

--- a/Packages/Account/Sources/Account/Edit/EditAccountViewModel.swift
+++ b/Packages/Account/Sources/Account/Edit/EditAccountViewModel.swift
@@ -42,6 +42,11 @@ import SwiftUI
 
   var isChangingAvatar: Bool = false
   var isChangingHeader: Bool = false
+    
+  // New images picked.
+  // Store until profile saved.
+  var temporaryAvatarData: Data?
+  var temporaryHeaderData: Data?
 
   var isLoading: Bool = true
   var isSaving: Bool = false
@@ -53,11 +58,12 @@ import SwiftUI
         Task {
           if let data = await getItemImageData(item: item) {
             if isChangingAvatar {
-              _ = await uploadAvatar(data: data)
+              temporaryAvatarData = data
+              print("New avatar temporary save")
             } else if isChangingHeader {
-              _ = await uploadHeader(data: data)
+              temporaryHeaderData = data
+              print("New header temporary save")
             }
-            await fetchAccount()
             isChangingAvatar = false
             isChangingHeader = false
             mediaPickers = []
@@ -92,6 +98,22 @@ import SwiftUI
   func save() async {
     isSaving = true
     do {
+      // Upload new images
+      if let temporaryAvatarData {
+        _ = await uploadAvatar(data: temporaryAvatarData)
+        print("Uploading avatar")
+      }
+      if let temporaryHeaderData {
+         _ = await uploadHeader(data: temporaryHeaderData)
+        print("Uploading header")
+      }
+      // Clear preview data
+      temporaryAvatarData = nil
+      temporaryHeaderData = nil
+      print("cleared temporary avatar and header")
+      // Fetch account to set header and avatar
+      await fetchAccount()
+        
       let data = UpdateCredentialsData(displayName: displayName,
                                        note: note,
                                        source: .init(privacy: postPrivacy, sensitive: isSensitive),

--- a/Packages/Account/Sources/Account/Edit/EditAccountViewModel.swift
+++ b/Packages/Account/Sources/Account/Edit/EditAccountViewModel.swift
@@ -103,7 +103,7 @@ import SwiftUI
       if let temporaryHeaderData {
          _ = await uploadHeader(data: temporaryHeaderData)
       }
-      // Clear preview data
+      // Clear preview data to show fetched avatar and header
       temporaryAvatarData = nil
       temporaryHeaderData = nil
       // Fetch account to set header and avatar

--- a/Packages/Account/Sources/Account/Edit/EditAccountViewModel.swift
+++ b/Packages/Account/Sources/Account/Edit/EditAccountViewModel.swift
@@ -59,10 +59,8 @@ import SwiftUI
           if let data = await getItemImageData(item: item) {
             if isChangingAvatar {
               temporaryAvatarData = data
-              print("New avatar temporary save")
             } else if isChangingHeader {
               temporaryHeaderData = data
-              print("New header temporary save")
             }
             isChangingAvatar = false
             isChangingHeader = false
@@ -101,16 +99,13 @@ import SwiftUI
       // Upload new images
       if let temporaryAvatarData {
         _ = await uploadAvatar(data: temporaryAvatarData)
-        print("Uploading avatar")
       }
       if let temporaryHeaderData {
          _ = await uploadHeader(data: temporaryHeaderData)
-        print("Uploading header")
       }
       // Clear preview data
       temporaryAvatarData = nil
       temporaryHeaderData = nil
-      print("cleared temporary avatar and header")
       // Fetch account to set header and avatar
       await fetchAccount()
         


### PR DESCRIPTION
### Environment:
- OS: iOS 17.3.1
- IceCubesApp version: 1.10.33
- Issue #1956 

### Issue:
https://github.com/Dimillian/IceCubesApp/issues/1956 When editing a profile, the header and avatar are updated to whatever a user picks even when they cancel.

### Causes:
Both header and avatar are immediately uploaded to the user's account the moment they pick an image.

### Solution:
We can instead display a picked image temporarily, like a preview. The image is only uploaded once we save the profile. 

The change'll look like this:

https://github.com/Dimillian/IceCubesApp/assets/52055110/bb227e09-c1ad-4899-b8a4-123954fdd8da

