### PR TITLE
Respect Reduce Motion at app root

### DIFF
--- a/IceCubesApp/App/Main/IceCubesApp+Scene.swift
+++ b/IceCubesApp/App/Main/IceCubesApp+Scene.swift
@@ -9,6 +9,11 @@ extension IceCubesApp {
     WindowGroup(id: "MainWindow") {
       AppView(selectedTab: $selectedTab, appRouterPath: $appRouterPath)
         .applyTheme(theme)
+        .transaction { transaction in
+          if reduceMotion {
+            transaction.disablesAnimations = true
+          }
+        }
         .onAppear {
           setNewClientsInEnv(client: appAccountsManager.currentClient)
           setupRevenueCat()

--- a/IceCubesApp/App/Main/IceCubesApp.swift
+++ b/IceCubesApp/App/Main/IceCubesApp.swift
@@ -18,6 +18,7 @@ struct IceCubesApp: App {
 
   @Environment(\.scenePhase) var scenePhase
   @Environment(\.openWindow) var openWindow
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   @State var appAccountsManager = AppAccountsManager.shared
   @State var currentInstance = CurrentInstance.shared


### PR DESCRIPTION
### Motivation
- Provide global suppression of implicit animations when the user's `Reduce Motion` accessibility setting is enabled.
- Ensure the main window scene honors `accessibilityReduceMotion` at the root of the view hierarchy.

### Description
- Added `@Environment(\.accessibilityReduceMotion) private var reduceMotion` to `IceCubesApp`.
- Applied a `.transaction` on the root `AppView` in the `WindowGroup` to set `transaction.disablesAnimations = true` when `reduceMotion` is true.
- Changes made in `IceCubesApp.swift` and `IceCubesApp+Scene.swift`.

### Testing
- No automated tests were run because Xcode build tooling was unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a6b41df2883258a78d9f6767c8088)