### PR TITLE
Collapse posts on tap (Apollo-style)

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Detail/StatusDetailView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Detail/StatusDetailView.swift
@@ -113,12 +113,15 @@ public struct StatusDetailView: View {
     .navigationBarTitleDisplayMode(.inline)
   }
 
+  @ViewBuilder
   private func makeStatusesListView(statuses: [Status]) -> some View {
-    ForEach(statuses) { status in
+    let collapsedIds = viewModel.hierarchyCollapseState.implicitlyCollapsedStatusIds(for: statuses)
+    ForEach(statuses.filter { !collapsedIds.contains($0.id) }) { status in
       let (indentationLevel, extraInsets) = viewModel.getIndentationLevel(id: status.id, maxIndent: userPreferences.getRealMaxIndent())
       let viewModel: StatusRowViewModel = .init(status: status,
                                                 client: client,
                                                 routerPath: routerPath,
+                                                hierarchyCollapseState: viewModel.hierarchyCollapseState,
                                                 scrollToId: $viewModel.scrollToId)
       let isFocused = self.viewModel.statusId == status.id
 

--- a/Packages/StatusKit/Sources/StatusKit/Detail/StatusDetailViewModel.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Detail/StatusDetailViewModel.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
   var client: Client?
   var routerPath: RouterPath?
+    
+  let hierarchyCollapseState = StatusHierarchyCollapseState()
 
   enum State {
     case loading, display(statuses: [Status]), error(error: Error)

--- a/Packages/StatusKit/Sources/StatusKit/Hierarchy/StatusHierarchyCollapseStatus.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Hierarchy/StatusHierarchyCollapseStatus.swift
@@ -1,0 +1,24 @@
+import Observation
+import Models
+
+@MainActor
+@Observable public class StatusHierarchyCollapseState {
+    public var explicitlyCollapsedStatusIds: Set<String>
+    
+    public init(explicitlyCollapsedStatusIds: Set<String> = []) {
+        self.explicitlyCollapsedStatusIds = explicitlyCollapsedStatusIds
+    }
+    
+    public func implicitlyCollapsedStatusIds(for statuses: [Status]) -> Set<String> {
+        let childs: [String: [String]] = Dictionary(
+            grouping: statuses.filter { $0.inReplyToId != nil },
+            by: { $0.inReplyToId! }
+        ).mapValues { $0.map(\.id) }
+        
+        func descendants(for id: String) -> [String] {
+            (childs[id] ?? []).flatMap { [$0] + descendants(for: $0) }
+        }
+        
+        return Set(explicitlyCollapsedStatusIds.flatMap(descendants(for:)))
+    }
+}

--- a/Packages/StatusKit/Sources/StatusKit/List/StatusesListView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/List/StatusesListView.swift
@@ -29,9 +29,7 @@ public struct StatusesListView<Fetcher>: View where Fetcher: StatusesFetcher {
     switch fetcher.statusesState {
     case .loading:
       ForEach(Status.placeholders()) { status in
-        StatusRowView(viewModel: .init(status: status,
-                                       client: client,
-                                       routerPath: routerPath),
+        StatusRowView(viewModel: .init(status: status, client: client, routerPath: routerPath),
                       context: .timeline)
           .redacted(reason: .placeholder)
           .allowsHitTesting(false)

--- a/Packages/StatusKit/Sources/StatusKit/List/StatusesListView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/List/StatusesListView.swift
@@ -29,7 +29,9 @@ public struct StatusesListView<Fetcher>: View where Fetcher: StatusesFetcher {
     switch fetcher.statusesState {
     case .loading:
       ForEach(Status.placeholders()) { status in
-        StatusRowView(viewModel: .init(status: status, client: client, routerPath: routerPath),
+        StatusRowView(viewModel: .init(status: status,
+                                       client: client,
+                                       routerPath: routerPath),
                       context: .timeline)
           .redacted(reason: .placeholder)
           .allowsHitTesting(false)

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -89,8 +89,7 @@ public struct StatusRowView: View {
               StatusRowContentView(viewModel: viewModel)
                 .contentShape(Rectangle())
                 .onTapGesture {
-                  guard !isFocused else { return }
-                  viewModel.navigateToDetail()
+                  handleTap()
                 }
                 .accessibilityActions {
                   if isFocused, viewModel.showActions {
@@ -161,8 +160,7 @@ public struct StatusRowView: View {
       ? StatusRowAccessibilityLabel(viewModel: viewModel).finalLabel() : Text(""))
     .accessibilityHidden(viewModel.filter?.filter.filterAction == .hide)
     .accessibilityAction {
-      guard !isFocused else { return }
-      viewModel.navigateToDetail()
+      handleTap()
     }
     .accessibilityActions {
       if !isFocused, viewModel.showActions, accessibilityVoiceOverEnabled {
@@ -173,8 +171,7 @@ public struct StatusRowView: View {
       Color.clear
         .contentShape(Rectangle())
         .onTapGesture {
-          guard !isFocused else { return }
-          viewModel.navigateToDetail()
+          handleTap()
         }
     }
     .overlay {
@@ -347,6 +344,11 @@ public struct StatusRowView: View {
     }
     .background(Color.black.opacity(0.40))
     .transition(.opacity)
+  }
+    
+  private func handleTap() {
+    guard !isFocused else { return }
+    viewModel.navigateToDetail()
   }
 }
 

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -348,7 +348,11 @@ public struct StatusRowView: View {
     
   private func handleTap() {
     guard !isFocused else { return }
-    viewModel.navigateToDetail()
+    if indentationLevel > 0, viewModel.hierarchyCollapseState != nil {
+      viewModel.isHierarchyExplicitlyCollapsed.toggle()
+    } else {
+      viewModel.navigateToDetail()
+    }
   }
 }
 

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -86,16 +86,18 @@ public struct StatusRowView: View {
               if !isCompact {
                 StatusRowHeaderView(viewModel: viewModel)
               }
-              StatusRowContentView(viewModel: viewModel)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                  handleTap()
-                }
-                .accessibilityActions {
-                  if isFocused, viewModel.showActions {
-                    accessibilityActions
+              if !viewModel.isHierarchyExplicitlyCollapsed {
+                StatusRowContentView(viewModel: viewModel)
+                  .contentShape(Rectangle())
+                  .onTapGesture {
+                    handleTap()
                   }
-                }
+                  .accessibilityActions {
+                    if isFocused, viewModel.showActions {
+                      accessibilityActions
+                    }
+                  }
+              }
               if !reasons.contains(.placeholder),
                  viewModel.showActions, isFocused || theme.statusActionsDisplay != .none,
                  !isInCaptureMode

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -349,7 +349,9 @@ public struct StatusRowView: View {
   private func handleTap() {
     guard !isFocused else { return }
     if indentationLevel > 0, viewModel.hierarchyCollapseState != nil {
-      viewModel.isHierarchyExplicitlyCollapsed.toggle()
+      withAnimation {
+        viewModel.isHierarchyExplicitlyCollapsed.toggle()
+      }
     } else {
       viewModel.navigateToDetail()
     }

--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowViewModel.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowViewModel.swift
@@ -18,6 +18,8 @@ import SwiftUI
 
   let client: Client
   let routerPath: RouterPath
+  
+  let hierarchyCollapseState: StatusHierarchyCollapseState?
 
   let userFollowedTag: HTMLString.Link?
 
@@ -64,6 +66,20 @@ import SwiftUI
          relationship.blocking || relationship.muting
       {
         lineLimit = 0
+      }
+    }
+  }
+  
+  // toggled on tap, collapses the post with its hierarchy of replies
+  var isHierarchyExplicitlyCollapsed: Bool {
+    get {
+      hierarchyCollapseState?.explicitlyCollapsedStatusIds.contains(status.id) ?? false
+    }
+    set {
+      if newValue {
+        hierarchyCollapseState?.explicitlyCollapsedStatusIds.insert(status.id)
+      } else {
+        hierarchyCollapseState?.explicitlyCollapsedStatusIds.remove(status.id)
       }
     }
   }
@@ -162,6 +178,7 @@ import SwiftUI
   public init(status: Status,
               client: Client,
               routerPath: RouterPath,
+              hierarchyCollapseState: StatusHierarchyCollapseState? = nil,
               isRemote: Bool = false,
               showActions: Bool = true,
               textDisabled: Bool = false,
@@ -171,6 +188,7 @@ import SwiftUI
     finalStatus = status.reblog ?? status
     self.client = client
     self.routerPath = routerPath
+    self.hierarchyCollapseState = hierarchyCollapseState
     self.isRemote = isRemote
     self.showActions = showActions
     self.textDisabled = textDisabled


### PR DESCRIPTION
### Fixes #1950

With this PR threads are now collapsed instead of focused when tapped:

https://github.com/user-attachments/assets/6adfdf4f-3928-40f8-9daf-07a83006d31b

This is similar to how apps like Apollo, Mlem and other apps with hierarchical comments handle this. In its current state, the PR _replaces_ the focus-on-tap behavior for any indented replies, if desired, I could see a few ways of reconciling the old/current behavior with this though:

- Provide a focus action as a separate context menu
- Provide a setting for changing the "tap" action (i.e. focus or collapse)
  - Perhaps we could rename the "Swipe Actions" settings to a more general "Gestures" and put it there?

Would love to hear some thoughts!