### PR TITLE
Align notifications filter sheet styling with timeline content filter

### DIFF
--- a/Packages/Notifications/Sources/Notifications/List/NotificationsPolicyView.swift
+++ b/Packages/Notifications/Sources/Notifications/List/NotificationsPolicyView.swift
@@ -1,4 +1,3 @@
-import DesignSystem
 import Models
 import NetworkClient
 import SwiftUI
@@ -8,7 +7,6 @@ struct NotificationsPolicyView: View {
   @Environment(\.dismiss) private var dismiss
 
   @Environment(MastodonClient.self) private var client
-  @Environment(Theme.self) private var theme
 
   @State private var policy: NotificationsPolicy?
   @State private var isUpdating: Bool = false
@@ -104,23 +102,26 @@ struct NotificationsPolicyView: View {
             }
           }
         }
-        #if !os(visionOS)
-          .listRowBackground(theme.primaryBackgroundColor.opacity(0.3))
-        #endif
       }
-      .formStyle(.grouped)
       .navigationTitle("notifications.content-filter.title")
       .navigationBarTitleDisplayMode(.inline)
       .scrollContentBackground(.hidden)
-      .toolbar { CloseToolbarItem() }
+      .toolbar {
+        ToolbarItem(placement: .navigationBarTrailing) {
+          Button {
+            dismiss()
+          } label: {
+            Text("action.done").bold()
+          }
+        }
+      }
       .disabled(policy == nil || isUpdating)
       .task {
         await getPolicy()
       }
       .redacted(reason: policy == nil ? .placeholder : [])
     }
-    .presentationDetents([.height(500)])
-    .presentationBackground(.thinMaterial)
+    .presentationDetents([.medium])
   }
 
   private var pickerMenu: some View {


### PR DESCRIPTION
### Motivation
- Make the Notifications filter sheet visually match the Timeline content filter sheet so the background is glass/transparent and the sheet feels consistent.
- Replace the leading close icon with a trailing `Done` button to match the Timeline sheet UX.

### Description
- Replaced the leading `CloseToolbarItem` with an explicit trailing `Done` button that calls `dismiss()` in the sheet toolbar.
- Removed usage of `Theme` and the opaque row background (`.listRowBackground(theme.primaryBackgroundColor.opacity(0.3))`) and the grouped `Form` style to allow the transparent/glass appearance.
- Changed presentation detents from `.presentationDetents([.height(500)])` to `.presentationDetents([.medium])` and removed `.presentationBackground(.thinMaterial)` so the system default glass presentation is used.
- Cleaned up an unused `DesignSystem` import that was no longer required by the view.

### Testing
- Attempted an iOS build with `xcodebuild -project IceCubesApp.xcodeproj -scheme IceCubesApp -destination 'platform=iOS Simulator,name=iPhone 15' build`, but `xcodebuild` is not available in this environment so the build could not be run (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a69ec58748325b5ed56d34b8912ff)