### PR TITLE
AccountDetailView: fix white spacing on top of the view

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailView.swift
@@ -83,7 +83,7 @@ public struct AccountDetailView: View {
                          client: client,
                          routerPath: routerPath)
       }
-      .environment(\.defaultMinListRowHeight, 1)
+      .environment(\.defaultMinListRowHeight, 0)
       .listStyle(.plain)
       #if !os(visionOS)
         .scrollContentBackground(.hidden)


### PR DESCRIPTION
## Bug fix

-  Fix white spacing on top of the view

### Screenshots
<img width="382" alt="before_preview" src="https://github.com/Dimillian/IceCubesApp/assets/10476030/2f820743-1681-491a-b95e-0fc5b24b3db5">  <img width="382" alt="after_preview" src="https://github.com/Dimillian/IceCubesApp/assets/10476030/d10807fa-b382-456a-a2fc-79f14f1140e0"> 


