### PR TITLE
Add optional alt text to image upload intents

### DIFF
--- a/IceCubesApp/App/Main/IceCubesApp+Scene.swift
+++ b/IceCubesApp/App/Main/IceCubesApp+Scene.swift
@@ -160,6 +160,7 @@ extension IceCubesApp {
       appRouterPath.presentedSheet = .imageURL(
         urls: urls,
         caption: imageIntent.caption,
+        altTexts: imageIntent.altText.map { [$0] },
         visibility: userPreferences.postVisibility)
     }
   }

--- a/IceCubesApp/App/Router/AppRegistry.swift
+++ b/IceCubesApp/App/Router/AppRegistry.swift
@@ -100,8 +100,8 @@ extension View {
       case .prefilledStatusEditor(let text, let visibility):
         StatusEditor.MainView(mode: .new(text: text, visibility: visibility))
           .withEnvironments()
-      case .imageURL(let urls, let caption, let visibility):
-        StatusEditor.MainView(mode: .imageURL(urls: urls, caption: caption, visibility: visibility))
+      case .imageURL(let urls, let caption, let altTexts, let visibility):
+        StatusEditor.MainView(mode: .imageURL(urls: urls, caption: caption, altTexts: altTexts, visibility: visibility))
           .withEnvironments()
       case .editStatusEditor(let status):
         StatusEditor.MainView(mode: .edit(status: status))

--- a/IceCubesAppIntents/InlinePostImageIntent.swift
+++ b/IceCubesAppIntents/InlinePostImageIntent.swift
@@ -51,9 +51,15 @@ struct InlinePostImageIntent: AppIntent {
       var mediaIds: [String] = []
       for (index, file) in images.enumerated() {
         guard let url = file.fileURL else { continue }
-        let dataAndMime = makeJPEGData(from: url) ?? (try Data(contentsOf: url), mimeType(for: url))
-        let data = dataAndMime.0
-        let mimeType = dataAndMime.1
+        let data: Data
+        let mimeType: String
+        if let converted = makeJPEGData(from: url) {
+          data = converted.0
+          mimeType = converted.1
+        } else {
+          data = try Data(contentsOf: url)
+          mimeType = mimeType(for: url)
+        }
         let media: MediaAttachment = try await client.mediaUpload(
           endpoint: Media.medias,
           version: .v2,

--- a/IceCubesAppIntents/InlinePostImageIntent.swift
+++ b/IceCubesAppIntents/InlinePostImageIntent.swift
@@ -52,19 +52,19 @@ struct InlinePostImageIntent: AppIntent {
       for (index, file) in images.enumerated() {
         guard let url = file.fileURL else { continue }
         let data: Data
-        let mimeType: String
+        let contentType: String
         if let converted = makeJPEGData(from: url) {
           data = converted.0
-          mimeType = converted.1
+          contentType = converted.1
         } else {
           data = try Data(contentsOf: url)
-          mimeType = mimeType(for: url)
+          contentType = mimeType(for: url)
         }
         let media: MediaAttachment = try await client.mediaUpload(
           endpoint: Media.medias,
           version: .v2,
           method: "POST",
-          mimeType: mimeType,
+          mimeType: contentType,
           filename: "file",
           data: data)
 

--- a/IceCubesAppIntents/InlinePostImageIntent.swift
+++ b/IceCubesAppIntents/InlinePostImageIntent.swift
@@ -62,7 +62,7 @@ struct InlinePostImageIntent: AppIntent {
           version: .v2,
           method: "POST",
           mimeType: mimeType,
-          filename: url.lastPathComponent.isEmpty ? "file" : url.lastPathComponent,
+          filename: "file",
           data: data)
 
         if let altTexts, index < altTexts.count {

--- a/IceCubesAppIntents/PostImageIntent.swift
+++ b/IceCubesAppIntents/PostImageIntent.swift
@@ -19,6 +19,11 @@ struct PostImageIntent: AppIntent {
     requestValueDialog: IntentDialog("Caption for your post"))
   var caption: String?
 
+  @Parameter(
+    title: "Image description",
+    requestValueDialog: IntentDialog("ALT text for the image"))
+  var altText: String?
+
   func perform() async throws -> some IntentResult {
     AppIntentService.shared.handledIntent = .init(intent: self)
     return .result()

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -57,7 +57,7 @@ public enum SheetDestination: Identifiable, Hashable {
 
   case newStatusEditor(visibility: Models.Visibility)
   case prefilledStatusEditor(text: String, visibility: Models.Visibility)
-  case imageURL(urls: [URL], caption: String?, visibility: Models.Visibility)
+  case imageURL(urls: [URL], caption: String?, altTexts: [String]?, visibility: Models.Visibility)
   case editStatusEditor(status: Status)
   case replyToStatusEditor(status: Status)
   case quoteStatusEditor(status: Status)

--- a/Packages/StatusKit/Sources/StatusKit/Editor/ViewModeMode.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Editor/ViewModeMode.swift
@@ -11,7 +11,7 @@ extension StatusEditor.ViewModel {
     case quoteLink(link: URL)
     case mention(account: Account, visibility: Models.Visibility)
     case shareExtension(items: [NSItemProvider])
-    case imageURL(urls: [URL], caption: String?, visibility: Models.Visibility)
+    case imageURL(urls: [URL], caption: String?, altTexts: [String]?, visibility: Models.Visibility)
 
     var isInShareExtension: Bool {
       switch self {

--- a/Packages/StatusKit/Sources/StatusKit/Editor/ViewModel.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Editor/ViewModel.swift
@@ -240,6 +240,14 @@ extension StatusEditor {
             multiple: pollVotingFrequency.canVoteMultipleTimes,
             expires_in: pollDuration.rawValue)
         }
+        // Fallback: include any pending containerIdToAltText in mediaAttributes if media got uploaded
+        if !containerIdToAltText.isEmpty {
+          for c in mediaContainers {
+            if let desc = containerIdToAltText[c.id], let id = c.mediaAttachment?.id {
+              mediaAttributes.append(.init(id: id, description: desc, thumbnail: nil, focus: nil))
+            }
+          }
+        }
         let data = StatusData(
           status: statusText.string,
           visibility: visibility,


### PR DESCRIPTION
Add optional alt text support to image upload app intents for accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7a7a0b5-1452-4bf4-ad2d-5c710ec018a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7a7a0b5-1452-4bf4-ad2d-5c710ec018a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

