### PR TITLE
Fix mention truncation in notifications

### DIFF
--- a/Packages/Notifications/Sources/Notifications/Row/NotificationRowContentView.swift
+++ b/Packages/Notifications/Sources/Notifications/Row/NotificationRowContentView.swift
@@ -23,6 +23,7 @@ struct NotificationRowContentView: View {
               routerPath: routerPath,
               showActions: true)
           )
+          .environment(\.isNotificationsTab, false)
           .environment(\.isMediaCompact, false)
         } else {
           StatusRowExternalView(


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Disable text truncation for mention notifications in the notifications tab to prevent their content from being cut off.

---
<a href="https://cursor.com/background-agent?bcId=bc-53858474-12f2-419e-aff7-b1484794bd47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53858474-12f2-419e-aff7-b1484794bd47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

