### PR TITLE
Implement Apple Translate

### DIFF
--- a/IceCubesApp.xcodeproj/project.pbxproj
+++ b/IceCubesApp.xcodeproj/project.pbxproj
@@ -87,7 +87,6 @@
 		9F7D93942980063100EE6B7A /* AppAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 9F7D93932980063100EE6B7A /* AppAccount */; };
 		9F7D939A29805DBD00EE6B7A /* AccountSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7D939929805DBD00EE6B7A /* AccountSettingView.swift */; };
 		9FA6FD6229C04A8800E2312C /* TranslationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA6FD6129C04A8800E2312C /* TranslationSettingsView.swift */; };
-		9FAD85832971BF7200496AB1 /* Secret.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9FAD85822971BF7200496AB1 /* Secret.plist */; };
 		9FAD858B29743F7400496AB1 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FAD858A29743F7400496AB1 /* ShareViewController.swift */; };
 		9FAD858E29743F7400496AB1 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		9FAD859229743F7400496AB1 /* IceCubesShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 9FAD858829743F7400496AB1 /* IceCubesShareExtension.appex */; platformFilters = (ios, maccatalyst, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -271,7 +270,6 @@
 		9F7D939529800B0300EE6B7A /* IceCubesApp-release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "IceCubesApp-release.xcconfig"; sourceTree = "<group>"; };
 		9F7D939929805DBD00EE6B7A /* AccountSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingView.swift; sourceTree = "<group>"; };
 		9FA6FD6129C04A8800E2312C /* TranslationSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranslationSettingsView.swift; sourceTree = "<group>"; };
-		9FAD85822971BF7200496AB1 /* Secret.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Secret.plist; sourceTree = "<group>"; };
 		9FAD858829743F7400496AB1 /* IceCubesShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = IceCubesShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FAD858A29743F7400496AB1 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		9FAD858F29743F7400496AB1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -602,7 +600,6 @@
 				9FAE4AC8293774FF00772766 /* Info.plist */,
 				9F398AB429360A5800A889F2 /* App */,
 				9F398AB529360A6100A889F2 /* Resources */,
-				9FAD85822971BF7200496AB1 /* Secret.plist */,
 			);
 			path = IceCubesApp;
 			sourceTree = "<group>";
@@ -960,7 +957,6 @@
 				9F18801829AE477F00D85459 /* favorite.wav in Resources */,
 				9F24EEB829360C330042359D /* Preview Assets.xcassets in Resources */,
 				069709A8298C87B5006E4CB5 /* OpenDyslexic-Regular.otf in Resources */,
-				9FAD85832971BF7200496AB1 /* Secret.plist in Resources */,
 				9F18801229AE477F00D85459 /* tabSelection.wav in Resources */,
 				9F18801429AE477F00D85459 /* bookmark.wav in Resources */,
 				9F18801629AE477F00D85459 /* refresh.wav in Resources */,

