### PR TITLE
Enable "GraphReuseLogging" for Debug build

### DIFF
--- a/IceCubesApp/App/Main/IceCubesApp.swift
+++ b/IceCubesApp/App/Main/IceCubesApp.swift
@@ -34,6 +34,14 @@ struct IceCubesApp: App {
 
   @State var isSupporter: Bool = false
 
+  init() {
+    #if DEBUG
+    // Enable "GraphReuseLogging" for debugging purpose
+    // subsystem: "com.apple.SwiftUI" category: "GraphReuse"
+    UserDefaults.standard.register(defaults: ["com.apple.SwiftUI.GraphReuseLogging": true])
+    #endif
+  }
+
   var body: some Scene {
     appScene
     otherScenes


### PR DESCRIPTION
Example result

![image](https://github.com/user-attachments/assets/e60d8521-5227-4ea0-8cb0-738b83f2d48f)

Useful for SwiftUI developer when SwiftUI.List fail to reuse something.