### PR TITLE
Fix nav bar crash and empty settings screen after logout

### DIFF
--- a/IceCubesApp/App/Main/AppView.swift
+++ b/IceCubesApp/App/Main/AppView.swift
@@ -122,6 +122,7 @@ struct AppView: View {
                 .tag(tab)
             }
           }
+          .id(availableTabs.count) /// Resets the TabView state when the number of tabs changes to avoid navigation bar issues and prevent crashes
           .introspect(.tabView, on: .iOS(.v17)) { (tabview: UITabBarController) in
             tabview.tabBar.isHidden = horizontalSizeClass == .regular
             tabview.customizableViewControllers = []


### PR DESCRIPTION

The settings screen is empty after logout as it seen in the video. It may be related dynamic tab view count. 

In that video the buggy one:
https://github.com/Dimillian/IceCubesApp/assets/78085814/c7b3c868-90ca-465e-9a84-32a895bc7fce

Here is the resolved one:

https://github.com/Dimillian/IceCubesApp/assets/78085814/165eab65-b1d8-4366-87ff-9927e7fe6dc2

There was a weird crash sometimes related UINavigationBar such as `*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Layout requested for visible navigation bar, <SwiftUI.UIKitNavigationBar: 0x109f91080; baseClass = UINavigationBar; frame = (0 24; 933.5 50); opaque = NO; autoresize = W; gestureRecognizers = <NSArray: 0x600000d7cea0>; layer = <CALayer: 0x6000005340a0>> delegate=0x135272800 standardAppearance=0x60000a62f180, when the top item belongs to a different navigation bar. topItem = <UINavigationItem: 0x12f5b3f10> title='@ozsayin' titleView=0x166b8b000 style=navigator leftItemsSupplementBackButton largeTitleDisplayMode=always, navigation bar = <SwiftUI.UIKitNavigationBar: 0x165ef79d0; baseClass = UINavigationBar; frame = (0 24; 533 50); opaque = NO; autoresize = W; userInteractionEnabled = NO; gestureRecognizers = <NSArray: 0x600000e1f060>; layer = <CALayer: 0x60000059acc0>> delegate=0x10acc9600 standardAppearance=0x60000a6cff00, possibly from a client attempt to nest wrapped navigation controllers.'`

That is resolved too .