### PR TITLE
Fix quote availability checks for reblogs

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusActionButton.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusActionButton.swift
@@ -8,6 +8,7 @@ struct StatusActionButton: View {
   let configuration: StatusRowActionsView.ActionButtonConfiguration
   let statusDataController: StatusDataController
   let status: Status
+  let quoteStatus: any AnyStatus
   let theme: Theme
   let isFocused: Bool
   let isNarrow: Bool
@@ -17,7 +18,7 @@ struct StatusActionButton: View {
   let handleAction: (StatusRowActionsView.Action) -> Void
 
   var isQuoteDisabled: Bool {
-    status.quoteApproval?.currentUser == .denied || status.visibility != .pub
+    quoteStatus.quoteApproval?.currentUser == .denied || quoteStatus.visibility != .pub
   }
 
   var body: some View {

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowActionsView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowActionsView.swift
@@ -310,18 +310,25 @@ struct StatusRowActionsView: View {
   @ViewBuilder
   private func actionButton(action: Action) -> some View {
     let configuration = configuration(for: action)
+    let finalStatus = viewModel.finalStatus
+    let isQuoteUnavailable =
+      finalStatus.visibility != .pub
+        || finalStatus.quoteApproval?.currentUser == .denied
+    let shouldDisableAction =
+      (configuration.trigger == .boost && viewModel.status.visibility != .pub)
+        || (configuration.trigger == .quote && isQuoteUnavailable)
+
     StatusActionButton(
       configuration: configuration,
       statusDataController: statusDataController,
       status: viewModel.status,
+      quoteStatus: finalStatus,
       theme: theme,
       isFocused: isFocused,
       isNarrow: isNarrow,
       isRemoteStatus: viewModel.isRemote,
       privateBoost: privateBoost(),
-      isDisabled: (configuration.trigger == .boost
-        || configuration.trigger == .quote)
-        && viewModel.status.visibility != .pub,
+      isDisabled: shouldDisableAction,
       handleAction: handleAction(action:)
     )
   }

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContextMenu.swift
@@ -34,7 +34,8 @@ struct StatusRowContextMenu: View {
   }
 
   var isQuoteDisabled: Bool {
-    viewModel.status.quoteApproval?.currentUser == .denied || viewModel.status.visibility != .pub
+    viewModel.finalStatus.quoteApproval?.currentUser == .denied
+      || viewModel.finalStatus.visibility != .pub
   }
 
   var body: some View {

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowSwipeView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowSwipeView.swift
@@ -74,10 +74,13 @@ struct StatusRowSwipeView: View {
       makeSwipeButtonForRouterPath(
         action: action, destination: .replyToStatusEditor(status: viewModel.status))
     case .quote:
+      let finalStatus = viewModel.finalStatus
       makeSwipeButtonForRouterPath(
         action: action, destination: .quoteStatusEditor(status: viewModel.status)
       )
-      .disabled(viewModel.status.visibility == .direct || viewModel.status.visibility == .priv)
+      .disabled(
+        finalStatus.visibility != .pub
+          || finalStatus.quoteApproval?.currentUser == .denied)
     case .favorite:
       makeSwipeButtonForTask(action: action) {
         await statusDataController.toggleFavorite(remoteStatus: nil)


### PR DESCRIPTION
## Summary
- ensure quote availability logic uses the underlying status instead of the wrapper when a post is a reblog
- disable quote actions in the status row when the original status forbids quoting
- align context menu and swipe actions with the updated quote eligibility checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e75ae7c74083259948ee951a699fbb