### PR TITLE
AccountDetail: fix wrong space on top of the header view

### DIFF
--- a/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
+++ b/Packages/Account/Sources/Account/AccountDetailHeaderView.swift
@@ -42,6 +42,7 @@ struct AccountDetailHeaderView: View {
         }
       }
       accountInfoView
+      Spacer()
     }
   }
 


### PR DESCRIPTION
## Bug

This should solves the following issue [#1973](https://github.com/Dimillian/IceCubesApp/issues/1973)
Reproduced by changing the font size from the iPhone settings.

### Screenshots

<img width="368" alt="before_preview" src="https://github.com/Dimillian/IceCubesApp/assets/10476030/d41507ed-d2f2-4a35-9595-dcd194a2189a">  <img width="368" alt="after_preview" src="https://github.com/Dimillian/IceCubesApp/assets/10476030/72cf9da4-e360-4016-8436-c7388d4227a2">



