### PR TITLE
Swipe actions overlapped with images #1845

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -67,7 +67,11 @@ public struct StatusRowMediaPreviewView: View {
           }
           .padding(.bottom, scrollBottomPadding)
         }
-        .scrollClipDisabled()
+        // This replaces scrollClipDisabled, which would overlay
+        // images over swipe actions.
+        // See https://github.com/Dimillian/IceCubesApp/issues/1845
+        .padding(.horizontal, .layoutPadding * -1)
+        .contentMargins(.horizontal, .layoutPadding)
       }
     }
   }


### PR DESCRIPTION
### Environment:
- OS: iOS 17.3.1
- IceCubesApp version: 1.10.33
- Issue #1845

### Issue:
https://github.com/Dimillian/IceCubesApp/issues/1845 Multiple images overlap left swipe actions.

### Causes:
In `StatusRowMediaViewPreview`, the [`scrollClipDisabled()`](https://www.hackingwithswift.com/quick-start/swiftui/how-to-disable-scrollview-clipping-so-contents-overflow) modifier allows multiple images to overflow outside the scrolling area. However from my understanding it was designed to flow on top of other content.

### Solution:
Replace `scrollClipDisabled()` with negative horizontal padding, and the same amount of content margin. That way we have the same visual effect as before, but there's no overlap problem.

Tested on iPhone and iPad 17.0

Demo video:

https://github.com/Dimillian/IceCubesApp/assets/52055110/97f5bbe6-9281-4af7-9952-e03f7cfcdab0

