### PR TITLE
AddRemoteTimelineView: show invalid instance error (#2105)

### DIFF
--- a/IceCubesApp/App/Tabs/Timeline/AddRemoteTimelineView.swift
+++ b/IceCubesApp/App/Tabs/Timeline/AddRemoteTimelineView.swift
@@ -37,6 +37,11 @@ struct AddRemoteTimelineView: View {
             .foregroundColor(.green)
             .listRowBackground(theme.primaryBackgroundColor)
         }
+        if !instanceName.isEmpty && instance == nil {
+          Label("timeline.\(instanceName)-not-valid", systemImage: "xmark.seal.fill")
+            .foregroundColor(.red)
+            .listRowBackground(theme.primaryBackgroundColor)
+        }
         Button {
           guard instance != nil else { return }
           context.insert(LocalTimeline(instance: instanceName))
@@ -45,6 +50,7 @@ struct AddRemoteTimelineView: View {
           Text("timeline.add.action.add")
         }
         .listRowBackground(theme.primaryBackgroundColor)
+        .disabled(instance == nil)
 
         instancesListView
       }

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -701,6 +701,17 @@
         }
       }
     },
+    "%@ ist keine valide Instanz" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ не є дійсним екземпляром"
+          }
+        }
+      }
+    },
     "%@ was posted on Mastodon" : {
       "localizations" : {
         "de" : {
@@ -78827,6 +78838,125 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 有效"
+          }
+        }
+      }
+    },
+    "timeline.%@-not-valid" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "be" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ не з'яўляецца сапраўдным прыкладам"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ no és una instància vàlida"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ist keine gültige Instanz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is not a valid instance"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is not a valid instance"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ no es una instancia válida"
+          }
+        },
+        "eu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ez da baliozko instantzia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ n'est pas une instance valide"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ non è un'istanza valida"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 有効なインスタンスではありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 유효한 인스턴스가 아닙니다"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ er ikke en gyldig instans"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is geen geldige instantie"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ nie jest poprawnym serwerem"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ não é uma instância válida"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ geçerli bir örnek değil"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ немає коректний сервера"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不是一个有效的实例"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不是一個有效的實例"
           }
         }
       }


### PR DESCRIPTION
The change generates an error message if the entered instance is not valid, and the Add button is then disabled. The error message is localized with the help of ChatGPT and Deepl Translator. 

<img width="392" alt="image" src="https://github.com/user-attachments/assets/3cbaac73-1741-4080-a682-4c9f8d11f80d">

