### PR TITLE
Replaced to async method for URLSessionWebSocketTask.receive().

### DIFF
--- a/IceCubesApp/App/Main/IceCubesApp+Scene.swift
+++ b/IceCubesApp/App/Main/IceCubesApp+Scene.swift
@@ -71,7 +71,9 @@ extension IceCubesApp {
     .onChange(of: appAccountsManager.currentClient) { _, newValue in
       setNewClientsInEnv(client: newValue)
       if newValue.isAuth {
-        watcher.watch(streams: [.user, .direct])
+        Task {
+          await watcher.watch(streams: [.user, .direct])
+        }
       }
     }
   }

--- a/IceCubesApp/App/Main/IceCubesApp.swift
+++ b/IceCubesApp/App/Main/IceCubesApp.swift
@@ -44,8 +44,8 @@ struct IceCubesApp: App {
     userPreferences.setClient(client: client)
     Task {
       await currentInstance.fetchCurrentInstance()
-      watcher.setClient(client: client, instanceStreamingURL: currentInstance.instance?.urls?.streamingApi)
-      watcher.watch(streams: [.user, .direct])
+      await watcher.setClient(client: client, instanceStreamingURL: currentInstance.instance?.urls?.streamingApi)
+      await watcher.watch(streams: [.user, .direct])
     }
   }
 
@@ -54,10 +54,10 @@ struct IceCubesApp: App {
     case .background:
       watcher.stopWatching()
     case .active:
-      watcher.watch(streams: [.user, .direct])
-      UNUserNotificationCenter.current().setBadgeCount(0)
-      userPreferences.reloadNotificationsCount(tokens: appAccountsManager.availableAccounts.compactMap(\.oauthToken))
       Task {
+        await watcher.watch(streams: [.user, .direct])
+        try? await UNUserNotificationCenter.current().setBadgeCount(0)
+        userPreferences.reloadNotificationsCount(tokens: appAccountsManager.availableAccounts.compactMap(\.oauthToken))
         await userPreferences.refreshServerPreferences()
       }
     default:


### PR DESCRIPTION
Using MainActor properties in an unstructured task would cause build errors in Swift 6, so `URLSessionWebSocketTask.receive(completionHandler:)` was replaced with ` URLSessionWebSocketTask.receive() async throws`.