### PR TITLE
Disable boosting from context menu for non-public statuses

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContextMenu.swift
@@ -38,6 +38,18 @@ struct StatusRowContextMenu: View {
       || viewModel.finalStatus.visibility != .pub
   }
 
+  var isBoostDisabled: Bool {
+    switch viewModel.finalStatus.visibility {
+    case .pub:
+      return false
+    case .priv:
+      guard let currentAccountId = account.account?.id else { return true }
+      return viewModel.finalStatus.account.id != currentAccountId
+    case .unlisted, .direct:
+      return true
+    }
+  }
+
   var body: some View {
     if !viewModel.isRemote {
       ControlGroup {
@@ -59,11 +71,7 @@ struct StatusRowContextMenu: View {
         } label: {
           boostLabel
         }
-        .disabled(
-          viewModel.status.visibility == .direct
-            || viewModel.status.visibility == .priv
-              && viewModel.status.account.id != account.account?.id
-        )
+        .disabled(isBoostDisabled)
 
         Button {
           Task {


### PR DESCRIPTION
## Summary
- disable the status context menu boost action when the underlying status cannot be boosted
- keep quoting availability unchanged while still allowing boosts of your own private posts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7775e1920832586c7a09d0c3f2cca