### PR TITLE
Added a "Moved To" Button to accounts that moved to other instances

### DIFF
--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -17067,6 +17067,23 @@
         }
       }
     },
+    "account.movedto.redirect-%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umgezogen nach %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moved To %@"
+          }
+        }
+      }
+    },
     "account.post.pinned" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -207,6 +207,7 @@ struct AccountDetailHeaderView: View {
             .foregroundStyle(.secondary)
             .textSelection(.enabled)
             .accessibilityRespondsToUserInteraction(false)
+          movedToView
           joinedAtView
         }
         .accessibilityElement(children: .contain)
@@ -311,6 +312,17 @@ struct AccountDetailHeaderView: View {
     }
   }
 
+  @ViewBuilder
+  private var movedToView: some View {
+    if let movedTo = viewModel.account?.moved {
+      Button("account.movedto.redirect-\("@\(movedTo.acct)")") {
+        routerPath.navigate(to: .accountDetailWithAccount(account: movedTo))
+      }
+      .font(.scaledCallout)
+      .foregroundColor(.accentColor)
+    }
+  }
+  
   @ViewBuilder
   private func makeNoteView(_ note: String) -> some View {
     VStack(alignment: .leading, spacing: 4) {

--- a/Packages/Models/Sources/Models/Account.swift
+++ b/Packages/Models/Sources/Models/Account.swift
@@ -61,6 +61,7 @@ public final class Account: Codable, Identifiable, Hashable, Sendable, Equatable
   public let source: Source?
   public let bot: Bool
   public let discoverable: Bool?
+  public let moved: Account?
 
   public var haveAvatar: Bool {
     avatar.lastPathComponent != "missing.png"
@@ -70,7 +71,7 @@ public final class Account: Codable, Identifiable, Hashable, Sendable, Equatable
     header.lastPathComponent != "missing.png"
   }
 
-  public init(id: String, username: String, displayName: String?, avatar: URL, header: URL, acct: String, note: HTMLString, createdAt: ServerDate, followersCount: Int, followingCount: Int, statusesCount: Int, lastStatusAt: String? = nil, fields: [Account.Field], locked: Bool, emojis: [Emoji], url: URL? = nil, source: Account.Source? = nil, bot: Bool, discoverable: Bool? = nil) {
+  public init(id: String, username: String, displayName: String?, avatar: URL, header: URL, acct: String, note: HTMLString, createdAt: ServerDate, followersCount: Int, followingCount: Int, statusesCount: Int, lastStatusAt: String? = nil, fields: [Account.Field], locked: Bool, emojis: [Emoji], url: URL? = nil, source: Account.Source? = nil, bot: Bool, discoverable: Bool? = nil, moved: Account? = nil) {
     self.id = id
     self.username = username
     self.displayName = displayName
@@ -90,6 +91,7 @@ public final class Account: Codable, Identifiable, Hashable, Sendable, Equatable
     self.source = source
     self.bot = bot
     self.discoverable = discoverable
+    self.moved = moved
 
     if let displayName, !displayName.isEmpty {
       cachedDisplayName = .init(stringValue: displayName)
@@ -118,6 +120,7 @@ public final class Account: Codable, Identifiable, Hashable, Sendable, Equatable
     case source
     case bot
     case discoverable
+    case moved
   }
 
   public init(from decoder: Decoder) throws {
@@ -141,6 +144,8 @@ public final class Account: Codable, Identifiable, Hashable, Sendable, Equatable
     source = try container.decodeIfPresent(Account.Source.self, forKey: .source)
     bot = try container.decode(Bool.self, forKey: .bot)
     discoverable = try container.decodeIfPresent(Bool.self, forKey: .discoverable)
+    moved = try container.decodeIfPresent(Account.self, forKey: .moved)
+      
     if let displayName, !displayName.isEmpty {
       cachedDisplayName = .init(stringValue: displayName)
     } else {


### PR DESCRIPTION
It's close to impossible to see when a user moved to a different instance.

I added a button that allows the user to navigate to the new profile.

If this can be merged then I'd love to change the "Follow" button to "New Profile" so the user doesn't try to follow a closed account (which doesn't work anyways)

![image](https://github.com/Dimillian/IceCubesApp/assets/33906/766dd7b2-02cc-437d-98e4-224386e8d110)
