### PR TITLE
Fix line-start dash rendering in status content

### DIFF
--- a/Packages/Models/Sources/Models/Alias/HTMLString.swift
+++ b/Packages/Models/Sources/Models/Alias/HTMLString.swift
@@ -279,6 +279,7 @@ public struct HTMLString: Codable, Equatable, Hashable, @unchecked Sendable {
         var txt = node.description
 
         txt = (try? Entities.unescape(txt)) ?? txt
+        let isLineStart = asMarkdown.isEmpty || asMarkdown.hasSuffix("\n")
 
         if let underscore_regex, let main_regex {
           //  This is the markdown escaper
@@ -288,6 +289,11 @@ public struct HTMLString: Codable, Equatable, Hashable, @unchecked Sendable {
           txt = underscore_regex.stringByReplacingMatches(
             in: txt, options: [], range: NSRange(location: 0, length: txt.count),
             withTemplate: "\\\\$1")
+        }
+        if isLineStart,
+          txt.hasPrefix("- ") || txt.hasPrefix("* ") || txt.hasPrefix("+ ")
+        {
+          txt = "\\" + txt
         }
         // Strip newlines and line separators - they should be being sent as <br>s
         asMarkdown += txt.replacingOccurrences(of: "\n", with: "").replacingOccurrences(

--- a/Packages/Models/Tests/ModelsTests/HTMLStringTests.swift
+++ b/Packages/Models/Tests/ModelsTests/HTMLStringTests.swift
@@ -99,6 +99,17 @@ func testHTMLStringInit_markdownEscaping() throws {
 }
 
 @Test
+func testHTMLStringInit_lineStartListMarkers() throws {
+  let decoder = JSONDecoder()
+
+  let listLikeContent = "\"<p>2025 year review:<br />- 11 accepted and merged pull requests</p>\""
+  let htmlString = try decoder.decode(HTMLString.self, from: Data(listLikeContent.utf8))
+  #expect("2025 year review:\n- 11 accepted and merged pull requests" == htmlString.asRawText)
+  #expect(
+    "2025 year review:\n\\- 11 accepted and merged pull requests" == htmlString.asMarkdown)
+}
+
+@Test
 func testHTMLStringInit_quoteInlineRemoval() throws {
   let decoder = JSONDecoder()
   


### PR DESCRIPTION
### Motivation

- Status content that begins lines with `- `, `* ` or `+ ` was being interpreted as Markdown list markers and rendered as list items instead of literal text.
- The HTML-to-markdown conversion in `HTMLString` must preserve literal leading list markers when they appear at the start of a line in the original content.

### Description

- Update `Packages/Models/Sources/Models/Alias/HTMLString.swift` to detect line starts when handling `#text` nodes and escape leading list markers by prefixing them with a backslash so they render as literal characters.
- The check treats a line start as when `asMarkdown` is empty or ends with a newline and escapes markers matching `- `, `* ` or `+ `.
- Add a regression test `testHTMLStringInit_lineStartListMarkers` in `Packages/Models/Tests/ModelsTests/HTMLStringTests.swift` that verifies a `<br />- ` sequence is preserved as `\- ` in `asMarkdown`.

### Testing

- Added unit test `testHTMLStringInit_lineStartListMarkers` to cover the regression scenario and ensure literal leading markers are escaped.
- No automated test suite was executed in this environment (`xcodebuild` / `swift test` not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cfa0e054c8325ad6fe10c025c3907)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents accidental list rendering when status text starts with list-like markers.
> 
> - Update `HTMLString.handleNode(#text)` to detect line starts (empty output or after `\n`) and prefix leading `- `, `* `, `+ ` with a backslash before appending to `asMarkdown`
> - Add `testHTMLStringInit_lineStartListMarkers` verifying `<br />- ` becomes `\- ` in `asMarkdown` while `asRawText` remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb30f7aec3581256b430610f5d068010f6f8451a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->