### PR TITLE
Implement background image upload and post

### DIFF
--- a/IceCubesAppIntents/AppShortcuts.swift
+++ b/IceCubesAppIntents/AppShortcuts.swift
@@ -21,6 +21,16 @@ struct AppShortcuts: AppShortcutsProvider {
       systemImageName: "square.and.pencil"
     )
     AppShortcut(
+      intent: InlinePostImageIntent(),
+      phrases: [
+        "Send images with \(.applicationName)",
+        "Send an image with \(.applicationName)",
+        "Post photos on Mastodon with \(.applicationName)",
+      ],
+      shortTitle: "Send image(s) (background)",
+      systemImageName: "photo.on.rectangle.angled"
+    )
+    AppShortcut(
       intent: TabIntent(),
       phrases: [
         "Open \(.applicationName)"

--- a/IceCubesAppIntents/InlinePostImageIntent.swift
+++ b/IceCubesAppIntents/InlinePostImageIntent.swift
@@ -1,0 +1,76 @@
+import AppAccount
+import AppIntents
+import Env
+import Foundation
+import Models
+import NetworkClient
+import UniformTypeIdentifiers
+
+struct InlinePostImageIntent: AppIntent {
+  static let title: LocalizedStringResource = "Send image(s) to Mastodon"
+  static let description: IntentDescription = "Send an image or multiple images to Mastodon with Ice Cubes without opening the app"
+  static let openAppWhenRun: Bool = false
+
+  @Parameter(title: "Account", requestValueDialog: IntentDialog("Account"))
+  var account: AppAccountEntity
+
+  @Parameter(title: "Post visibility", requestValueDialog: IntentDialog("Visibility of your post"))
+  var visibility: PostVisibility
+
+  @Parameter(
+    title: "Images",
+    description: "Image(s) to post on Mastodon",
+    supportedContentTypes: [.image, .jpeg, .png, .gif, .heic],
+    inputConnectionBehavior: .connectToPreviousIntentResult)
+  var images: [IntentFile]
+
+  @Parameter(
+    title: "Caption",
+    requestValueDialog: IntentDialog("Caption for your post"))
+  var caption: String?
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
+    guard !images.isEmpty else {
+      return .result(dialog: "No images provided to post.")
+    }
+
+    let client = MastodonClient(
+      server: account.account.server,
+      version: .v1,
+      oauthToken: account.account.oauthToken)
+
+    do {
+      var mediaIds: [String] = []
+      for file in images {
+        guard let url = file.fileURL else { continue }
+        let data = try Data(contentsOf: url)
+        let mimeType: String = {
+          if let ut = UTType(filenameExtension: url.pathExtension), let mt = ut.preferredMIMEType {
+            return mt
+          } else {
+            return "application/octet-stream"
+          }
+        }()
+        let media: MediaAttachment = try await client.mediaUpload(
+          endpoint: Media.medias,
+          version: .v2,
+          method: "POST",
+          mimeType: mimeType,
+          filename: url.lastPathComponent.isEmpty ? "file" : url.lastPathComponent,
+          data: data)
+        mediaIds.append(media.id)
+      }
+
+      let statusText = caption ?? ""
+      let statusData = StatusData(
+        status: statusText,
+        visibility: visibility.toAppVisibility,
+        mediaIds: mediaIds)
+      let _: Status = try await client.post(endpoint: Statuses.postStatus(json: statusData))
+      return .result(dialog: "Posted \(mediaIds.count) image(s) on Mastodon")
+    } catch {
+      return .result(dialog: "An error occured while posting to Mastodon, please try again.")
+    }
+  }
+}


### PR DESCRIPTION
Adds a new App Intent to upload and post images to Mastodon in the background without opening the app.

---
<a href="https://cursor.com/background-agent?bcId=bc-db60d828-65d5-4ee3-bf4f-00baf78c47b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db60d828-65d5-4ee3-bf4f-00baf78c47b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

