### PR TITLE
[#2466] Fix missing color of icons for destructive actions (report and delete toot)

### DIFF
--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
@@ -176,7 +176,7 @@ struct ConversationMessageView: View {
         Button(role: .destructive) {
           routerPath.presentedSheet = .report(status: message.reblogAsAsStatus ?? message)
         } label: {
-          Label("status.action.report", systemImage: "exclamationmark.bubble")
+          Label("status.action.report", systemImage: "exclamationmark.bubble").tint(.red)
         }
       }
     }

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContextMenu.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContextMenu.swift
@@ -214,7 +214,10 @@ struct StatusRowContextMenu: View {
         Button(
           role: .destructive,
           action: { viewModel.showDeleteAlert = true },
-          label: { Label("status.action.delete", systemImage: "trash") })
+          label: {
+            Label("status.action.delete", systemImage: "trash")
+              .tint(.red)
+          })
       }
     } else {
       if !viewModel.isRemote {
@@ -266,7 +269,7 @@ struct StatusRowContextMenu: View {
           viewModel.routerPath.presentedSheet = .report(
             status: viewModel.status.reblogAsAsStatus ?? viewModel.status)
         } label: {
-          Label("status.action.report", systemImage: "exclamationmark.bubble")
+          Label("status.action.report", systemImage: "exclamationmark.bubble").tint(.red)
         }
       }
     }


### PR DESCRIPTION
# Description

The delete and the report actions for toot in dedicated menu can be considered as destructive. Thus the color of the text is red.
However the icon was not red and should be.
Now the icons are red tinted like the text.

# Related issue

Closes #2466

# Screenshots

## Before

<img height="300" alt="Report action without red icon" src="https://github.com/user-attachments/assets/e2e6d465-c966-458c-b525-9773e980c55a" />
<img height="300" alt="Delete action without red icon" src="https://github.com/user-attachments/assets/f929b894-27b8-431e-a334-7842d9e256a4" />

## After

### iOS 26 (dark mode)

<img height="300" alt="Report action with red icon" src="https://github.com/user-attachments/assets/ff287604-3ac1-4880-94ee-81ed28c6128d" />
<img height="300" alt="Delete action with red icon" src="https://github.com/user-attachments/assets/e04943c8-2e1a-4fab-bc77-f1e158e3510e" />

### iOS 18.6 (light mode)

<img height="300" alt="Report action with red icon" src="https://github.com/user-attachments/assets/f4561ae2-58e7-4367-96fe-57f65650f1b5" />
<img height="300" alt="Delete action with red icon" src="https://github.com/user-attachments/assets/befd3ef1-7971-4240-851c-5b1820daa617" />
