### PR TITLE
Disable full fetch on local and federated timelines

### DIFF
--- a/Packages/Timeline/Sources/Timeline/View/TimelineViewModel.swift
+++ b/Packages/Timeline/Sources/Timeline/View/TimelineViewModel.swift
@@ -72,7 +72,14 @@ import SwiftUI
   }
 
   private var isFullTimelineFetchEnabled: Bool {
-    UserPreferences.shared.fullTimelineFetch
+    guard UserPreferences.shared.fullTimelineFetch else { return false }
+
+    switch timeline {
+    case .local, .federated:
+      return false
+    default:
+      return true
+    }
   }
 
   private var isCacheEnabled: Bool {


### PR DESCRIPTION
## Summary
- ensure the full timeline fetch preference does not apply to local and federated timelines so they continue using gap pagination

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fdb02ca3ac8325a9f366fb80b21197