### PR TITLE
Log telemetry when lists are created

### DIFF
--- a/Packages/Lists/Sources/Lists/Create/ListCreateView.swift
+++ b/Packages/Lists/Sources/Lists/Create/ListCreateView.swift
@@ -51,6 +51,12 @@ public struct ListCreateView: View {
                   title: title,
                   repliesPolicy: repliesPolicy,
                   exclusive: isExclusive))
+              Telemetry.signal(
+                "list.created",
+                parameters: [
+                  "replies_policy": repliesPolicy.rawValue,
+                  "exclusive": isExclusive ? "true" : "false",
+                ])
               await currentAccount.fetchLists()
               isSaving = false
               dismiss()


### PR DESCRIPTION
### Motivation
- Record a telemetry event when users create a list so creation actions can be analyzed.
- Capture key metadata (`repliesPolicy` and `exclusive`) to understand list configuration choices.

### Description
- Added a `Telemetry.signal` call in `Packages/Lists/Sources/Lists/Create/ListCreateView.swift` after a successful `Lists.createList` call.
- The signal emitted is `"list.created"` with parameters `"replies_policy"` set to `repliesPolicy.rawValue` and `"exclusive"` set to `"true"`/`"false"`.
- The telemetry call is invoked before `await currentAccount.fetchLists()` and the view dismissal to ensure the event is logged on success.

### Testing
- No automated tests were executed in this environment due to XcodeBuildMCP being unavailable. 
- Project build and package tests should be run locally with the recommended `mcp__XcodeBuildMCP__build_*` and `mcp__XcodeBuildMCP__test_sim` commands to validate the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957a86df0b08325870192cafd90ecdc)