### PR TITLE
Initial Akkoma support

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/InstanceInfoView.swift
+++ b/IceCubesApp/App/Tabs/Settings/InstanceInfoView.swift
@@ -28,7 +28,11 @@ public struct InstanceInfoSection: View {
   public var body: some View {
     Section("instance.info.section.info") {
       LabeledContent("instance.info.name", value: instance.title)
-      Text(instance.shortDescription)
+      if instance.shortDescription != nil {
+        Text(instance.shortDescription!)
+      } else if instance.description != nil {
+        Text(instance.description!)
+      }
       LabeledContent("instance.info.email", value: instance.email)
       LabeledContent("instance.info.version") {
         Text(instance.version).monospaced()

--- a/Packages/Models/Sources/Models/Account.swift
+++ b/Packages/Models/Sources/Models/Account.swift
@@ -26,7 +26,7 @@ public final class Account: Codable, Identifiable, Hashable, Sendable, Equatable
   }
 
   public struct Source: Codable, Equatable, Sendable {
-    public let privacy: Visibility
+    public let privacy: Visibility?
     public let sensitive: Bool
     public let language: String?
     public let note: String

--- a/Packages/Models/Sources/Models/Card.swift
+++ b/Packages/Models/Sources/Models/Card.swift
@@ -22,8 +22,8 @@ public struct Card: Codable, Identifiable, Equatable, Hashable {
   public let providerName: String?
   public let type: String
   public let image: URL?
-  public let width: CGFloat
-  public let height: CGFloat
+  public let width: CGFloat?
+  public let height: CGFloat?
   public let history: [History]?
   public let authors: [CardAuthor]?
 }

--- a/Packages/Models/Sources/Models/Instance.swift
+++ b/Packages/Models/Sources/Models/Instance.swift
@@ -34,7 +34,8 @@ public struct Instance: Codable, Sendable {
   }
 
   public let title: String
-  public let shortDescription: String
+  public let description: String?
+  public let shortDescription: String?
   public let email: String
   public let version: String
   public let stats: Stats

--- a/Packages/Models/Sources/Models/Tag.swift
+++ b/Packages/Models/Sources/Models/Tag.swift
@@ -19,11 +19,27 @@ public struct Tag: Codable, Identifiable, Equatable, Hashable {
   public let history: [History]
 
   public var totalUses: Int {
-    history.compactMap { Int($0.uses) }.reduce(0, +)
+    return history.compactMap { Int($0.uses) }.reduce(0, +)
   }
 
   public var totalAccounts: Int {
-    history.compactMap { Int($0.accounts) }.reduce(0, +)
+    return history.compactMap { Int($0.accounts) }.reduce(0, +)
+  }
+  
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    name = try container.decode(String.self, forKey: .name)
+    url = try container.decode(String.self, forKey: .url)
+    do {
+      history = try container.decode([History].self, forKey: .history)
+    } catch DecodingError.keyNotFound {
+      history = []
+    }
+    do {
+      following = try container.decode(Bool.self, forKey: .following)
+    } catch DecodingError.keyNotFound {
+      following = false
+    }
   }
 }
 

--- a/Packages/Network/Sources/Network/Endpoint/Apps.swift
+++ b/Packages/Network/Sources/Network/Endpoint/Apps.swift
@@ -1,6 +1,13 @@
 import Foundation
 import Models
 
+private struct InstanceAppRequest: Codable, Sendable {
+  public let clientName: String
+  public let redirectUris: String
+  public let scopes: String
+  public let website: String
+}
+
 public enum Apps: Endpoint {
   case registerApp
 
@@ -10,16 +17,15 @@ public enum Apps: Endpoint {
       "apps"
     }
   }
-
+  
   public func queryItems() -> [URLQueryItem]? {
+    nil
+  }
+
+  public var jsonValue: Encodable? {
     switch self {
     case .registerApp:
-      [
-        .init(name: "client_name", value: AppInfo.clientName),
-        .init(name: "redirect_uris", value: AppInfo.scheme),
-        .init(name: "scopes", value: AppInfo.scopes),
-        .init(name: "website", value: AppInfo.weblink),
-      ]
+      InstanceAppRequest(clientName: AppInfo.clientName, redirectUris: AppInfo.scheme, scopes: AppInfo.scopes, website: AppInfo.weblink)
     }
   }
 }

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowCardView.swift
@@ -113,7 +113,7 @@ public struct StatusRowCardView: View {
   @ViewBuilder
   private func defaultLinkPreview(_ title: String, _ url: URL) -> some View {
     if let imageURL = card.image {
-      DefaultPreviewImage(url: imageURL, originalWidth: card.width, originalHeight: card.height)
+      DefaultPreviewImage(url: imageURL, originalWidth: card.width ?? 0, originalHeight: card.height ?? 0)
     }
 
     VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
First time using Swift, please be patient with me :)
I've added some initial support for Akkoma here. You can browse pretty much everything just fine. Most of the incompatibilities were caused by keys not existing in Akkoma which are required by IceCubes. Another notable issue was that the endpoint to register apps can't handle being passed query parameters, so I've switched to using a JSON body- Very very unsure about how I'm doing that though, it works but having no experience with Swift I'm doubtful I've done this the best.
I'm aware of at least one thing remaining, and I don't doubt other problems exist too- In the logs, I was getting errors about the notification push endpoint not being supported.

I think this is pretty usable, just needing some polishing up to actually do things "correctly". Let me know!