### PR TITLE
Disable hashtag navigation for avoiding redundant fetching

### DIFF
--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -134,13 +134,17 @@ public enum SettingsStartingPoint {
 
   public var path: [RouterDestination] = []
   public var presentedSheet: SheetDestination?
+    public var currentDestination: RouterDestination?
 
   public static var settingsStartingPoint: SettingsStartingPoint? = nil
 
   public init() {}
 
   public func navigate(to: RouterDestination) {
-    path.append(to)
+      if currentDestination != to {
+          path.append(to)
+          currentDestination = to
+      }
   }
 
   public func handleStatus(status: AnyStatus, url: URL) -> OpenURLAction.Result {

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -27,25 +27,6 @@ public enum RouterDestination: Hashable {
   case notificationForAccount(accountId: String)
   case blockedAccounts
   case mutedAccounts
-
-  public static func == (lhs: RouterDestination, rhs: RouterDestination) -> Bool {
-    switch (lhs, rhs) {
-    case (.hashTag(let lhsTag, let lhsAccount), .hashTag(let rhsTag, let rhsAccount)):
-      return lhsTag.caseInsensitiveCompare(rhsTag) == .orderedSame && lhsAccount == rhsAccount
-    default:
-      return lhs.hashValue == rhs.hashValue
-    }
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    switch self {
-    case .hashTag(let tag, let account):
-      hasher.combine(tag.lowercased())
-      hasher.combine(account?.lowercased())
-    default:
-      hasher.combine(hashValue)
-    }
-  }
 }
 
 
@@ -161,12 +142,15 @@ public enum SettingsStartingPoint {
   public init() {}
 
   public func navigate(to: RouterDestination) {
+    if case .hashTag(let newTag, let newAccount) = to,
+       let currentDest = currentDestination,
+       case .hashTag(let currentTag, let currentAccount) = currentDest,
+       newTag.caseInsensitiveCompare(currentTag) == .orderedSame,
+       newAccount?.caseInsensitiveCompare(currentAccount ?? "") == .orderedSame {
+      return
+    }
+    
     if currentDestination != to {
-      if case .hashTag(let newTag, _) = to, let currentDest = currentDestination, case .hashTag(let currentTag, _) = currentDest {
-        if newTag.caseInsensitiveCompare(currentTag) == .orderedSame {
-          return
-        }
-      }
       path.append(to)
       currentDestination = to
     }


### PR DESCRIPTION
I noticed that you can navigate to the same hashtag that you are currently at, which ultimately can lead to memory bloating and, if done too many times, can freeze or crash the app. To better understand the situation I am referring to, check the linked issue.

This hopefully fixes the issue, modifying the `Router` file inside the `Env` package. These modifications disable navigation from the same destination you are currently at, it can be either hashtags (case-insensitively), user profiles, etc. Hopefully I am not introducing any bugs or performance issues!

- fixes #2082 