--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -31,7 +31,9 @@ struct SettingsTabs: View {
   @Binding var popToRootTab: Tab
 
   let isModal: Bool
-
+  
+  @State private var startingPoint: SettingsStartingPoint? = nil
+  
   var body: some View {
     NavigationStack(path: $routerPath.path) {
       Form {
@@ -64,6 +66,32 @@ struct SettingsTabs: View {
         }
         .withAppRouter()
         .withSheetDestinations(sheetDestinations: $routerPath.presentedSheet)
+        .onAppear {
+          startingPoint = RouterPath.settingsStartingPoint
+          RouterPath.settingsStartingPoint = nil
+        }
+        .navigationDestination(item: $startingPoint) { targetView in
+          switch targetView {
+            case .display:
+              DisplaySettingsView()
+            case .haptic:
+              HapticSettingsView()
+            case .remoteTimelines:
+              RemoteTimelinesSettingView()
+            case .tagGroups:
+              TagsGroupSettingView()
+            case .recentTags:
+              RecenTagsSettingView()
+            case .content:
+              ContentSettingsView()
+            case .swipeActions:
+              SwipeActionsSettingsView()
+            case .tabAndSidebarEntries:
+              EmptyView()
+            case .translation:
+              TranslationSettingsView()
+          }
+        }
     }
     .onAppear {
       routerPath.client = client

--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -110,6 +110,9 @@ struct TranslationSettingsView: View {
     {
       Section {
         Text("settings.translation.api-key-still-stored")
+        if preferences.preferredTranslationType == .useServerIfPossible {
+          Text("It can however still be used as a fallback for your instance's translation service.")
+        }
         Button(role: .destructive) {
           withAnimation {
             writeNewValue(value: "")

--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -54,7 +54,11 @@ struct TranslationSettingsView: View {
     @Bindable var preferences = preferences
     Picker("settings.translation.preferred-translation-type", selection: $preferences.preferredTranslationType) {
       ForEach(TranslationType.allCases, id: \.self) { type in
-        Text(type.description).tag(type)
+        if #available(iOS 17.4, *) {
+          Text(type.description).tag(type)
+        } else if type != .useApple {
+          Text(type.description).tag(type)
+        }
       }
     }
     #if !os(visionOS)

--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -68,17 +68,17 @@ struct TranslationSettingsView: View {
         return true
       }
       #if canImport(_Translation_SwiftUI)
-      if #available(iOS 17.4, *) {
-        return true
-      } else {
-        return false
-      }
+        if #available(iOS 17.4, *) {
+          return true
+        } else {
+          return false
+        }
       #else
-      return false
+        return false
       #endif
     }
   }
-  
+
   @ViewBuilder
   private var deepLPicker: some View {
     @Bindable var preferences = preferences
@@ -102,11 +102,12 @@ struct TranslationSettingsView: View {
     .listRowBackground(theme.primaryBackgroundColor)
     #endif
   }
-  
+
   @ViewBuilder
   private var backgroundAPIKey: some View {
     if preferences.preferredTranslationType != .useDeepl,
-       !apiKey.isEmpty {
+       !apiKey.isEmpty
+    {
       Section {
         Text("settings.translation.api-key-still-stored")
         Button(role: .destructive) {

--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -54,7 +54,7 @@ struct TranslationSettingsView: View {
     @Bindable var preferences = preferences
     Picker("settings.translation.preferred-translation-type", selection: $preferences.preferredTranslationType) {
       ForEach(TranslationType.allCases, id: \.self) { type in
-        Text(type.rawValue).tag(type)
+        Text(type.description).tag(type)
       }
     }
     #if !os(visionOS)

--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -109,7 +109,7 @@ struct TranslationSettingsView: View {
        !apiKey.isEmpty
     {
       Section {
-        Text("settings.translation.api-key-still-stored")
+        Text("The DeepL API Key is still stored!")
         if preferences.preferredTranslationType == .useServerIfPossible {
           Text("It can however still be used as a fallback for your instance's translation service.")
         }

--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -18,9 +18,6 @@ struct TranslationSettingsView: View {
           SecureField("settings.translation.user-api-key", text: $apiKey)
             .textContentType(.password)
         }
-        .onAppear {
-          readValue()
-        }
         #if !os(visionOS)
         .listRowBackground(theme.primaryBackgroundColor)
         #endif
@@ -37,6 +34,7 @@ struct TranslationSettingsView: View {
           #endif
         }
       }
+      backgroundAPIKey
       autoDetectSection
     }
     .navigationTitle("settings.translation.navigation-title")
@@ -48,6 +46,7 @@ struct TranslationSettingsView: View {
         writeNewValue()
       }
       .onAppear(perform: updatePrefs)
+      .onAppear(perform: readValue)
   }
 
   @ViewBuilder
@@ -86,6 +85,27 @@ struct TranslationSettingsView: View {
     .listRowBackground(theme.primaryBackgroundColor)
     #endif
   }
+  
+  @ViewBuilder
+  private var backgroundAPIKey: some View {
+    if preferences.preferredTranslationType != .useDeepl,
+       !apiKey.isEmpty {
+      Section {
+        Text("settings.translation.api-key-still-stored")
+        Button(role: .destructive) {
+          withAnimation {
+            writeNewValue(value: "")
+            readValue()
+          }
+        } label: {
+          Text("action.delete")
+        }
+      }
+      #if !os(visionOS)
+      .listRowBackground(theme.primaryBackgroundColor)
+      #endif
+    }
+  }
 
   private func writeNewValue() {
     writeNewValue(value: apiKey)
@@ -96,11 +116,7 @@ struct TranslationSettingsView: View {
   }
 
   private func readValue() {
-    if let apiKey = DeepLUserAPIHandler.readIfAllowed() {
-      self.apiKey = apiKey
-    } else {
-      apiKey = ""
-    }
+    apiKey = DeepLUserAPIHandler.readKey()
   }
 
   private func updatePrefs() {

--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -53,12 +53,8 @@ struct TranslationSettingsView: View {
   private var translationSelector: some View {
     @Bindable var preferences = preferences
     Picker("settings.translation.preferred-translation-type", selection: $preferences.preferredTranslationType) {
-      ForEach(TranslationType.allCases, id: \.self) { type in
-        if #available(iOS 17.4, *) {
-          Text(type.description).tag(type)
-        } else if type != .useApple {
-          Text(type.description).tag(type)
-        }
+      ForEach(allTTCases, id: \.self) { type in
+        Text(type.description).tag(type)
       }
     }
     #if !os(visionOS)
@@ -66,6 +62,23 @@ struct TranslationSettingsView: View {
     #endif
   }
 
+  var allTTCases: [TranslationType] {
+    TranslationType.allCases.filter { type in
+      if type != .useApple {
+        return true
+      }
+      #if canImport(_Translation_SwiftUI)
+      if #available(iOS 17.4, *) {
+        return true
+      } else {
+        return false
+      }
+      #else
+      return false
+      #endif
+    }
+  }
+  
   @ViewBuilder
   private var deepLPicker: some View {
     @Bindable var preferences = preferences

--- a/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TranslationSettingsView.swift
@@ -11,8 +11,8 @@ struct TranslationSettingsView: View {
 
   var body: some View {
     Form {
-      deepLToggle
-      if preferences.alwaysUseDeepl {
+      translationSelector
+      if preferences.preferredTranslationType == .useDeepl {
         Section("settings.translation.user-api-key") {
           deepLPicker
           SecureField("settings.translation.user-api-key", text: $apiKey)
@@ -51,10 +51,12 @@ struct TranslationSettingsView: View {
   }
 
   @ViewBuilder
-  private var deepLToggle: some View {
+  private var translationSelector: some View {
     @Bindable var preferences = preferences
-    Toggle(isOn: $preferences.alwaysUseDeepl) {
-      Text("settings.translation.always-deepl")
+    Picker("settings.translation.preferred-translation-type", selection: $preferences.preferredTranslationType) {
+      ForEach(TranslationType.allCases, id: \.self) { type in
+        Text(type.rawValue).tag(type)
+      }
     }
     #if !os(visionOS)
     .listRowBackground(theme.primaryBackgroundColor)
@@ -80,6 +82,9 @@ struct TranslationSettingsView: View {
     } footer: {
       Text("settings.translation.auto-detect-post-language-footer")
     }
+    #if !os(visionOS)
+    .listRowBackground(theme.primaryBackgroundColor)
+    #endif
   }
 
   private func writeNewValue() {

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -26160,6 +26160,23 @@
         }
       }
     },
+    "enum.translation-type.use-server-if-possible" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Instanz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instance"
+          }
+        }
+      }
+    },
     "env.poll-vote-frequency.multiple" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -59866,121 +59883,18 @@
         }
       }
     },
-    "settings.translation.always-deepl" : {
-      "extractionState" : "stale",
+    "settings.translation.api-key-still-stored" : {
       "localizations" : {
-        "be" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Translate using DeepL"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Translate using DeepL"
-          }
-        },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Immer mit DeepL übersetzen"
+            "state" : "needs_review",
+            "value" : "Der DeepL-API-Schlüssel ist noch gespeichert!"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Always Translate using DeepL"
-          }
-        },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Translate using DeepL"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Traducir siempre con DeepL"
-          }
-        },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Itzuli beti DeepL erabiliz"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Translate using DeepL"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Traduci sempre con DeepL"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DeepLを使用して常に翻訳する"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "항상 DeepL을 통해 번역"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oversett alltid med DeepL"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vertaal altijd met DeepL"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zawsze tłumacz przy pomocy DeepL"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sempre traduzir utilizando DeepL"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Her Zaman DeepL kullanarak Çevir"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завжди перекладати за допомогою DeepL"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "总是使用 DeepL 翻译"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一概用 DeepL 翻譯"
+            "value" : "The DeepL API Key is still stored!"
           }
         }
       }
@@ -60461,122 +60375,135 @@
       "localizations" : {
         "be" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "This feature requires a DeepL API key"
           }
         },
         "ca" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "This feature requires a DeepL API key"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Für diese Funktion ist ein DeepL-API-Schlüssel erforderlich."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This feature requires a DeepL API key"
+            "value" : "This feature requires a DeepL API Key"
           }
         },
         "en-GB" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "This feature requires a DeepL API key"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Esta funcionalidad requiere una clave API de DeepL"
           }
         },
         "eu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ezaugarri honek DeepL API gako bat behar du"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "This feature requires a DeepL API key"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Questa funzione richiede una chiave API DeepL"
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "この機能には DeepL APIキーが必要です"
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "이 기능을 사용하려면 DeepL에서 발급받은 API 키가 있어야 합니다."
           }
         },
         "nb" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Denne funksjonen krever en DeepL API-nøkkel"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Deze functionaliteit vereist een DeepL API-sleutel"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ta funkcja wymaga klucza DeepL API"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Esta funcionalidade requer uma chave de API DeepL"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Bu özellik bir DeepL API anahtarı gerektirir"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ця функція потребує ключа DeepL API key"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "该功能需要 DeepL API 密钥"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "本功能需有 DeepL API 密鑰"
           }
         }
       }
     },
     "settings.translation.preferred-translation-type" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersetzungs-Service"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Translation Service"
