### PR TITLE
Adjust toolbar label offset for iOS 26

### DIFF
--- a/IceCubesApp/App/Tabs/ToolbarTab.swift
+++ b/IceCubesApp/App/Tabs/ToolbarTab.swift
@@ -22,6 +22,7 @@ struct ToolbarTab: ToolbarContent {
           AppAccountsSelectorView(
             routerPath: routerPath,
             avatarConfig: .embed)
+            .offset(x: -8)
         }
         .sharedBackgroundVisibility(.hidden)
       } else {

--- a/IceCubesApp/App/Tabs/ToolbarTab.swift
+++ b/IceCubesApp/App/Tabs/ToolbarTab.swift
@@ -22,7 +22,7 @@ struct ToolbarTab: ToolbarContent {
           AppAccountsSelectorView(
             routerPath: routerPath,
             avatarConfig: .embed)
-            .offset(x: -8)
+            .offset(x: -12)
         }
         .sharedBackgroundVisibility(.hidden)
       } else {


### PR DESCRIPTION
Add a -8 x-offset to the app account selector toolbar item on iOS versions prior to 27.0 to correct its alignment on iOS 26.

On iOS 26, disabling the glass effect on the toolbar item caused the operating system to no longer draw the button's border, resulting in an incorrect visual offset. This change applies a negative x-offset to realign it.

---
<a href="https://cursor.com/background-agent?bcId=bc-28c1bcd6-0125-42db-b95d-638e2ca1fc95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28c1bcd6-0125-42db-b95d-638e2ca1fc95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

