### PR TITLE
Fix notifications filter reset

### DIFF
--- a/Packages/Notifications/Sources/Notifications/List/NotificationsListView.swift
+++ b/Packages/Notifications/Sources/Notifications/List/NotificationsListView.swift
@@ -70,11 +70,7 @@ public struct NotificationsListView: View {
       if lockedType == nil && lockedAccountId == nil {
         ToolbarTitleMenu {
           Button {
-            selectedType = nil
-            Task {
-              viewState = .loading
-              await fetchNotifications()
-            }
+            applyFilter(type: nil)
           } label: {
             Label("notifications.navigation-title", systemImage: "bell.fill")
               .tint(theme.labelColor)
@@ -82,11 +78,7 @@ public struct NotificationsListView: View {
           Divider()
           ForEach(Notification.NotificationType.allCases, id: \.self) { type in
             Button {
-              selectedType = type
-              Task {
-                viewState = .loading
-                await fetchNotifications()
-              }
+              applyFilter(type: type)
             } label: {
               Label {
                 Text(type.menuTitle())
@@ -277,6 +269,16 @@ public struct NotificationsListView: View {
 }
 
 extension NotificationsListView {
+  private func applyFilter(type: Models.Notification.NotificationType?) {
+    selectedType = type
+    dataSource.reset()
+    viewState = .loading
+
+    Task {
+      await fetchNotifications()
+    }
+  }
+
   private func fetchNotifications() async {
     do {
       let result = try await dataSource.fetchNotifications(


### PR DESCRIPTION
## Summary
- reset the notifications data source when a toolbar filter is selected so the fetch starts cleanly
- centralize filter selection logic for the notifications toolbar menu

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68edf7404e8c83258ce733a347822485