### PR TITLE
Improve contrast for completed poll results

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Poll/StatusPollView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Poll/StatusPollView.swift
@@ -177,7 +177,7 @@ public struct StatusPollView: View {
       .background(alignment: .leading) {
         if viewModel.showResults || status.account.id == currentAccount.account?.id {
           _PercentWidthLayout(percent: relativePercent(for: option.votesCount ?? 0)) {
-            RoundedRectangle(cornerRadius: 10).foregroundColor(theme.tintColor)
+            RoundedRectangle(cornerRadius: 10).foregroundColor(theme.tintColor.opacity(0.6))
               .transition(
                 .asymmetric(
                   insertion: .push(from: .leading),


### PR DESCRIPTION
### Motivation
- Poll option text can be hard to read when a custom `tintColor` is used because the completed-result fill was fully opaque with the same tint.  
- The uncompleted poll background uses `opacity(0.4)`, so increasing the completed result opacity improves legibility.  
- The change aims to make poll results more readable across different user-selected themes.  

### Description
- Updated `Packages/StatusKit/Sources/StatusKit/Poll/StatusPollView.swift` to use `theme.tintColor.opacity(0.6)` for the result fill.  
- The change targets the `RoundedRectangle` used inside the `_PercentWidthLayout` that renders the option result width.  
- This is a single-line visual tweak and does not alter layout or interaction logic.  

### Testing
- No automated tests were run for this change.  
- A local commit and PR were created to capture the change for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d67319fdc8325b12e9f51fbaf68e1)