### PR TITLE
Rework add/remove lists view: present create-list locally and move create button into list

### DIFF
--- a/Packages/Lists/Sources/Lists/AddAccounts/ListAddAccountView.swift
+++ b/Packages/Lists/Sources/Lists/AddAccounts/ListAddAccountView.swift
@@ -10,8 +10,8 @@ public struct ListAddAccountView: View {
   @Environment(MastodonClient.self) private var client
   @Environment(Theme.self) private var theme
   @Environment(CurrentAccount.self) private var currentAccount
-  @Environment(RouterPath.self) private var routerPath
   @State private var viewModel: ListAddAccountViewModel
+  @State private var isPresentingCreateList = false
 
   public init(account: Account) {
     _viewModel = .init(initialValue: .init(account: account))
@@ -20,6 +20,15 @@ public struct ListAddAccountView: View {
   public var body: some View {
     NavigationStack {
       List {
+        Section {
+          Button {
+            isPresentingCreateList = true
+          } label: {
+            Label("account.list.create", systemImage: "plus")
+          }
+        }
+        .listRowBackground(theme.primaryBackgroundColor)
+
         ForEach(currentAccount.sortedLists) { list in
           HStack {
             Toggle(
@@ -49,19 +58,15 @@ public struct ListAddAccountView: View {
       .navigationTitle("lists.add-remove-\(viewModel.account.safeDisplayName)")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
-        ToolbarItem(placement: .navigationBarLeading) {
-          Button {
-            routerPath.presentedSheet = .listCreate
-          } label: {
-            Label("account.list.create", systemImage: "plus")
-          }
-        }
         ToolbarItem(placement: .navigationBarTrailing) {
           Button("action.done") {
             dismiss()
           }
         }
       }
+    }
+    .sheet(isPresented: $isPresentingCreateList) {
+      ListCreateView()
     }
     .task {
       viewModel.client = client


### PR DESCRIPTION
### Motivation
- The current add/remove list flow uses a global sheet for creating lists which dismisses the current flow and interrupts toggling a user into a newly created list.
- The create-list action in the navigation toolbar is not discoverable in the context of adding/removing a user from lists.
- Creating a list should be presented locally so the user can immediately continue toggling the target account into the newly created list.

### Description
- Added a top `Section` with a `Button` labeled `Label("account.list.create", systemImage: "plus")` inside `ListAddAccountView` so the create action appears in the list content.
- Introduced `@State private var isPresentingCreateList` and present `ListCreateView()` with `.sheet(isPresented:)` to show the create flow locally on top of the current sheet.
- Removed reliance on the global `RouterPath` create action and the toolbar create button while keeping the Done action in the toolbar.
- Modified file `Packages/Lists/Sources/Lists/AddAccounts/ListAddAccountView.swift` to implement the above UX and presentation changes.

### Testing
- Attempted to build the app with `xcodebuild -scheme IceCubesApp -project IceCubesApp.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 15' build`, but `xcodebuild` is not available in the environment so the build could not be executed.
- No other automated tests were run in this environment due to the missing build tooling.
- Manual inspection of the changed `ListAddAccountView` UI code confirms the create button is now in-list and `ListCreateView` is presented locally via `.sheet`.
- Further verification should include running the app locally and executing the project tests with `xcodebuild` or in Xcode to confirm compile and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e461fecd4832595ea46f5807a89a0)