### PR TITLE
Adapt load more for bidirectional post loading

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/List/TimelineGapView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/List/TimelineGapView.swift
@@ -1,12 +1,26 @@
 import DesignSystem
 import Models
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+private struct GapMidYPreferenceKey: PreferenceKey {
+  static var defaultValue: CGFloat = 0
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = nextValue()
+  }
+}
 
 struct TimelineGapView: View {
   @Environment(Theme.self) private var theme
 
   let gap: TimelineGap
   let onLoadMore: () async -> Void
+
+  @State private var isInBottomHalf: Bool = false
 
   var body: some View {
     VStack(spacing: 12) {
@@ -23,7 +37,7 @@ struct TimelineGapView: View {
             }
           } label: {
             HStack(spacing: 8) {
-              Image(systemName: "arrow.down.circle")
+              Image(systemName: arrowSystemName)
               Text("Load more")
             }
             .font(.callout)
@@ -35,6 +49,34 @@ struct TimelineGapView: View {
         Spacer()
       }
       .padding(.vertical, 24)
+      .background(
+        GeometryReader { proxy in
+          Color.clear
+            .preference(key: GapMidYPreferenceKey.self, value: proxy.frame(in: .global).midY)
+        }
+      )
+      .onPreferenceChange(GapMidYPreferenceKey.self) { midY in
+        #if canImport(UIKit)
+        let screenHeight = UIScreen.main.bounds.height
+        #elseif canImport(AppKit)
+        let screenHeight = NSScreen.main?.frame.height ?? 0
+        #else
+        let screenHeight: CGFloat = 0
+        #endif
+        if screenHeight > 0 {
+          isInBottomHalf = midY > screenHeight / 2
+        } else {
+          isInBottomHalf = false
+        }
+      }
     }
+  }
+
+  private var arrowSystemName: String {
+    // Only bidirectional for bridge gaps (when sinceId exists). Older-only gaps stay downward.
+    if gap.sinceId.isEmpty {
+      return "arrow.down.circle"
+    }
+    return isInBottomHalf ? "arrow.up.circle" : "arrow.down.circle"
   }
 }


### PR DESCRIPTION
Dynamically change the 'Load more' arrow direction in timeline gaps based on its viewport position to improve UX.

The arrow now points upward when the "Load more" button is in the bottom half of the screen, and downward when in the top half. This visual change helps users understand the loading direction (newer posts above/below) more intuitively, while the underlying data fetching logic remains unchanged.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5b902bc-3669-4171-859f-cc5c48aea62d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5b902bc-3669-4171-859f-cc5c48aea62d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

