### PR TITLE
[Optimize] Enable SwiftUI's LogForEachSlowPath by default in debug builds

### DIFF
--- a/IceCubesApp/App/Main/IceCubesApp.swift
+++ b/IceCubesApp/App/Main/IceCubesApp.swift
@@ -38,9 +38,10 @@ struct IceCubesApp: App {
 
   init() {
     #if DEBUG
-      // Enable "GraphReuseLogging" for debugging purpose
-      // subsystem: "com.apple.SwiftUI" category: "GraphReuse"
-      UserDefaults.standard.register(defaults: ["com.apple.SwiftUI.GraphReuseLogging": true])
+      UserDefaults.standard.register(defaults: [
+        "com.apple.SwiftUI.GraphReuseLogging": true, // Enable "GraphReuseLogging" by default. The log can be found via - subsystem: "com.apple.SwiftUI" category: "GraphReuse"
+        "LogForEachSlowPath": true, // Enable "LogForEachSlowPath" by default. The log can be found via - subsystem: "com.apple.SwiftUI" category: "Invalid Configuration"
+      ])
     #endif
   }
 


### PR DESCRIPTION
Always enable SwiftUI's LogForEachSlowPath in debug builds.

## Summary

SwiftUI's ForEach [documentation](https://developer.apple.com/documentation/swiftui/foreach) states that we can enable such log by adding `-LogForEachSlowPath YES` in launch arguments.

It is equivalent to set UserDefaults since the SwiftUI Runtime is always using UserDefaults to check it.

This PR makes this feature default to true in debug builds.

To disable such log, append `-LogForEachSlowPath NO` in launch arguments or simply comment out the added code.

## Result

<img width="1574" height="1036" alt="image" src="https://github.com/user-attachments/assets/354f073b-aad7-4ad4-8b6b-a07604b4c0f5" />

When hitting a slow path for `ForEach`, a warning log will be emitted and then we may consider taking some actions to fix it to improve render performance.

```
Unable to determine number of views per element in the collection Array<Action>. If this view only produces one view per element in the collection, consider views in a VStack to take the fast path.
```

Currently, I have found one for the `Array<Action>` data. A potential fix PR may be submitted later.