### PR TITLE
AddAccountView: fix error handling

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/AddAccountsView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AddAccountsView.swift
@@ -136,11 +136,12 @@ struct AddAccountView: View {
                 instance = nil
                 instanceFetchError = nil
               }
-            } catch _ as DecodingError {
+            } catch _ as ServerError {
               instance = nil
               instanceFetchError = "account.add.error.instance-not-supported"
             } catch {
               instance = nil
+              instanceFetchError = nil
             }
           }
         }


### PR DESCRIPTION
In `Client > makeEntityRequest`, every `DecodingError` is transformed into a `ServerError`, causing the error handling in `AddAccountsView` to fail. This change fixes that issue.