### PR TITLE
Fix remote local timeline filter switching from sidebar

### DIFF
--- a/IceCubesApp/App/Tabs/Tabs.swift
+++ b/IceCubesApp/App/Tabs/Tabs.swift
@@ -127,7 +127,7 @@ enum AppTab: Identifiable, Hashable, CaseIterable, Codable {
   ) -> some View {
     switch self {
     case let .anyTimelineFilter(filter):
-      TimelineTab(timeline: .constant(filter))
+      TimelineFilterTab(initialFilter: filter)
     case .timeline:
       TimelineTab(canFilterTimeline: true, timeline: homeTimeline, pinedFilters: pinnedFilters)
     case .trending:
@@ -277,6 +277,18 @@ enum AppTab: Identifiable, Hashable, CaseIterable, Codable {
     case .other:
       ""
     }
+  }
+}
+
+private struct TimelineFilterTab: View {
+  @State private var timeline: TimelineFilter
+
+  init(initialFilter: TimelineFilter) {
+    _timeline = State(initialValue: initialFilter)
+  }
+
+  var body: some View {
+    TimelineTab(timeline: $timeline)
   }
 }
 


### PR DESCRIPTION
### Motivation
- Selecting a remote-local timeline from the sidebar could not be switched to `local`/`federated`/`trending` using the toolbar menu because the tab was created with a constant `TimelineFilter` binding.
- The toolbar menu expects a mutable binding so changes propagate to the displayed timeline view for that sidebar tab.
- The intent is to keep per-sidebar-tab filter stateful so toolbar filter actions apply when a remote-local timeline tab is opened.

### Description
- Replace the direct use of `TimelineTab(timeline: .constant(filter))` for `.anyTimelineFilter` with a small wrapper view `TimelineFilterTab` that owns a `@State private var timeline` initialized with the provided filter.
- `TimelineFilterTab` exposes a binding to the internal `timeline` and forwards it to `TimelineTab` via `TimelineTab(timeline: $timeline)` so toolbar changes mutate the tab state.
- Change is contained in `IceCubesApp/App/Tabs/Tabs.swift` and adds the private `TimelineFilterTab` struct.

### Testing
- No automated tests were run as part of this change.
- No CI build or test results are available for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf85322248325ab6629e759b1feac)