### PR TITLE
Add tappable toast actions and navigate to status on post success

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/Views/ToastOverlayView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/ToastOverlayView.swift
@@ -14,6 +14,9 @@ public struct ToastOverlayView: View {
           .padding(.top, 12)
           .transition(.move(edge: .top).combined(with: .opacity))
           .onTapGesture {
+            if let action = toast.action {
+              action.handler()
+            }
             toastCenter.dismiss(id: toast.id)
           }
       }

--- a/Packages/Env/Sources/Env/ToastCenter.swift
+++ b/Packages/Env/Sources/Env/ToastCenter.swift
@@ -4,6 +4,20 @@ import SwiftUI
 @Observable
 public final class ToastCenter {
   public struct Toast: Identifiable, Equatable {
+    public struct Action: Identifiable, Equatable {
+      public let id: UUID
+      public let handler: () -> Void
+
+      public init(id: UUID = UUID(), handler: @escaping () -> Void) {
+        self.id = id
+        self.handler = handler
+      }
+
+      public static func == (lhs: Action, rhs: Action) -> Bool {
+        lhs.id == rhs.id
+      }
+    }
+
     public enum Kind: Equatable {
       case message
       case progress
@@ -16,6 +30,7 @@ public final class ToastCenter {
     public var tint: Color
     public var kind: Kind
     public var progress: Double?
+    public var action: Action?
 
     public init(
       id: UUID = UUID(),
@@ -24,7 +39,8 @@ public final class ToastCenter {
       systemImage: String? = nil,
       tint: Color = .accentColor,
       kind: Kind = .message,
-      progress: Double? = nil
+      progress: Double? = nil,
+      action: Action? = nil
     ) {
       self.id = id
       self.title = title
@@ -33,6 +49,18 @@ public final class ToastCenter {
       self.tint = tint
       self.kind = kind
       self.progress = progress
+      self.action = action
+    }
+
+    public static func == (lhs: Toast, rhs: Toast) -> Bool {
+      lhs.id == rhs.id &&
+        lhs.title == rhs.title &&
+        lhs.message == rhs.message &&
+        lhs.systemImage == rhs.systemImage &&
+        lhs.tint == rhs.tint &&
+        lhs.kind == rhs.kind &&
+        lhs.progress == rhs.progress &&
+        lhs.action?.id == rhs.action?.id
     }
   }
 

--- a/Packages/StatusKit/Sources/StatusKit/Editor/ToolbarItems.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Editor/ToolbarItems.swift
@@ -18,6 +18,7 @@ extension StatusEditor {
     @Environment(\.modelContext) private var context
     @Environment(UserPreferences.self) private var preferences
     @Environment(Theme.self) private var theme
+    @Environment(RouterPath.self) private var routerPath
     @Environment(ToastCenter.self) private var toastCenter
 
     #if targetEnvironment(macCatalyst)
@@ -149,13 +150,16 @@ extension StatusEditor {
         mainStore.postingToastID = nil
       }
 
-      if status != nil {
+      if let status {
         let successToast = ToastCenter.Toast(
           id: toastID,
           title: String(localized: "toast.posting.success.title"),
           systemImage: "checkmark.circle.fill",
           tint: theme.tintColor,
-          kind: .message
+          kind: .message,
+          action: .init { [routerPath] in
+            routerPath.navigate(to: .statusDetailWithStatus(status: status))
+          }
         )
         toastCenter.update(id: toastID, toast: successToast, autoDismissAfter: .seconds(3))
       } else {


### PR DESCRIPTION
### Motivation
- Make toasts actionable so tapping a toast can perform an application action instead of only dismissing it.
- Specifically allow the "post sent" success toast to navigate to the created status detail when tapped.
- Provide an extensible mechanism so other toasts can carry actions in the future.

### Description
- Added `Toast.Action` nested struct and an optional `action` property to `ToastCenter.Toast`, and updated the initializer and equality logic to include the action id.
- Updated `ToastOverlayView` to invoke `action.handler()` when a toast is tapped before dismissing the toast.
- Wired the post-success toast in `StatusEditor.ToolbarItems` to set an action that calls `routerPath.navigate(to: .statusDetailWithStatus(status: status))` so tapping the success toast opens the status detail.
- Kept existing toast behaviors (`show`, `update`, `dismiss`, progress handling) unchanged apart from the added action support.

### Testing
- No automated tests were executed in this environment because `XcodeBuildMCP`/CI was not available here.
- Please run a full build and package tests locally or in CI (per project guidelines) to validate compilation and behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595b96ad7483258fd38073bc8b52e7)