### PR TITLE
Fixes context-menu crash on AccountsListRow

### DIFF
--- a/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
+++ b/Packages/Account/Sources/Account/AccountsList/AccountsListRow.swift
@@ -1,4 +1,5 @@
 import Combine
+import AppAccount
 import DesignSystem
 import EmojiText
 import Env
@@ -27,6 +28,8 @@ public struct AccountsListRow: View {
   @Environment(RouterPath.self) private var routerPath
   @Environment(MastodonClient.self) private var client
   @Environment(QuickLook.self) private var quickLook
+  @Environment(StreamWatcher.self) private var watcher
+  @Environment(AppAccountsManager.self) private var appAccountsManager
 
   @State var viewModel: AccountsListRowViewModel
 
@@ -157,6 +160,8 @@ public struct AccountsListRow: View {
       .environment(client)
       .environment(quickLook)
       .environment(routerPath)
+      .environment(watcher)
+      .environment(appAccountsManager)
     }
   }
 }


### PR DESCRIPTION
This PR fixes a runtime crash when trying to open the context menu from a profile inside a list. The root cause was missing environment variables.

| Image of the feature (Working after the fix) |
|--------|
| <img width="420" height="912" alt="image" src="https://github.com/user-attachments/assets/5dc6ac2b-8c84-4b83-8f43-e0a305f3bd2c" /> | 