### PR TITLE
Fix StatusRowContentView invade SwipeActions area

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -83,33 +83,33 @@ public struct StatusRowView: View {
                   viewModel.navigateToAccountDetail(account: viewModel.finalStatus.account)
                 }
             }
-            VStack(alignment: .leading, spacing: .statusComponentSpacing) {
-              if !isCompact {
-                StatusRowHeaderView(viewModel: viewModel)
+            if !isCompact {
+              StatusRowHeaderView(viewModel: viewModel)
+            }
+          }
+          VStack(alignment: .leading, spacing: .statusComponentSpacing) {
+            StatusRowContentView(viewModel: viewModel)
+              .contentShape(Rectangle())
+              .onTapGesture {
+                guard !isFocused else { return }
+                viewModel.navigateToDetail()
               }
-              StatusRowContentView(viewModel: viewModel)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                  guard !isFocused else { return }
-                  viewModel.navigateToDetail()
+              .accessibilityActions {
+                if isFocused, viewModel.showActions {
+                  accessibilityActions
                 }
-                .accessibilityActions {
-                  if isFocused, viewModel.showActions {
-                    accessibilityActions
-                  }
-                }
-              if !reasons.contains(.placeholder),
-                 viewModel.showActions, isFocused || theme.statusActionsDisplay != .none,
-                 !isInCaptureMode
-              {
-                StatusRowActionsView(isBlockConfirmationPresented: $isBlockConfirmationPresented,
-                                     viewModel: viewModel)
-                  .tint(isFocused ? theme.tintColor : .gray)
               }
+            if !reasons.contains(.placeholder),
+               viewModel.showActions, isFocused || theme.statusActionsDisplay != .none,
+               !isInCaptureMode
+            {
+              StatusRowActionsView(isBlockConfirmationPresented: $isBlockConfirmationPresented,
+                                   viewModel: viewModel)
+                .tint(isFocused ? theme.tintColor : .gray)
+            }
 
-              if isFocused, !isCompact {
-                StatusRowDetailView(viewModel: viewModel)
-              }
+            if isFocused, !isCompact {
+              StatusRowDetailView(viewModel: viewModel)
             }
           }
         }

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -54,6 +54,7 @@ public struct StatusRowMediaPreviewView: View {
             : CGSize(width: imageMaxHeight, height: imageMaxHeight),
           sensitive: sensitive
         )
+        .padding(.horizontal, .layoutPadding)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Self.accessibilityLabel(for: attachments[0]))
         .accessibilityAddTraits([.isButton, .isImage])
@@ -66,9 +67,11 @@ public struct StatusRowMediaPreviewView: View {
             }
           }
           .padding(.bottom, scrollBottomPadding)
+          .padding(.horizontal, .layoutPadding)
         }
       }
     }
+    .padding(.horizontal, -1 * .layoutPadding)
   }
 
   @ViewBuilder

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -67,7 +67,6 @@ public struct StatusRowMediaPreviewView: View {
           }
           .padding(.bottom, scrollBottomPadding)
         }
-        .scrollClipDisabled()
       }
     }
   }


### PR DESCRIPTION
Fix issue that StatusRowContentView invade SwipeActions area
Issue Bug: Swipe actions are overlapped with images  #1845

before:

https://github.com/Dimillian/IceCubesApp/assets/52348220/45702f05-b831-4274-a181-fa9ad178376c

after:


https://github.com/Dimillian/IceCubesApp/assets/52348220/38eb9ac3-eaf3-409c-9b44-968163daf28a



