### PR TITLE
Fix scrolling issue on emoji picker

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Editor/Components/CustomEmojisView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Editor/Components/CustomEmojisView.swift
@@ -8,16 +8,16 @@ extension StatusEditor {
   @MainActor
   struct CustomEmojisView: View {
     @Environment(\.dismiss) private var dismiss
-
+    
     @Environment(Theme.self) private var theme
-
+    
     var viewModel: ViewModel
-
+    
     var body: some View {
       NavigationStack {
         ScrollView {
-          ForEach(viewModel.customEmojiContainer) { container in
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 40, maximum: 40))], spacing: 9) {
+          LazyVGrid(columns: [GridItem(.adaptive(minimum: 40, maximum: 40))], spacing: 9) {
+            ForEach(viewModel.customEmojiContainer) { container in
               Section {
                 ForEach(container.emojis) { emoji in
                   LazyImage(url: emoji.url) { state in
@@ -39,15 +39,11 @@ extension StatusEditor {
                     viewModel.insertStatusText(text: " :\(emoji.shortcode): ")
                   }
                 }
+                .padding(.horizontal, 8)
               } header: {
-                HStack {
-                  Text(container.categoryName)
-                    .font(.scaledFootnote)
-                  Spacer()
-                }
+                Text(container.categoryName)
               }
             }
-            .padding(.horizontal, 8)
           }
         }
         .toolbar {

--- a/Packages/StatusKit/Sources/StatusKit/Editor/Components/CustomEmojisView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Editor/Components/CustomEmojisView.swift
@@ -39,9 +39,14 @@ extension StatusEditor {
                     viewModel.insertStatusText(text: " :\(emoji.shortcode): ")
                   }
                 }
-                .padding(.horizontal, 8)
+                .padding(.horizontal, 16)
               } header: {
                 Text(container.categoryName)
+                  .font(.scaledHeadline)
+                  .bold()
+                  .foregroundStyle(Color.secondary)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .padding(.horizontal, 16)
               }
             }
           }


### PR DESCRIPTION
When I was scrolling through a list of emojis, there was an issue where if I scrolled upwards, it would stutter and not scroll.

- Fixed categorizing emojis to handle all of them in one LazyVGrid instead of using multiple LazyVGrids. #1920   
- I also changed the section headers to look a little better.

## Preview
### Before
https://github.com/Dimillian/IceCubesApp/assets/712513/784bdbbc-132f-4db2-8adf-a1e91df4cdc4

### After
https://github.com/Dimillian/IceCubesApp/assets/712513/99b034bf-eb5b-452c-b27e-685852ccd306

