### PR TITLE
Make toast fully tappable

### DIFF
--- a/Packages/DesignSystem/Sources/DesignSystem/Views/ToastOverlayView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/ToastOverlayView.swift
@@ -12,6 +12,7 @@ public struct ToastOverlayView: View {
         ToastView(toast: toast)
           .padding(.horizontal, .layoutPadding)
           .padding(.top, 12)
+          .contentShape(Rectangle())
           .transition(.move(edge: .top).combined(with: .opacity))
           .onTapGesture {
             if let action = toast.action {


### PR DESCRIPTION
### Motivation
- The toast hit area was effectively limited to the label, making taps on the rest of the toast ignored and resulting in poor UX.
- The intent is that tapping anywhere on the toast should trigger its action and dismissal.
- Apply a minimal change to expand the tappable region without altering behavior.

### Description
- Added `.contentShape(Rectangle())` to the `ToastView` instance in `Packages/DesignSystem/Sources/DesignSystem/Views/ToastOverlayView.swift` to expand the hit area.
- Preserved the existing `.onTapGesture` which invokes the toast `action.handler()` and calls `toastCenter.dismiss(id:)`.
- No other behavior, layout, or animation changes were made.

### Testing
- No automated tests were run for this change.
- Builds/tests were not executed in this environment because `XcodeBuildMCP` was not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a5f2535b083258ce4b2ea30b00195)