+          }
+        }
+      }
     },
     "settings.translation.user-api-key" : {
       "localizations" : {

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -32513,6 +32513,20 @@
         }
       }
     },
+    "It can however still be used as a fallback for your instance's translation service." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Er kann aber auch als Fallback für den Übersetzungsservice deiner Instanz dienen."
+          }
+        }
+      }
+    },
+    "Key" : {
+      "extractionState" : "manual"
+    },
     "list.edit.isExclusive" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -26160,28 +26160,6 @@
         }
       }
     },
-    "enum.translation-type.apple" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Translate"
-          }
-        }
-      }
-    },
-    "enum.translation-type.deepl" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DeepL"
-          }
-        }
-      }
-    },
     "enum.translation-type.use-server-if-possible" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -20424,40 +20424,6 @@
         }
       }
     },
-    "alert.translation-error.deepl" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DeepL konnte nicht erreicht werden!\nIst der API-Schlüssel korrekt?"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DeepL couldn't be reached!\nIs the API Key correct?"
-          }
-        }
-      }
-    },
-    "alert.translation-error.instance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Übersetzung-Service deiner Instanz konnte nicht erreicht werden!"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The Translation Service of your Instance couldn't be reached!"
-          }
-        }
-      }
-    },
     "An error occured while posting to Mastodon, please try again." : {
       "localizations" : {
         "de" : {
@@ -22174,6 +22140,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "DeepL API Pro"
+          }
+        }
+      }
+    },
+    "DeepL couldn't be reached!\nIs the API Key correct?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DeepL konnte nicht erreicht werden! Ist der API-Schlüssel korrekt?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DeepL couldn't be reached!\nIs the API Key correct?"
           }
         }
       }
@@ -26310,23 +26293,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圖文"
-          }
-        }
-      }
-    },
-    "enum.translation-type.use-server-if-possible" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Instanz"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instance"
           }
         }
       }
@@ -30974,6 +30940,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "向 Mastodon 发布的图片"
+          }
+        }
+      }
+    },
+    "Instance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instanz"
           }
         }
       }
@@ -60051,22 +60028,6 @@
         }
       }
     },
-    "settings.translation.api-key-still-stored" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Der DeepL-API-Schlüssel ist noch gespeichert!"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The DeepL API Key is still stored!"
-          }
-        }
-      }
-    },
     "settings.translation.api-key-type" : {
       "localizations" : {
         "be" : {
@@ -76921,6 +76882,28 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "The DeepL API Key is still stored!" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der DeepL-API-Schlüssel ist noch gespeichert!"
+          }
+        }
+      }
+    },
+    "The Translation Service of your Instance couldn't be reached!" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Übersetzung-Service deiner Instanz konnte nicht erreicht werden!"
           }
         }
       }

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -18412,6 +18412,126 @@
         }
       }
     },
