### PR TITLE
Clip StatusRowView to prevent media from hiding swipe action buttons

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -115,8 +115,9 @@ public struct StatusRowView: View {
           }
         }
       }
-      .padding(.init(top: isCompact ? 6 : 12, leading: 0, bottom: isFocused ? 12 : 6, trailing: 0))
+      .padding(.init(top: isCompact ? 6 : 12, leading: .layoutPadding, bottom: isFocused ? 12 : 6, trailing: .layoutPadding))
     }
+    .clipped()
     .onAppear {
       if !reasons.contains(.placeholder) {
         if !isCompact, viewModel.embeddedStatus == nil {
@@ -153,10 +154,7 @@ public struct StatusRowView: View {
     #else
     .listRowBackground(viewModel.highlightRowColor)
     #endif
-    .listRowInsets(.init(top: 0,
-                         leading: .layoutPadding,
-                         bottom: 0,
-                         trailing: .layoutPadding))
+    .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
     .accessibilityElement(children: isFocused ? .contain : .combine)
     .accessibilityLabel(isFocused == false && accessibilityVoiceOverEnabled
       ? StatusRowAccessibilityLabel(viewModel: viewModel).finalLabel() : Text(""))


### PR DESCRIPTION
## Description

When a status contains multiple images, they overlap with the swipe action buttons, hiding them.

Fixes #2106 

This PR clips the `StatusRowView` and switches the horizontal inset for horizontal padding.

At first, I only added the clipping. 

Unfortunately, due to the list inset, this made the content not go edge to edge, defeating what I guess was the desired effect of the feature. (See alternative solution for the result)

This is the reason why I also had to replace the list horizontal inset for the horizontal content padding.

## Before
![before](https://github.com/Dimillian/IceCubesApp/assets/183470/935034e9-3fc6-4308-a844-3f1f9fcf11c0)

 ## After
![fix](https://github.com/Dimillian/IceCubesApp/assets/183470/a3aee712-c942-410c-b9d5-c47fa0b7edf5)

 ## Alternative solution
![alternative](https://github.com/Dimillian/IceCubesApp/assets/183470/9113f813-507d-4b6e-bfea-2e939f14e0d5)


