### PR TITLE
Fix remote timeline client initialization

### DIFF
--- a/Packages/Timeline/Sources/Timeline/View/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/View/TimelineView.swift
@@ -116,7 +116,12 @@ public struct TimelineView: View {
       viewModel.canFilterTimeline = canFilterTimeline
 
       if viewModel.client == nil {
-        viewModel.client = client
+        switch timeline {
+        case .remoteLocal(let server, _):
+          viewModel.client = MastodonClient(server: server)
+        default:
+          viewModel.client = client
+        }
       }
 
       viewModel.timeline = timeline


### PR DESCRIPTION
## Summary
- ensure TimelineView selects a remote MastodonClient when opening a remote timeline filter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e775919c388325869d29aff5bbc7b3