### PR TITLE
Fix quoted posts not displaying on macOS (#2469)

### DIFF
--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContentView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContentView.swift
@@ -45,7 +45,9 @@ struct StatusRowContentView: View {
             client: viewModel.client,
             routerPath: viewModel.routerPath
           )
+          #if !targetEnvironment(macCatalyst)
           .fixedSize(horizontal: false, vertical: true)
+          #endif
           .transition(.opacity)
         } else {
           StatusEmbeddedView(
@@ -53,7 +55,9 @@ struct StatusRowContentView: View {
             client: viewModel.client,
             routerPath: viewModel.routerPath
           )
+          #if !targetEnvironment(macCatalyst)
           .fixedSize(horizontal: false, vertical: true)
+          #endif
           .redacted(reason: .placeholder)
           .transition(.opacity)
         }


### PR DESCRIPTION
Fixes #2469

### Problem

A post that quotes another post does not display the quoted content on macOS (Mac Catalyst), even when **Show Quotes** is enabled in Content Settings. The same post correctly shows the quoted content on iPhone.

**Affected version:** 2.1.3 (3244)  
**Platform:** macOS only (iOS works correctly)

### Root Cause

The issue is in [`StatusRowContentView.swift`](Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContentView.swift), where `StatusEmbeddedView` (the quoted post widget) had `.fixedSize(horizontal: false, vertical: true)` applied unconditionally on all platforms.

`StatusEmbeddedView` has this layout structure:

```swift
HStack {
    VStack {
        makeAccountView(...)   // author header
        StatusRowView(...)     // quoted post body
    }
    Spacer()                   // ← the culprit
}
```

The `Spacer()` inside the `HStack` triggers a SwiftUI layout conflict when `.fixedSize(horizontal: false, vertical: true)` is applied:

1. SwiftUI asks the `HStack` for its **ideal height** assuming **infinite width**
2. With infinite width, `Spacer()` collapses to **0**, so text renders as a **single line**
3. That tiny single-line height is then **permanently "fixed"** by the modifier
4. At actual rendering width (where text wraps to multiple lines), the container stays pinned to the collapsed height → **invisible quoted post**

**Why it works on iOS but not on macOS:**  
On iOS, UIKit's `UITableView`-backed `List` absorbs or avoids this measurement conflict. On macOS Catalyst's `NSTableView`-backed `List`, the layout engine applies stricter size measurement semantics that expose the conflict directly.

### Fix

Wrap the `.fixedSize(horizontal: false, vertical: true)` modifier in a compile-time `#if !targetEnvironment(macCatalyst)` guard, so it is only applied on iOS/visionOS where it is needed:

```swift
StatusEmbeddedView(
    status: embeddedStatus,
    client: viewModel.client,
    routerPath: viewModel.routerPath
)
#if !targetEnvironment(macCatalyst)
.fixedSize(horizontal: false, vertical: true)
#endif
.transition(.opacity)
```

This is applied to both branches in the block — the loaded status and the `.redacted` placeholder shown while loading — to prevent a height jump/pop-in during the loading state.

### Verification

**No side effects:**

| Concern | Result |
|---|---|
| iOS behavior | ✅ Unchanged — `#if` is compile-time; iOS code path is identical |
| visionOS behavior | ✅ Unchanged — separate `os(visionOS)` blocks are unaffected |
| Quote fetching on Mac | ✅ Still works — fetching is triggered in `StatusRowView.onAppear`, independent of this modifier |
| Infinite nesting guard | ✅ Still intact — `!isCompact` check prevents recursive embedding |
| Notification tab quotes | ✅ Unaffected — `NotificationRowContentView` had no `fixedSize` on its `StatusEmbeddedView` |
| Account Metrics "Top posts" | ✅ Unaffected — uses `StatusEmbeddedView` in a `ScrollView`, not a `List` |
| "Show Quotes" content filter | ✅ Unaffected — filtering happens in `TimelineDatasource` before rendering |
| Placeholder loading state | ✅ Both branches (real + placeholder) guarded, no layout jump |

**Pattern consistency:**  
`#if targetEnvironment(macCatalyst)` guards are used 30+ times throughout StatusKit following this exact same pattern (e.g. `StatusRowCardView`, `StatusRowContextMenu`, `StatusRowActionsView`). This fix follows the established convention.

### Files Changed

- `Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowContentView.swift` — Added `#if !targetEnvironment(macCatalyst)` compile guard around `.fixedSize` on `StatusEmbeddedView` (4 lines added)