### PR TITLE
Add max width to StatusRowView for improved readability on large screens

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/StatusRowView.swift
@@ -121,6 +121,8 @@ public struct StatusRowView: View {
           }
         }
       }
+      .frame(maxWidth: 1000)
+      .frame(maxWidth: .infinity, alignment: .center)
       .padding(.init(top: isCompact ? 6 : 12, leading: 0, bottom: isFocused ? 12 : 6, trailing: 0))
     }
     .onAppear {


### PR DESCRIPTION
Limits StatusRowView’s width to 1000 points to prevent overly long lines of text, enhancing readability on larger screens. This helps users read content more comfortably by keeping line lengths at an optimal width.

### Before

<img width="1624" alt="before" src="https://github.com/user-attachments/assets/9224cf56-3123-4328-8734-9a39f536f2b2" />

### After
<img width="1624" alt="after" src="https://github.com/user-attachments/assets/2c9a5671-da73-44d3-af0a-be1de98e2c3e" />
