### PR TITLE
Copy Text from Image

### DIFF
--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -31904,6 +31904,9 @@
         }
       }
     },
+    "Full timeline fetch" : {
+
+    },
     "Home Timeline" : {
       "localizations" : {
         "de" : {
@@ -56717,6 +56720,7 @@
       }
     },
     "settings.section.other.footer" : {
+      "extractionState" : "stale",
       "localizations" : {
         "be" : {
           "stringUnit" : {
@@ -69279,6 +69283,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近用過"
+          }
+        }
+      }
+    },
+    "status.editor.media.copy-text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🤖 Copy text from image"
+          }
+        },
+        "en-GB" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🤖 Copy text from image"
           }
         }
       }


### PR DESCRIPTION
Add a button to the media edit view that uses VisionKit to analyse the image and use any text found as the image description.

<img width="574" height="759" alt="Screenshot 2025-11-13 at 11 26 21 pm" src="https://github.com/user-attachments/assets/be5526d2-9ba9-407c-8962-ecc6915f089d" />

It doesn't use the live text feature for two reasons
 - it isn't supported in SwiftUI's `Image` and using a `UIImageView` in the place of the `Image` didn't work easily to match the current design
 - the image could be scaled such that the text was so tiny it was unreadable and unselectable

With these reasons I thought just adding a second button was the easiest option.