### PR TITLE
Improve deep link handling on cold start

### DIFF
--- a/IceCubesApp/App/SafariRouter.swift
+++ b/IceCubesApp/App/SafariRouter.swift
@@ -31,7 +31,7 @@ private struct SafariRouter: ViewModifier {
         // Open external URL (from icecubesapp://)
         let urlString = url.absoluteString.replacingOccurrences(of: AppInfo.scheme, with: "https://")
         guard let url = URL(string: urlString), url.host != nil else { return }
-        _ = routerPath.handle(url: url)
+        _ = routerPath.handleDeepLink(url: url)
       }
       .onAppear {
         routerPath.urlHandler = { url in


### PR DESCRIPTION
Previously, if the app was not already running when the Safari action extension was used to open a post in the app, the post would open in the in-app Safari instead of using the Ice Cubes UI. 
The action extension only worked well if Ice Cubes was already running but backgrounded when it was used. 
This was because of the `hasConnection(with:)` check used to ensure that the current server has a federation relationship with the server the post is on. 
Early in app launch, the list of federated peers has not come back from the API request yet, so `hasConnection(with:)` was always returning `false`.

To fix, issue a request to fetch the peers as part of the URL handling process, before checking `hasConnection(with:)` to make the final navigation decision. 
As an optimization, only do this if `hasConnection(with:)` returns `false` initially -- if it returns `true`, we already know a connection exists so no need to check again.