### PR TITLE
Fix long tap on follower/following rows

### DIFF
--- a/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
+++ b/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
@@ -1,3 +1,4 @@
+import AppAccount
 import Combine
 import DesignSystem
 import EmojiText
@@ -27,6 +28,8 @@ public struct AccountsListRow: View {
   @Environment(RouterPath.self) private var routerPath
   @Environment(Client.self) private var client
   @Environment(QuickLook.self) private var quickLook
+  @Environment(StreamWatcher.self) private var watcher
+  @Environment(AppAccountsManager.self) private var appAccount
 
   @State var viewModel: AccountsListRowViewModel
 
@@ -149,6 +152,8 @@ public struct AccountsListRow: View {
       .environment(client)
       .environment(quickLook)
       .environment(routerPath)
+      .environment(watcher)
+      .environment(appAccount)
     }
   }
 }


### PR DESCRIPTION
## What's changed
Some environment objects were missing, so the context menu couldn't open.
Now we're passing all the required environment objects to the context menu.

Fixes #2271

[Simulator Screenshot - iPhone 16 Pro - 2025-06-02 at 20 52 50](https://github.com/user-attachments/assets/2a9bfd5f-8876-4726-8f6b-f32965a385fe)