### PR TITLE
Fix the version that supports editing

### DIFF
--- a/Packages/Env/Sources/Env/CurrentInstance.swift
+++ b/Packages/Env/Sources/Env/CurrentInstance.swift
@@ -28,7 +28,7 @@ import Observation
   }
 
   public var isEditSupported: Bool {
-    version >= 4
+    version >= 3.5
   }
 
   public var isEditAltTextSupported: Bool {


### PR DESCRIPTION
The version that supports editing is assumed to be from version 4.0 onwards. But in fact Mastodon has actually supported editing since 3.5.

Mastodon Changelog: [Mastodon 3.5](https://blog.joinmastodon.org/2022/03/mastodon-3.5/)