+    "action.cancel" : {
+      "comment" : "MARK: Common strings",
+      "extractionState" : "stale",
+      "localizations" : {
+        "be" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скасаваць"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel·la"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "eu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utzi"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avbryt"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuleer"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anuluj"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İptal Et"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відміна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
     "action.delete" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -20300,6 +20420,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "錯誤！"
+          }
+        }
+      }
+    },
+    "alert.translation-error.deepl" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DeepL konnte nicht erreicht werden!\nIst der API-Schlüssel korrekt?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DeepL couldn't be reached!\nIs the API Key correct?"
+          }
+        }
+      }
+    },
+    "alert.translation-error.instance" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Übersetzung-Service deiner Instanz konnte nicht erreicht werden!"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Translation Service of your Instance couldn't be reached!"
           }
         }
       }
@@ -81077,126 +81231,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用 Ice Cubes 向 Mastodon 发布带有图片的状态"
-          }
-        }
-      }
-    },
-     "action.cancel" : {
-      "comment" : "MARK: Common strings",
-      "extractionState" : "stale",
-      "localizations" : {
-        "be" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скасаваць"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel·la"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
-          }
-        },
-        "en-GB" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
-        "eu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utzi"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avbryt"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuleer"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anuluj"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İptal Et"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відміна"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
           }
         }
       }

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -59867,6 +59867,7 @@
       }
     },
     "settings.translation.always-deepl" : {
+      "extractionState" : "stale",
       "localizations" : {
         "be" : {
           "stringUnit" : {
@@ -60573,6 +60574,9 @@
           }
         }
       }
+    },
+    "settings.translation.preferred-translation-type" : {
+
     },
     "settings.translation.user-api-key" : {
       "localizations" : {

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -26160,6 +26160,28 @@
         }
       }
     },
+    "enum.translation-type.apple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Translate"
+          }
+        }
+      }
+    },
+    "enum.translation-type.deepl" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DeepL"
+          }
+        }
+      }
+    },
     "enum.translation-type.use-server-if-possible" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/IceCubesApp/Secret.plist
+++ b/IceCubesApp/Secret.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>DEEPL_SECRET</key>
-	<string>NICE_TRY_AGAIN</string>
-</dict>
-</plist>

--- a/Packages/Account/Sources/Account/AccountDetailViewModel.swift
+++ b/Packages/Account/Sources/Account/AccountDetailViewModel.swift
@@ -280,7 +280,7 @@ import SwiftUI
       isLoadingTranslation = true
     }
 
-    let userAPIKey = DeepLUserAPIHandler.readIfAllowed()
+    let userAPIKey = DeepLUserAPIHandler.readKeyIfAllowed()
     let userAPIFree = UserPreferences.shared.userDeeplAPIFree
     let deeplClient = DeepLClient(userAPIKey: userAPIKey, userAPIFree: userAPIFree)
 

