### PR TITLE
Add context menu and draggability to attachment image views

### DIFF
--- a/Packages/MediaUI/Sources/MediaUI/MediaUIAttachmentImageView.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIAttachmentImageView.swift
@@ -22,6 +22,7 @@ struct MediaUIAttachmentImageView: View {
             .progressViewStyle(.circular)
         }
       }
+      .draggable(MediaUIImageTransferable(url: url))
       .contextMenu {
         MediaUIShareLink(url: url, type: .image)
       }

--- a/Packages/MediaUI/Sources/MediaUI/MediaUIAttachmentImageView.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIAttachmentImageView.swift
@@ -25,6 +25,19 @@ struct MediaUIAttachmentImageView: View {
       .draggable(MediaUIImageTransferable(url: url))
       .contextMenu {
         MediaUIShareLink(url: url, type: .image)
+        Button {
+          Task {
+            let transferable = MediaUIImageTransferable(url: url)
+            UIPasteboard.general.image = UIImage(data: await transferable.fetchData())
+          }
+        } label: {
+          Label("status.media.contextmenu.copy", systemImage: "doc.on.doc")
+        }
+        Button {
+          UIPasteboard.general.url = url
+        } label: {
+          Label("status.action.copy-link", systemImage: "link")
+        }
       }
     }
   }

--- a/Packages/MediaUI/Sources/MediaUI/MediaUIAttachmentImageView.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIAttachmentImageView.swift
@@ -22,6 +22,9 @@ struct MediaUIAttachmentImageView: View {
             .progressViewStyle(.circular)
         }
       }
+      .contextMenu {
+        MediaUIShareLink(url: url, type: .image)
+      }
     }
   }
 }

--- a/Packages/MediaUI/Sources/MediaUI/MediaUIShareLink.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIShareLink.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct MediaUIShareLink: View, @unchecked Sendable {
+  let url: URL
+  let type: DisplayType
+
+  var body: some View {
+    if type == .image {
+      let transferable = MediaUIImageTransferable(url: url)
+      ShareLink(item: transferable, preview: .init("status.media.contextmenu.share",
+                                                   image: transferable))
+    } else {
+      ShareLink(item: url)
+    }
+  }
+}

--- a/Packages/MediaUI/Sources/MediaUI/ShareToolbarItem.swift
+++ b/Packages/MediaUI/Sources/MediaUI/ShareToolbarItem.swift
@@ -6,13 +6,7 @@ struct ShareToolbarItem: ToolbarContent, @unchecked Sendable {
 
   var body: some ToolbarContent {
     ToolbarItem(placement: .topBarTrailing) {
-      if type == .image {
-        let transferable = MediaUIImageTransferable(url: url)
-        ShareLink(item: transferable, preview: .init("status.media.contextmenu.share",
-                                                     image: transferable))
-      } else {
-        ShareLink(item: url)
-      }
+      MediaUIShareLink(url: url, type: type)
     }
   }
 }


### PR DESCRIPTION
This adds a context menu and the standard drag gesture to attachment images:

https://github.com/user-attachments/assets/c26d98b7-f6b6-4885-a879-3f493b139c1a