### PR TITLE
MediaUIView - Fix image download bug (#2131)

### DIFF
--- a/IceCubesApp.xcodeproj/project.pbxproj
+++ b/IceCubesApp.xcodeproj/project.pbxproj
@@ -1545,7 +1545,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Upload photos & videos to attach to your Mastodon posts.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "© 2024 Thomas Ricouard";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Ice Cubes would like to save the selected photo in your photo library.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Upload photos & videos to Mastodon";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -1612,7 +1612,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Upload photos & videos to attach to your Mastodon posts.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "© 2024 Thomas Ricouard";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Ice Cubes would like to save the selected photo in your photo library.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Upload photos & videos to Mastodon";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/IceCubesApp.xcodeproj/project.pbxproj
+++ b/IceCubesApp.xcodeproj/project.pbxproj
@@ -1545,6 +1545,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Upload photos & videos to attach to your Mastodon posts.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "© 2024 Thomas Ricouard";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Upload photos & videos to Mastodon";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -1611,6 +1612,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Upload photos & videos to attach to your Mastodon posts.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "© 2024 Thomas Ricouard";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Upload photos & videos to Mastodon";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/IceCubesApp/App/IceCubesApp-release.entitlements
+++ b/IceCubesApp/App/IceCubesApp-release.entitlements
@@ -28,6 +28,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(BUNDLE_ID_PREFIX).IceCubesApp</string>

--- a/IceCubesApp/App/IceCubesApp.entitlements
+++ b/IceCubesApp/App/IceCubesApp.entitlements
@@ -28,6 +28,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(BUNDLE_ID_PREFIX).IceCubesApp</string>

--- a/Packages/MediaUI/Sources/MediaUI/MediaUIView.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIView.swift
@@ -185,17 +185,17 @@ private struct SavePhotoToolbarItem: ToolbarContent, @unchecked Sendable {
   }
   
   private func saveImage(url: URL) async -> Bool {
+    guard let image = try? await uiimageFor(url: url) else { return false }
+    
     var status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
     
-    if let image = try? await uiimageFor(url: url) {
-      if status != .authorized {
-        await PHPhotoLibrary.requestAuthorization(for: .addOnly)
-        status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
-      }
-      if status == .authorized {
-        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
-        return true
-      }
+    if status != .authorized {
+      await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+      status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
+    }
+    if status == .authorized {
+      UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+      return true
     }
     return false
   }

--- a/Packages/MediaUI/Sources/MediaUI/MediaUIView.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIView.swift
@@ -3,6 +3,7 @@ import Models
 import Nuke
 import QuickLook
 import SwiftUI
+import Photos
 
 public struct MediaUIView: View, @unchecked Sendable {
   private let data: [DisplayData]
@@ -144,6 +145,8 @@ private struct SavePhotoToolbarItem: ToolbarContent, @unchecked Sendable {
                   state = .unsaved
                 }
               }
+            } else {
+              state = .unsaved
             }
           }
         } label: {
@@ -180,11 +183,19 @@ private struct SavePhotoToolbarItem: ToolbarContent, @unchecked Sendable {
     }
     return nil
   }
-
+  
   private func saveImage(url: URL) async -> Bool {
+    var status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
+    
     if let image = try? await uiimageFor(url: url) {
-      UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
-      return true
+      if status != .authorized {
+        await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
+      }
+      if status == .authorized {
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+        return true
+      }
     }
     return false
   }


### PR DESCRIPTION
If the user has not yet granted permission to download photos, they will be asked to do so: `PHPhotoLibrary.requestAuthorization(for: .addOnly)`. Afterward, the photos can also be downloaded to the desktop. Previously, broader access was granted (`requestAuthorization(_:)`), but this method is now deprecated. Apparently, Mac Catalyst support for more advanced permission checks is still not fully developed. Once permission is denied, it can no longer be granted in the settings. You have to do it via a terminal command: `'tccutil reset PhotosAdd <your.app.bundle.identifier>'`.