--- a/Packages/Env/Sources/Env/DeepLUserAPIHandler.swift
+++ b/Packages/Env/Sources/Env/DeepLUserAPIHandler.swift
@@ -32,7 +32,7 @@ public enum DeepLUserAPIHandler {
   public static func readKey() -> String {
     return readKeyInternal() ?? ""
   }
-  
+
   private static func readKeyInternal() -> String? {
     keychain.synchronizable = true
     return keychain.get(key)

--- a/Packages/Env/Sources/Env/DeepLUserAPIHandler.swift
+++ b/Packages/Env/Sources/Env/DeepLUserAPIHandler.swift
@@ -23,26 +23,30 @@ public enum DeepLUserAPIHandler {
     }
   }
 
-  public static func readIfAllowed() -> String? {
+  public static func readKeyIfAllowed() -> String? {
     guard UserPreferences.shared.preferredTranslationType == .useDeepl else { return nil }
 
-    return readValue()
+    return readKeyInternal()
   }
 
-  private static func readValue() -> String? {
+  public static func readKey() -> String {
+    return readKeyInternal() ?? ""
+  }
+  
+  private static func readKeyInternal() -> String? {
     keychain.synchronizable = true
     return keychain.get(key)
   }
 
   public static func deactivateToggleIfNoKey() {
     if UserPreferences.shared.preferredTranslationType == .useDeepl {
-      if readValue() == nil {
+      if readKeyInternal() == nil {
         UserPreferences.shared.preferredTranslationType = .useServerIfPossible
       }
     }
   }
 
   public static var shouldAlwaysUseDeepl: Bool {
-    readIfAllowed() != nil
+    readKeyIfAllowed() != nil
   }
 }

--- a/Packages/Env/Sources/Env/DeepLUserAPIHandler.swift
+++ b/Packages/Env/Sources/Env/DeepLUserAPIHandler.swift
@@ -24,7 +24,7 @@ public enum DeepLUserAPIHandler {
   }
 
   public static func readIfAllowed() -> String? {
-    guard UserPreferences.shared.alwaysUseDeepl else { return nil }
+    guard UserPreferences.shared.preferredTranslationType == .useDeepl else { return nil }
 
     return readValue()
   }
@@ -35,7 +35,11 @@ public enum DeepLUserAPIHandler {
   }
 
   public static func deactivateToggleIfNoKey() {
-    UserPreferences.shared.alwaysUseDeepl = shouldAlwaysUseDeepl
+    if UserPreferences.shared.preferredTranslationType == .useDeepl {
+      if readValue() == nil {
+        UserPreferences.shared.preferredTranslationType = .useServerIfPossible
+      }
+    }
   }
 
   public static var shouldAlwaysUseDeepl: Bool {

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -115,6 +115,18 @@ public enum SheetDestination: Identifiable, Hashable {
   }
 }
 
+public enum SettingsStartingPoint {
+  case display
+  case haptic
+  case remoteTimelines
+  case tagGroups
+  case recentTags
+  case content
+  case swipeActions
+  case tabAndSidebarEntries
+  case translation
+}
+
 @MainActor
 @Observable public class RouterPath {
   public var client: Client?
@@ -122,6 +134,8 @@ public enum SheetDestination: Identifiable, Hashable {
 
   public var path: [RouterDestination] = []
   public var presentedSheet: SheetDestination?
+
+  public static var settingsStartingPoint: SettingsStartingPoint? = nil
 
   public init() {}
 

--- a/Packages/Env/Sources/Env/TranslationType.swift
+++ b/Packages/Env/Sources/Env/TranslationType.swift
@@ -10,9 +10,9 @@ public enum TranslationType: String, CaseIterable {
     case .useServerIfPossible:
       "enum.translation-type.use-server-if-possible"
     case .useDeepl:
-      "enum.translation-type.deepl"
+      "DeepL"
     case .useApple:
-      "enum.translation-type.apple"
+      "Apple Translate"
     }
   }
 }

--- a/Packages/Env/Sources/Env/TranslationType.swift
+++ b/Packages/Env/Sources/Env/TranslationType.swift
@@ -10,9 +10,9 @@ public enum TranslationType: String, CaseIterable {
       case .useServerIfPossible:
         "enum.translation-type.use-server-if-possible"
       case .useDeepl:
-        "DeepL"
+        "enum.translation-type.deepl"
       case .useApple:
-        "Apple Translate"
+        "enum.translation-type.apple"
     }
   }
 }

--- a/Packages/Env/Sources/Env/TranslationType.swift
+++ b/Packages/Env/Sources/Env/TranslationType.swift
@@ -1,0 +1,5 @@
+public enum TranslationType: String, CaseIterable {
+  case useServerIfPossible
+  case useDeepl
+  case useApple
+}

--- a/Packages/Env/Sources/Env/TranslationType.swift
+++ b/Packages/Env/Sources/Env/TranslationType.swift
@@ -8,7 +8,7 @@ public enum TranslationType: String, CaseIterable {
   public var description: LocalizedStringKey {
     switch self {
     case .useServerIfPossible:
-      "enum.translation-type.use-server-if-possible"
+      "Instance"
     case .useDeepl:
       "DeepL"
     case .useApple:

--- a/Packages/Env/Sources/Env/TranslationType.swift
+++ b/Packages/Env/Sources/Env/TranslationType.swift
@@ -7,12 +7,12 @@ public enum TranslationType: String, CaseIterable {
 
   public var description: LocalizedStringKey {
     switch self {
-      case .useServerIfPossible:
-        "enum.translation-type.use-server-if-possible"
-      case .useDeepl:
-        "enum.translation-type.deepl"
-      case .useApple:
-        "enum.translation-type.apple"
+    case .useServerIfPossible:
+      "enum.translation-type.use-server-if-possible"
+    case .useDeepl:
+      "enum.translation-type.deepl"
+    case .useApple:
+      "enum.translation-type.apple"
     }
   }
 }

--- a/Packages/Env/Sources/Env/TranslationType.swift
+++ b/Packages/Env/Sources/Env/TranslationType.swift
@@ -1,5 +1,18 @@
+import SwiftUI
+
 public enum TranslationType: String, CaseIterable {
   case useServerIfPossible
   case useDeepl
   case useApple
+
+  public var description: LocalizedStringKey {
+    switch self {
+      case .useServerIfPossible:
+        "enum.translation-type.use-server-if-possible"
+      case .useDeepl:
+        "DeepL"
+      case .useApple:
+        "Apple Translate"
+    }
+  }
 }

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -64,6 +64,10 @@ import SwiftUI
     @AppStorage("sidebar_expanded") public var isSidebarExpanded: Bool = false
 
     init() {
+      prepareTranslationType()
+    }
+    
+    private func prepareTranslationType() {
       let sharedDefault = UserDefaults.standard
       if let alwaysUseDeepl = (sharedDefault.object(forKey: "always_use_deepl") as? Bool) {
         if alwaysUseDeepl {
@@ -71,10 +75,16 @@ import SwiftUI
         }
         sharedDefault.removeObject(forKey: "always_use_deepl")
       }
+#if canImport(_Translation_SwiftUI)
       if #unavailable(iOS 17.4),
          preferredTranslationType == .useApple {
         preferredTranslationType = .useServerIfPossible
       }
+#else
+      if preferredTranslationType == .useApple {
+        preferredTranslationType = .useServerIfPossible
+      }
+#endif
     }
   }
 

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -185,11 +185,7 @@ import SwiftUI
     }
   }
 
-  public var alwaysUseDeepl: Bool {
-    didSet {
-      storage.alwaysUseDeepl = alwaysUseDeepl
-    }
-  }
+  public var preferredTranslationType: TranslationType
 
   public var userDeeplAPIFree: Bool {
     didSet {
@@ -482,7 +478,7 @@ import SwiftUI
     appDefaultPostsSensitive = storage.appDefaultPostsSensitive
     appRequireAltText = storage.appRequireAltText
     autoPlayVideo = storage.autoPlayVideo
-    alwaysUseDeepl = storage.alwaysUseDeepl
+    preferredTranslationType = .useServerIfPossible
     userDeeplAPIFree = storage.userDeeplAPIFree
     autoDetectPostLanguage = storage.autoDetectPostLanguage
     inAppBrowserReaderView = storage.inAppBrowserReaderView

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -71,6 +71,10 @@ import SwiftUI
         }
         sharedDefault.removeObject(forKey: "always_use_deepl")
       }
+      if #unavailable(iOS 17.4),
+         preferredTranslationType == .useApple {
+        preferredTranslationType = .useServerIfPossible
+      }
     }
   }
 

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -25,7 +25,7 @@ import SwiftUI
     @AppStorage("app_require_alt_text") public var appRequireAltText = false
     @AppStorage("autoplay_video") public var autoPlayVideo = true
     @AppStorage("mute_video") public var muteVideo = true
