### PR TITLE
Settings: add explanatory footers and split social keyboard, streaming and timeline fetch into sections

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
+++ b/IceCubesApp/App/Tabs/Settings/SettingsTab.swift
@@ -249,7 +249,7 @@ struct SettingsTabs: View {
         Label("settings.other.social-keyboard", systemImage: "keyboard")
       }
     } footer: {
-      Text("Adds a social keyboard row to quickly insert mentions, hashtags, and emojis.")
+      Text("Adds @ and # keys directly on the keyboard for faster mentions and hashtags.")
     }
     #if !os(visionOS)
       .listRowBackground(theme.primaryBackgroundColor)
@@ -264,7 +264,7 @@ struct SettingsTabs: View {
           .symbolVariant(preferences.streamHomeTimeline ? .none : .slash)
       }
     } footer: {
-      Text("Keeps your home timeline up to date in real time using streaming when available.")
+      Text("Keeps your home timeline up to date in real time using streaming when available. Disable in case of performance issues.")
     }
     #if !os(visionOS)
       .listRowBackground(theme.primaryBackgroundColor)
@@ -279,7 +279,7 @@ struct SettingsTabs: View {
           .symbolVariant(preferences.fullTimelineFetch ? .none : .slash)
       }
     } footer: {
-      Text("Fetches additional posts on refresh so you can catch up beyond the most recent page.")
+      Text("Fetches all new timeline posts (up to 800) instead of only the latest 40 + manually loading the gap.")
     }
     #if !os(visionOS)
       .listRowBackground(theme.primaryBackgroundColor)


### PR DESCRIPTION
### Motivation
- Improve clarity of the main settings screen by adding short explanatory footers for a few toggles. 
- Surface the `isSocialKeyboardEnabled`, `streamHomeTimeline`, and `fullTimelineFetch` options as their own sections so their meaning is clearer. 
- Keep unrelated toggles grouped under the existing "Other" section.

### Description
- Added three new sections implemented as `socialKeyboardSection`, `streamHomeTimelineSection`, and `timelineFetchSection` in `SettingsTab.swift` and inserted them into the `Form` above `otherSections`.
- Removed the `isSocialKeyboardEnabled`, `streamHomeTimeline`, and `fullTimelineFetch` toggles from the existing `otherSections` and reintroduced them inside their dedicated sections. 
- Each new section includes a footer `Text` explaining what the toggle does and preserves the existing look via `.listRowBackground(theme.primaryBackgroundColor)` where applicable.
- Kept remaining toggles unchanged and preserved the `otherSections` header and behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a69642a0c8325a68a6d3c3a8683cc)