### PR TITLE
Make toolbar account selector button avatar match shape option.

### DIFF
--- a/IceCubesApp/App/Tabs/ToolbarTab.swift
+++ b/IceCubesApp/App/Tabs/ToolbarTab.swift
@@ -9,6 +9,7 @@ struct ToolbarTab: ToolbarContent {
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
   @Environment(UserPreferences.self) private var userPreferences
+  @Environment(Theme.self) private var theme
 
   @Binding var routerPath: RouterPath
 
@@ -35,7 +36,7 @@ struct ToolbarTab: ToolbarContent {
         (UIDevice.current.userInterfaceIdiom == .pad && horizontalSizeClass == .compact)
       {
         ToolbarItem(placement: .navigationBarLeading) {
-          AppAccountsSelectorView(routerPath: routerPath)
+          AppAccountsSelectorView(routerPath: routerPath, avatarConfig: theme.avatarShape == .circle ? .badge : .badgeRounded)
         }
       }
     }

--- a/Packages/DesignSystem/Sources/DesignSystem/Views/AvatarView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/AvatarView.swift
@@ -53,6 +53,7 @@ public struct AvatarView: View {
     #endif
     public static let embed = FrameConfig(width: 34, height: 34)
     public static let badge = FrameConfig(width: 28, height: 28, cornerRadius: 14)
+    public static let badgeRounded = FrameConfig(width: 28, height: 28)
     public static let list = FrameConfig(width: 20, height: 20, cornerRadius: 10)
     public static let boost = FrameConfig(width: 12, height: 12, cornerRadius: 6)
   }


### PR DESCRIPTION
## Description
Currently, the avatar shape display setting isn't applied to the account selector toolbar button. 

This PR adds an additional enum value `badgeRounded` to` AvatarView.FrameConfig` and observes the currently set `Theme.avatarShape` in `ToolbarTab` to set the appropriate `FrameConfig`.

## Before
![image](https://github.com/Dimillian/IceCubesApp/assets/35841468/66cd6d6d-dbd7-4829-b488-ec018eee030a)


## After
![Simulator Screenshot - iPhone 15 Pro - 2024-06-10 at 10 57 17](https://github.com/Dimillian/IceCubesApp/assets/35841468/a68e7005-e3a4-451b-8c0f-801459c6ae19)