-    @AppStorage("always_use_deepl") public var alwaysUseDeepl = false
+    @AppStorage("preferred_translation_type") public var preferredTranslationType = TranslationType.useServerIfPossible
     @AppStorage("user_deepl_api_free") public var userDeeplAPIFree = true
     @AppStorage("auto_detect_post_language") public var autoDetectPostLanguage = true
 
@@ -63,7 +63,15 @@ import SwiftUI
     
     @AppStorage("sidebar_expanded") public var isSidebarExpanded: Bool = false
 
-    init() {}
+    init() {
+      let sharedDefault = UserDefaults.standard
+      if let alwaysUseDeepl = (sharedDefault.object(forKey: "always_use_deepl") as? Bool) {
+        if alwaysUseDeepl {
+          preferredTranslationType = .useDeepl
+        }
+        sharedDefault.removeObject(forKey: "always_use_deepl")
+      }
+    }
   }
 
   public static let sharedDefault = UserDefaults(suiteName: "group.com.thomasricouard.IceCubesApp")

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -193,7 +193,11 @@ import SwiftUI
     }
   }
 
-  public var preferredTranslationType: TranslationType
+  public var preferredTranslationType: TranslationType {
+    didSet {
+      storage.preferredTranslationType = preferredTranslationType
+    }
+  }
 
   public var userDeeplAPIFree: Bool {
     didSet {
@@ -486,7 +490,7 @@ import SwiftUI
     appDefaultPostsSensitive = storage.appDefaultPostsSensitive
     appRequireAltText = storage.appRequireAltText
     autoPlayVideo = storage.autoPlayVideo
-    preferredTranslationType = .useServerIfPossible
+    preferredTranslationType = storage.preferredTranslationType
     userDeeplAPIFree = storage.userDeeplAPIFree
     autoDetectPostLanguage = storage.autoDetectPostLanguage
     inAppBrowserReaderView = storage.inAppBrowserReaderView

--- a/Packages/Env/Sources/Env/UserPreferences.swift
+++ b/Packages/Env/Sources/Env/UserPreferences.swift
@@ -60,13 +60,13 @@ import SwiftUI
     @AppStorage("show_reply_indentation") public var showReplyIndentation: Bool = true
 
     @AppStorage("show_account_popover") public var showAccountPopover: Bool = true
-    
+
     @AppStorage("sidebar_expanded") public var isSidebarExpanded: Bool = false
 
     init() {
       prepareTranslationType()
     }
-    
+
     private func prepareTranslationType() {
       let sharedDefault = UserDefaults.standard
       if let alwaysUseDeepl = (sharedDefault.object(forKey: "always_use_deepl") as? Bool) {
@@ -75,16 +75,17 @@ import SwiftUI
         }
         sharedDefault.removeObject(forKey: "always_use_deepl")
       }
-#if canImport(_Translation_SwiftUI)
-      if #unavailable(iOS 17.4),
-         preferredTranslationType == .useApple {
-        preferredTranslationType = .useServerIfPossible
-      }
-#else
-      if preferredTranslationType == .useApple {
-        preferredTranslationType = .useServerIfPossible
-      }
-#endif
+      #if canImport(_Translation_SwiftUI)
+        if #unavailable(iOS 17.4),
+           preferredTranslationType == .useApple
+        {
+          preferredTranslationType = .useServerIfPossible
+        }
+      #else
+        if preferredTranslationType == .useApple {
+          preferredTranslationType = .useServerIfPossible
+        }
+      #endif
     }
   }
 
@@ -350,7 +351,7 @@ import SwiftUI
       storage.showAccountPopover = showAccountPopover
     }
   }
