### PR TITLE
Resolve escaped characters in a status

### DIFF
--- a/Packages/Models/Sources/Models/Alias/HTMLString.swift
+++ b/Packages/Models/Sources/Models/Alias/HTMLString.swift
@@ -61,7 +61,7 @@ public struct HTMLString: Codable, Equatable, Hashable, @unchecked Sendable {
           _ = text.removeLast()
           _ = text.removeLast()
         }
-        asRawText = (try? Entities.unescape(text)) ?? ""
+        asRawText = (try? Entities.unescape(text)) ?? text
 
         if asMarkdown.hasPrefix("\n") {
           _ = asMarkdown.removeFirst()

--- a/Packages/Models/Sources/Models/Alias/HTMLString.swift
+++ b/Packages/Models/Sources/Models/Alias/HTMLString.swift
@@ -175,7 +175,9 @@ public struct HTMLString: Codable, Equatable, Hashable, @unchecked Sendable {
         return
       } else if node.nodeName() == "#text" {
         var txt = node.description
-
+        
+        txt = (try? Entities.unescape(txt)) ?? txt
+        
         if let underscore_regex, let main_regex {
           //  This is the markdown escaper
           txt = main_regex.stringByReplacingMatches(in: txt, options: [], range: NSRange(location: 0, length: txt.count), withTemplate: "\\\\$1")

--- a/Packages/Models/Sources/Models/Alias/HTMLString.swift
+++ b/Packages/Models/Sources/Models/Alias/HTMLString.swift
@@ -61,7 +61,7 @@ public struct HTMLString: Codable, Equatable, Hashable, @unchecked Sendable {
           _ = text.removeLast()
           _ = text.removeLast()
         }
-        asRawText = text
+        asRawText = (try? Entities.unescape(text)) ?? ""
 
         if asMarkdown.hasPrefix("\n") {
           _ = asMarkdown.removeFirst()


### PR DESCRIPTION
Escaped characters are now returned to their original form for HTMLString.asRawText. That's important for translating posts.
See https://osna.social/@Mordoukna/112082755067296741