### PR TITLE
loc: add translations for hide posts with media preference

### DIFF
--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -85452,7 +85452,7 @@
         }
       }
     },
-    "settings.content.media.hide-posts-with-media" : {
+    "timeline.filter.hide-posts-with-media" : {
       "localizations" : {
         "be" : {
           "stringUnit" : {


### PR DESCRIPTION
## Summary
This PR adds the necessary localization keys for the "Hide posts with media" preference. 

## Changes
- Added `settings.content.media.hide-posts-with-media` to `Localizable.xcstrings`.
- Provided translations for **en** and **en-GB**.
- Added placeholders for other languages to be populated by the community.

## Context
This is a follow-up to my logic PR (#[/pull/2400]) to keep the feature implementation and string translations separate per maintainer request.

Closes #2382