-  
+
   public var isSidebarExpanded: Bool {
     didSet {
       storage.isSidebarExpanded = isSidebarExpanded

--- a/Packages/StatusKit/Sources/StatusKit/Editor/Components/MediaEditView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Editor/Components/MediaEditView.swift
@@ -161,7 +161,7 @@ extension StatusEditor {
 
     private func translateDescription() async -> String? {
       isTranslating = true
-      let userAPIKey = DeepLUserAPIHandler.readIfAllowed()
+      let userAPIKey = DeepLUserAPIHandler.readKeyIfAllowed()
       let userAPIFree = UserPreferences.shared.userDeeplAPIFree
       let deeplClient = DeepLClient(userAPIKey: userAPIKey, userAPIFree: userAPIFree)
       let lang = preferences.serverPreferences?.postLanguage ?? Locale.current.language.languageCode?.identifier

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -233,14 +233,14 @@ public struct StatusRowView: View {
       StatusDataControllerProvider.shared.dataController(for: viewModel.finalStatus,
                                                          client: viewModel.client)
     )
-    .alert("alert.translation-error.deepl", isPresented: $viewModel.deeplTranslationError) {
+    .alert("DeepL couldn't be reached!\nIs the API Key correct?", isPresented: $viewModel.deeplTranslationError) {
       Button("alert.button.ok", role: .cancel) {}
       Button("settings.general.translate") {
         RouterPath.settingsStartingPoint = .translation
         routerPath.presentedSheet = .settings
       }
     }
-    .alert("alert.translation-error.instance", isPresented: $viewModel.instanceTranslationError) {
+    .alert("The Translation Service of your Instance couldn't be reached!", isPresented: $viewModel.instanceTranslationError) {
       Button("alert.button.ok", role: .cancel) {}
       Button("settings.general.translate") {
         RouterPath.settingsStartingPoint = .translation

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -5,6 +5,7 @@ import Foundation
 import Models
 import Network
 import SwiftUI
+import Translation
 
 @MainActor
 public struct StatusRowView: View {
@@ -219,6 +220,7 @@ public struct StatusRowView: View {
       StatusDataControllerProvider.shared.dataController(for: viewModel.finalStatus,
                                                          client: viewModel.client)
     )
+    .addTranslateView(isPresented: $viewModel.showAppleTranslation, text: viewModel.finalStatus.content.asRawText)
   }
 
   @ViewBuilder
@@ -354,4 +356,14 @@ public struct StatusRowView: View {
   .listStyle(.plain)
   .withPreviewsEnv()
   .environment(Theme.shared)
+}
+
+extension View {
+    func addTranslateView(isPresented: Binding<Bool>, text: String) -> some View {
+        if #available(iOS 17.4, *) {
+            return self.translationPresentation(isPresented: isPresented, text: text)
+        } else {
+            return self
+        }
+    }
 }

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -6,17 +6,17 @@ import Models
 import Network
 import SwiftUI
 #if canImport(_Translation_SwiftUI)
-import Translation
+  import Translation
 
-extension View {
-  func addTranslateView(isPresented: Binding<Bool>, text: String) -> some View {
-    if #available(iOS 17.4, *) {
-      return self.translationPresentation(isPresented: isPresented, text: text)
-    } else {
-      return self
+  extension View {
+    func addTranslateView(isPresented: Binding<Bool>, text: String) -> some View {
+      if #available(iOS 17.4, *) {
+        return self.translationPresentation(isPresented: isPresented, text: text)
+      } else {
+        return self
+      }
     }
   }
-}
 #endif
 
 @MainActor
@@ -232,9 +232,9 @@ public struct StatusRowView: View {
       StatusDataControllerProvider.shared.dataController(for: viewModel.finalStatus,
                                                          client: viewModel.client)
     )
-#if canImport(_Translation_SwiftUI)
+    #if canImport(_Translation_SwiftUI)
     .addTranslateView(isPresented: $viewModel.showAppleTranslation, text: viewModel.finalStatus.content.asRawText)
-#endif
+    #endif
   }
 
   @ViewBuilder

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -28,6 +28,7 @@ public struct StatusRowView: View {
   @Environment(\.accessibilityVoiceOverEnabled) private var accessibilityVoiceOverEnabled
   @Environment(\.isStatusFocused) private var isFocused
   @Environment(\.indentationLevel) private var indentationLevel
+  @Environment(RouterPath.self) private var routerPath: RouterPath
 
   @Environment(QuickLook.self) private var quickLook
   @Environment(Theme.self) private var theme
@@ -232,6 +233,20 @@ public struct StatusRowView: View {
       StatusDataControllerProvider.shared.dataController(for: viewModel.finalStatus,
                                                          client: viewModel.client)
     )
+    .alert("alert.translation-error.deepl", isPresented: $viewModel.deeplTranslationError) {
+      Button("alert.button.ok", role: .cancel) {}
+      Button("settings.general.translate") {
+        RouterPath.settingsStartingPoint = .translation
+        routerPath.presentedSheet = .settings
+      }
+    }
+    .alert("alert.translation-error.instance", isPresented: $viewModel.instanceTranslationError) {
+      Button("alert.button.ok", role: .cancel) {}
+      Button("settings.general.translate") {
+        RouterPath.settingsStartingPoint = .translation
+        routerPath.presentedSheet = .settings
+      }
+    }
     #if canImport(_Translation_SwiftUI)
     .addTranslateView(isPresented: $viewModel.showAppleTranslation, text: viewModel.finalStatus.content.asRawText)
     #endif

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -5,7 +5,19 @@ import Foundation
 import Models
 import Network
 import SwiftUI
+#if canImport(_Translation_SwiftUI)
 import Translation
+
+extension View {
+  func addTranslateView(isPresented: Binding<Bool>, text: String) -> some View {
+    if #available(iOS 17.4, *) {
+      return self.translationPresentation(isPresented: isPresented, text: text)
+    } else {
+      return self
+    }
+  }
+}
+#endif
 
 @MainActor
 public struct StatusRowView: View {
@@ -220,7 +232,9 @@ public struct StatusRowView: View {
       StatusDataControllerProvider.shared.dataController(for: viewModel.finalStatus,
                                                          client: viewModel.client)
     )
+#if canImport(_Translation_SwiftUI)
     .addTranslateView(isPresented: $viewModel.showAppleTranslation, text: viewModel.finalStatus.content.asRawText)
+#endif
   }
 
   @ViewBuilder
@@ -356,14 +370,4 @@ public struct StatusRowView: View {
   .listStyle(.plain)
   .withPreviewsEnv()
   .environment(Theme.shared)
-}
-
-extension View {
-    func addTranslateView(isPresented: Binding<Bool>, text: String) -> some View {
-        if #available(iOS 17.4, *) {
-            return self.translationPresentation(isPresented: isPresented, text: text)
-        } else {
-            return self
-        }
-    }
 }

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowViewModel.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowViewModel.swift
@@ -40,6 +40,7 @@ import SwiftUI
       }
     }
   }
+
   var deeplTranslationError = false
   var instanceTranslationError = false
 
@@ -318,13 +319,19 @@ import SwiftUI
       isLoadingTranslation = true
     }
     if preferredTranslationType != .useDeepl {
-        let translation: Translation? = try? await client.post(endpoint: Statuses.translate(id: finalStatus.id,
+      let translation: Translation? = try? await client.post(endpoint: Statuses.translate(id: finalStatus.id,
                                                                                           lang: userLang))
-        withAnimation {
-            self.translation = translation
-            isLoadingTranslation = false
-        }
+
       if translation == nil {
+        await translateWithDeepL(userLang: userLang)
+      } else {
+        withAnimation {
+          self.translation = translation
+          isLoadingTranslation = false
+        }
+      }
+
+      if self.translation == nil {
         instanceTranslationError = true
       }
     } else {
@@ -356,7 +363,7 @@ import SwiftUI
   }
 
   private var userAPIKey: String? {
-    DeepLUserAPIHandler.readKeyIfAllowed()
+    DeepLUserAPIHandler.readKey()
   }
 
   func updatePreferredTranslation() {

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowViewModel.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowViewModel.swift
@@ -354,7 +354,7 @@ import SwiftUI
   }
 
   private var userAPIKey: String? {
-    DeepLUserAPIHandler.readIfAllowed()
+    DeepLUserAPIHandler.readKeyIfAllowed()
   }
 
   func updatePreferredTranslation() {

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowTranslateView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowTranslateView.swift
@@ -2,6 +2,7 @@ import DesignSystem
 import Env
 import Models
 import SwiftUI
+import Translation
 
 @MainActor
 struct StatusRowTranslateView: View {
@@ -35,7 +36,8 @@ struct StatusRowTranslateView: View {
     }
   }
 
-  var body: some View {
+  @ViewBuilder
+  var translateButton: some View {
     if !isInCaptureMode,
        !isCompact,
        let userLang = preferences.serverPreferences?.postLanguage,
@@ -54,8 +56,26 @@ struct StatusRowTranslateView: View {
       }
       .buttonStyle(.borderless)
     }
+  }
 
-    if let translation = viewModel.translation, !viewModel.isLoadingTranslation {
+  @ViewBuilder
+  var generalTranslateButton: some View {
+    if #available(iOS 17.4, *) {
+      @Bindable var viewModel = viewModel
+      translateButton
+        .translationPresentation(isPresented: $viewModel.showAppleTranslation, text: viewModel.finalStatus.content.asRawText)
+    } else {
+      translateButton
+    }
+  }
+
+  var body: some View {
+    generalTranslateButton
+      .onChange(of: preferences.preferredTranslationType) { _, _ in
+        _ = viewModel.updatePreferredTranslation()
+      }
+
+    if let translation = viewModel.translation, !viewModel.isLoadingTranslation, preferences.preferredTranslationType != .useApple {
       GroupBox {
         VStack(alignment: .leading, spacing: 4) {
           Text(translation.content.asSafeMarkdownAttributedString)

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowTranslateView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowTranslateView.swift
@@ -65,7 +65,9 @@ struct StatusRowTranslateView: View {
   var body: some View {
     generalTranslateButton
       .onChange(of: preferences.preferredTranslationType) { _, _ in
-        _ = viewModel.updatePreferredTranslation()
+        withAnimation {
+          _ = viewModel.updatePreferredTranslation()
+        }
       }
 
     if let translation = viewModel.translation, !viewModel.isLoadingTranslation, preferences.preferredTranslationType != .useApple {

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowTranslateView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowTranslateView.swift
@@ -2,7 +2,6 @@ import DesignSystem
 import Env
 import Models
 import SwiftUI
-import Translation
 
 @MainActor
 struct StatusRowTranslateView: View {
@@ -60,13 +59,7 @@ struct StatusRowTranslateView: View {
 
   @ViewBuilder
   var generalTranslateButton: some View {
-    if #available(iOS 17.4, *) {
-      @Bindable var viewModel = viewModel
-      translateButton
-        .translationPresentation(isPresented: $viewModel.showAppleTranslation, text: viewModel.finalStatus.content.asRawText)
-    } else {
-      translateButton
-    }
+    translateButton
   }
 
   var body: some View {


### PR DESCRIPTION
Instead of just their instance and DeepL, the user has now the option between their instance, DeepL and Apple Translate. The user's previous choice (DeepL on / off) is reflected in the first value of the new setting and the old always_use_deepl App-Storage Key is deleted.
The option is only available on iOS 17.4 or later and not on Mac or Vision Pro. If the user is on an unsupported platform but the option to use Apple Translate is set, it's reset to use the instance.

This also includes a couple of fixes that aren't necessary for Apple Translate, but related:
- The background of the "Auto detect language" button is now consistent with all the other rows
- All loaded translations are removed if the translation type is switched
- A warning is shown to the user if they've switched away from using DeepL, but there's still an API key stored
- The spelling of "DeepL API Key" is unified, previously the "Key" was sometimes lowercase.

Tested on iPhone, iPad, Mac & visionOS Simulator