### PR TITLE
Dim disabled boost and quote actions

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusActionButton.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusActionButton.swift
@@ -36,6 +36,7 @@ struct StatusActionButton: View {
         .offset(x: -8)
       #endif
       .disabled(isDisabled)
+      .opacity(isDisabled ? 0.35 : 1)
       .accessibilityElement(children: .combine)
       .accessibilityLabel(
         configuration.display.accessibilityLabel(
@@ -63,6 +64,7 @@ struct StatusActionButton: View {
           }
         }
         .disabled(isQuoteDisabled)
+        .opacity(isQuoteDisabled ? 0.35 : 1)
       } label: {
         HStack(spacing: 2) {
           actionImage(for: configuration.display)

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContextMenu.swift
@@ -72,6 +72,7 @@ struct StatusRowContextMenu: View {
           boostLabel
         }
         .disabled(isBoostDisabled)
+        .opacity(isBoostDisabled ? 0.35 : 1)
 
         Button {
           Task {


### PR DESCRIPTION
## Summary
- lower the opacity of disabled status action buttons so boost/quote limits are visible
- fade the boost option inside the status context menu whenever the action is unavailable

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec905258148325a488fdc49b22a8bb