### PR TITLE
Fix instance info section background color

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/InstanceInfoView.swift
+++ b/IceCubesApp/App/Tabs/Settings/InstanceInfoView.swift
@@ -46,6 +46,9 @@ public struct InstanceInfoSection: View {
         LabeledContent("Monthly Active Users", value: format(activeMonth))
       }
     }
+    #if !os(visionOS)
+      .listRowBackground(theme.primaryBackgroundColor)
+    #endif
 
     Section("Instance Administrator") {
       LabeledContent("instance.info.email", value: instance.contact.email)


### PR DESCRIPTION
### Motivation
- The instance info area in the add-account screen and the instance information screen had a different background than other sections, causing a visual inconsistency.
- The goal is to align that section with the app's section styling by using the same themed background color.
- This change targets the `InstanceInfoSection` view so both add-account and instance screens look consistent.

### Description
- Apply `.listRowBackground(theme.primaryBackgroundColor)` to the info `Section` inside `InstanceInfoSection` so it matches other sections.
- The change is guarded with `#if !os(visionOS)` to preserve existing `visionOS` behavior.
- No other UI behavior or business logic was modified.

### Testing
- No automated tests were run in this environment because the `XcodeBuildMCP` tooling was unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a7b8819c08325b317d8d8d69755ff)