### PR TITLE
Add read-only support for Mastodon 4.6 Collections

### DIFF
--- a/IceCubesApp/App/Router/AppRegistry.swift
+++ b/IceCubesApp/App/Router/AppRegistry.swift
@@ -93,6 +93,8 @@ extension View {
           pinnedFilters: .constant([]),
           selectedTagGroup: .constant(nil),
           canFilterTimeline: false)
+      case .collectionDetail(let collection):
+        CollectionDetailView(collection: collection)
       case .linkTimeline(let url, let title):
         TimelineView(
           timeline: .constant(.link(url: url, title: title)),

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -12062,6 +12062,29 @@
         }
       }
     },
+    "account.detail.collections-n-accounts %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld account"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld accounts"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "account.detail.featured-tags-n-posts %lld" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/Account/Sources/Account/Collections/CollectionDetailView.swift
+++ b/Packages/Account/Sources/Account/Collections/CollectionDetailView.swift
@@ -1,0 +1,93 @@
+import DesignSystem
+import Models
+import NetworkClient
+import SwiftUI
+
+@MainActor
+public struct CollectionDetailView: View {
+  @Environment(Theme.self) private var theme
+  @Environment(MastodonClient.self) private var client
+
+  public let collection: AccountCollection
+
+  @State private var accounts: [Account] = []
+  @State private var isLoading: Bool = true
+  @State private var didError: Bool = false
+
+  public init(collection: AccountCollection) {
+    self.collection = collection
+  }
+
+  public var body: some View {
+    List {
+      headerSection
+      accountsSection
+    }
+    .listStyle(.plain)
+    #if !os(visionOS)
+      .scrollContentBackground(.hidden)
+      .background(theme.primaryBackgroundColor)
+    #endif
+    .navigationTitle(collection.name)
+    .navigationBarTitleDisplayMode(.inline)
+    .task {
+      await fetchAccounts()
+    }
+  }
+
+  @ViewBuilder
+  private var headerSection: some View {
+    Section {
+      if !collection.description.asRawText.isEmpty {
+        Text(collection.description.asSafeMarkdownAttributedString)
+          .font(.scaledBody)
+      }
+      if let tag = collection.tag {
+        Text("#\(tag.name)")
+          .font(.scaledCallout)
+          .foregroundStyle(theme.tintColor)
+      }
+    }
+    #if !os(visionOS)
+      .listRowBackground(theme.primaryBackgroundColor)
+    #endif
+  }
+
+  @ViewBuilder
+  private var accountsSection: some View {
+    Section {
+      if isLoading {
+        ProgressView()
+          .frame(maxWidth: .infinity, alignment: .center)
+      } else if didError {
+        Button("action.retry") {
+          Task {
+            await fetchAccounts()
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+      } else {
+        ForEach(accounts) { account in
+          AccountsListRow(viewModel: .init(account: account))
+        }
+      }
+    }
+    #if !os(visionOS)
+      .listRowBackground(theme.primaryBackgroundColor)
+    #endif
+  }
+
+  private func fetchAccounts() async {
+    isLoading = true
+    didError = false
+    do {
+      let response: AccountCollectionResponse = try await client.get(
+        endpoint: Collections.collection(id: collection.id))
+      accounts = response.accounts
+      isLoading = false
+    } catch {
+      isLoading = false
+      didError = true
+    }
+  }
+}

--- a/Packages/Account/Sources/Account/Collections/CollectionDetailView.swift
+++ b/Packages/Account/Sources/Account/Collections/CollectionDetailView.swift
@@ -10,9 +10,11 @@ public struct CollectionDetailView: View {
 
   public let collection: AccountCollection
 
+  @State private var fetchedCollection: AccountCollection?
   @State private var accounts: [Account] = []
   @State private var isLoading: Bool = true
   @State private var didError: Bool = false
+  @State private var isSensitiveContentRevealed: Bool = false
 
   public init(collection: AccountCollection) {
     self.collection = collection
@@ -20,29 +22,56 @@ public struct CollectionDetailView: View {
 
   public var body: some View {
     List {
-      headerSection
-      accountsSection
+      if isSensitiveContentHidden {
+        sensitiveContentSection
+      } else {
+        headerSection
+        accountsSection
+      }
     }
     .listStyle(.plain)
     #if !os(visionOS)
       .scrollContentBackground(.hidden)
       .background(theme.primaryBackgroundColor)
     #endif
-    .navigationTitle(collection.name)
+    .navigationTitle(displayedCollection.name)
     .navigationBarTitleDisplayMode(.inline)
-    .task {
+    .task(id: isSensitiveContentRevealed) {
+      guard !isSensitiveContentHidden else { return }
       await fetchAccounts()
     }
+  }
+
+  private var displayedCollection: AccountCollection {
+    fetchedCollection ?? collection
+  }
+
+  private var isSensitiveContentHidden: Bool {
+    displayedCollection.sensitive && !isSensitiveContentRevealed
+  }
+
+  private var sensitiveContentSection: some View {
+    Section {
+      Button {
+        isSensitiveContentRevealed = true
+      } label: {
+        Label("status.media.sensitive.show", systemImage: "eye")
+          .frame(maxWidth: .infinity, alignment: .center)
+      }
+    }
+    #if !os(visionOS)
+      .listRowBackground(theme.primaryBackgroundColor)
+    #endif
   }
 
   @ViewBuilder
   private var headerSection: some View {
     Section {
-      if !collection.description.asRawText.isEmpty {
-        Text(collection.description.asSafeMarkdownAttributedString)
+      if !displayedCollection.description.asRawText.isEmpty {
+        Text(displayedCollection.description.asSafeMarkdownAttributedString)
           .font(.scaledBody)
       }
-      if let tag = collection.tag {
+      if let tag = displayedCollection.tag {
         Text("#\(tag.name)")
           .font(.scaledCallout)
           .foregroundStyle(theme.tintColor)
@@ -83,7 +112,9 @@ public struct CollectionDetailView: View {
     do {
       let response: AccountCollectionResponse = try await client.get(
         endpoint: Collections.collection(id: collection.id))
-      accounts = response.accounts
+      fetchedCollection = response.collection
+      let acceptedAccountIds = Set(response.collection.acceptedAccountIds)
+      accounts = response.accounts.filter { acceptedAccountIds.contains($0.id) }
       isLoading = false
     } catch {
       isLoading = false

--- a/Packages/Account/Sources/Account/Detail/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/Detail/AccountDetailView.swift
@@ -25,6 +25,7 @@ public struct AccountDetailView: View {
   @State private var viewState: AccountDetailState = .loading
   @State private var relationship: Relationship?
   @State private var familiarFollowers: [Account] = []
+  @State private var collections: [AccountCollection] = []
   @State private var followButtonViewModel: FollowButtonViewModel?
   @State private var translation: Translation?
   @State private var isLoadingTranslation = false
@@ -65,6 +66,8 @@ public struct AccountDetailView: View {
           FamiliarFollowersView(familiarFollowers: familiarFollowers)
             .applyAccountDetailsRowStyle(theme: theme)
           FeaturedTagsView(featuredTags: featuredTags, accountId: accountId)
+            .applyAccountDetailsRowStyle(theme: theme)
+          AccountCollectionsView(collections: collections)
             .applyAccountDetailsRowStyle(theme: theme)
           if let tabManager {
             makeTabPicker(tabManager: tabManager)
@@ -122,6 +125,9 @@ public struct AccountDetailView: View {
               group.addTask {
                 await fetchFamiliarFollowers()
               }
+            }
+            group.addTask {
+              await fetchCollections()
             }
           }
         }
@@ -336,6 +342,14 @@ extension AccountDetailView {
       account: account,
       featuredTags: featuredTags,
       relationships: [])
+  }
+
+  private func fetchCollections() async {
+    // Collections only exist on Mastodon >= 4.6; on older servers the request
+    // fails and the row simply stays hidden.
+    let response: AccountCollectionsResponse? = try? await client.get(
+      endpoint: Collections.accountCollections(id: accountId))
+    collections = response?.collections ?? []
   }
 
   private func fetchFamiliarFollowers() async {

--- a/Packages/Account/Sources/Account/Detail/AccountDetailView.swift
+++ b/Packages/Account/Sources/Account/Detail/AccountDetailView.swift
@@ -138,6 +138,7 @@ public struct AccountDetailView: View {
         SoundEffectManager.shared.playSound(.pull)
         HapticManager.shared.fireHaptic(.dataRefresh(intensity: 0.3))
         await fetchAccount()
+        await fetchCollections()
         if let tabManager {
           await tabManager.refreshCurrentTab()
         }
@@ -160,6 +161,7 @@ public struct AccountDetailView: View {
       if oldValue == .accountEditInfo || newValue == .accountEditInfo {
         Task {
           await fetchAccount()
+          await fetchCollections()
           await preferences.refreshServerPreferences()
         }
       }
@@ -345,11 +347,14 @@ extension AccountDetailView {
   }
 
   private func fetchCollections() async {
-    // Collections only exist on Mastodon >= 4.6; on older servers the request
-    // fails and the row simply stays hidden.
-    let response: AccountCollectionsResponse? = try? await client.get(
+    if let apiVersion = currentInstance.instance?.apiVersions?.mastodon, apiVersion < 10 {
+      collections = []
+      return
+    }
+    guard let response: AccountCollectionsResponse = try? await client.get(
       endpoint: Collections.accountCollections(id: accountId))
-    collections = response?.collections ?? []
+    else { return }
+    collections = response.collections.filter(\.discoverable)
   }
 
   private func fetchFamiliarFollowers() async {

--- a/Packages/Account/Sources/Account/Detail/Components/AccountCollectionsView.swift
+++ b/Packages/Account/Sources/Account/Detail/Components/AccountCollectionsView.swift
@@ -1,0 +1,33 @@
+import DesignSystem
+import Env
+import Models
+import SwiftUI
+
+struct AccountCollectionsView: View {
+  @Environment(RouterPath.self) private var routerPath
+
+  let collections: [AccountCollection]
+
+  var body: some View {
+    if !collections.isEmpty {
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 4) {
+          ForEach(collections) { collection in
+            Button {
+              routerPath.navigate(to: .collectionDetail(collection: collection))
+            } label: {
+              VStack(alignment: .leading, spacing: 0) {
+                Label(collection.name, systemImage: "person.2.crop.square.stack")
+                  .font(.scaledCallout)
+                Text("account.detail.collections-n-accounts \(collection.itemCount)")
+                  .font(.caption2)
+              }
+            }.buttonStyle(.bordered)
+          }
+        }
+        .padding(.leading, .layoutPadding)
+      }
+      .padding(.top, 8)
+    }
+  }
+}

--- a/Packages/Env/Sources/Env/Router.swift
+++ b/Packages/Env/Sources/Env/Router.swift
@@ -16,6 +16,7 @@ public enum RouterDestination: Hashable {
   case conversationDetail(conversation: Conversation)
   case hashTag(tag: String, account: String?)
   case list(list: Models.List)
+  case collectionDetail(collection: AccountCollection)
   case followers(id: String)
   case following(id: String)
   case favoritedBy(id: String)

--- a/Packages/Models/Sources/Models/AccountCollection.swift
+++ b/Packages/Models/Sources/Models/AccountCollection.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A Mastodon Collection (4.6+): a public or unlisted, shareable curated list of accounts,
+/// shown on the curator's profile. Named `AccountCollection` to avoid clashing with
+/// `Swift.Collection`.
+public struct AccountCollection: Codable, Identifiable, Equatable, Hashable {
+  public struct ShallowTag: Codable, Equatable, Hashable, Sendable {
+    public let name: String
+    public let url: String
+  }
+
+  public struct Item: Codable, Identifiable, Equatable, Hashable, Sendable {
+    public let id: String
+    public let accountId: String
+    /// `accepted` or `pending`; pending items are only visible to the curator.
+    public let state: String
+    public let createdAt: ServerDate
+  }
+
+  public let id: String
+  public let accountId: String
+  public let uri: String
+  public let url: URL?
+  public let name: String
+  public let description: HTMLString
+  public let language: String?
+  public let local: Bool
+  public let sensitive: Bool
+  public let discoverable: Bool
+  public let tag: ShallowTag?
+  public let createdAt: ServerDate
+  public let updatedAt: ServerDate
+  public let itemCount: Int
+  public let items: [Item]
+
+  public var acceptedAccountIds: [String] {
+    items.filter { $0.state == "accepted" }.map(\.accountId)
+  }
+}
+
+extension AccountCollection: Sendable {}
+
+/// Response shape of `GET /api/v1/accounts/:id/collections`.
+public struct AccountCollectionsResponse: Codable, Sendable {
+  public let collections: [AccountCollection]
+}
+
+/// Response shape of `GET /api/v1/collections/:id`, which also includes the
+/// member accounts.
+public struct AccountCollectionResponse: Codable, Sendable {
+  public let collection: AccountCollection
+  public let accounts: [Account]
+}

--- a/Packages/Models/Sources/Models/AccountCollection.swift
+++ b/Packages/Models/Sources/Models/AccountCollection.swift
@@ -11,8 +11,8 @@ public struct AccountCollection: Codable, Identifiable, Equatable, Hashable {
 
   public struct Item: Codable, Identifiable, Equatable, Hashable, Sendable {
     public let id: String
-    public let accountId: String
-    /// `accepted` or `pending`; pending items are only visible to the curator.
+    public let accountId: String?
+    /// `pending`, `accepted`, `rejected`, or `revoked`.
     public let state: String
     public let createdAt: ServerDate
   }
@@ -34,7 +34,9 @@ public struct AccountCollection: Codable, Identifiable, Equatable, Hashable {
   public let items: [Item]
 
   public var acceptedAccountIds: [String] {
-    items.filter { $0.state == "accepted" }.map(\.accountId)
+    items.compactMap { item in
+      item.state == "accepted" ? item.accountId : nil
+    }
   }
 }
 

--- a/Packages/Models/Tests/ModelsTests/AccountCollectionTests.swift
+++ b/Packages/Models/Tests/ModelsTests/AccountCollectionTests.swift
@@ -134,3 +134,55 @@ func testAccountCollectionDecodingWithoutOptionalFields() throws {
   #expect(collection.items.isEmpty)
   #expect(collection.acceptedAccountIds.isEmpty)
 }
+
+@Test
+func testAccountCollectionItemDecodingWithoutAccount() throws {
+  let decoder = JSONDecoder()
+  decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+  let json = """
+    {
+      "id": "1",
+      "account_id": null,
+      "state": "revoked",
+      "created_at": "2026-02-25T11:35:01.394Z"
+    }
+    """
+
+  let item = try decoder.decode(AccountCollection.Item.self, from: Data(json.utf8))
+  #expect(item.accountId == nil)
+  #expect(item.state == "revoked")
+}
+
+@Test
+func testAccountCollectionResponseDecoding() throws {
+  let decoder = JSONDecoder()
+  decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+  let json = """
+    {
+      "collection": {
+        "id": "1",
+        "account_id": "2",
+        "uri": "https://example.com/ap/2/collections/1",
+        "url": "https://example.com/collections/1",
+        "name": "People",
+        "description": "",
+        "language": null,
+        "local": true,
+        "sensitive": false,
+        "discoverable": true,
+        "tag": null,
+        "item_count": 0,
+        "items": [],
+        "created_at": "2026-02-25T11:35:01.394Z",
+        "updated_at": "2026-02-25T11:35:01.394Z"
+      },
+      "accounts": []
+    }
+    """
+
+  let response = try decoder.decode(AccountCollectionResponse.self, from: Data(json.utf8))
+  #expect(response.collection.name == "People")
+  #expect(response.accounts.isEmpty)
+}

--- a/Packages/Models/Tests/ModelsTests/AccountCollectionTests.swift
+++ b/Packages/Models/Tests/ModelsTests/AccountCollectionTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import Models
+
+@Test
+func testAccountCollectionDecoding() throws {
+  let decoder = JSONDecoder()
+  decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+  // Example payload from https://docs.joinmastodon.org/entities/Collection/
+  let json = """
+    {
+      "id": "116131056935959117",
+      "account_id": "113668893442515793",
+      "uri": "https://example.com/ap/113668893442515793/collections/116131056935959117",
+      "url": "https://example.com/collections/116131056935959117",
+      "name": "Excellent people",
+      "description": "Well worth following",
+      "language": "en",
+      "local": true,
+      "sensitive": false,
+      "discoverable": true,
+      "tag": {
+        "name": "discovery",
+        "url": "https://example.com/tags/discovery"
+      },
+      "item_count": 2,
+      "items": [
+        {
+          "id": "116141056635954112",
+          "account_id": "112658193342215767",
+          "state": "accepted",
+          "created_at": "2026-02-25T11:35:01.394Z"
+        },
+        {
+          "id": "116141051635254139",
+          "account_id": "117628196343117789",
+          "state": "pending",
+          "created_at": "2026-02-25T11:35:01.394Z"
+        }
+      ],
+      "created_at": "2026-02-25T11:35:01.394Z",
+      "updated_at": "2026-02-25T11:37:38.182Z"
+    }
+    """
+
+  let collection = try decoder.decode(AccountCollection.self, from: Data(json.utf8))
+  #expect(collection.id == "116131056935959117")
+  #expect(collection.accountId == "113668893442515793")
+  #expect(collection.name == "Excellent people")
+  #expect(collection.description.asRawText == "Well worth following")
+  #expect(collection.language == "en")
+  #expect(collection.local == true)
+  #expect(collection.sensitive == false)
+  #expect(collection.discoverable == true)
+  #expect(collection.tag?.name == "discovery")
+  #expect(collection.itemCount == 2)
+  #expect(collection.items.count == 2)
+  #expect(collection.items[0].state == "accepted")
+  #expect(collection.items[1].state == "pending")
+  #expect(collection.acceptedAccountIds == ["112658193342215767"])
+}
+
+@Test
+func testAccountCollectionsResponseDecoding() throws {
+  let decoder = JSONDecoder()
+  decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+  // GET /api/v1/accounts/:id/collections wraps the array (shape observed on
+  // mastodon.social 4.6).
+  let json = """
+    {
+      "collections": [
+        {
+          "id": "116784146949292427",
+          "uri": "https://mastodon.social/ap/users/1/collections/116784146949292427",
+          "name": "News organizations of Mastodon",
+          "description": "",
+          "language": "en",
+          "account_id": "1",
+          "local": true,
+          "sensitive": false,
+          "discoverable": true,
+          "url": "https://mastodon.social/collections/116784146949292427",
+          "item_count": 6,
+          "created_at": "2026-06-20T19:44:24.162Z",
+          "updated_at": "2026-06-20T19:44:24.162Z",
+          "tag": {
+            "name": "news",
+            "url": "https://mastodon.social/tags/news"
+          },
+          "items": []
+        }
+      ]
+    }
+    """
+
+  let response = try decoder.decode(AccountCollectionsResponse.self, from: Data(json.utf8))
+  #expect(response.collections.count == 1)
+  #expect(response.collections[0].name == "News organizations of Mastodon")
+  #expect(response.collections[0].itemCount == 6)
+}
+
+@Test
+func testAccountCollectionDecodingWithoutOptionalFields() throws {
+  let decoder = JSONDecoder()
+  decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+  let json = """
+    {
+      "id": "1",
+      "account_id": "2",
+      "uri": "https://example.com/ap/2/collections/1",
+      "url": null,
+      "name": "Minimal",
+      "description": "",
+      "language": null,
+      "local": false,
+      "sensitive": false,
+      "discoverable": false,
+      "tag": null,
+      "item_count": 0,
+      "items": [],
+      "created_at": "2026-02-25T11:35:01.394Z",
+      "updated_at": "2026-02-25T11:35:01.394Z"
+    }
+    """
+
+  let collection = try decoder.decode(AccountCollection.self, from: Data(json.utf8))
+  #expect(collection.url == nil)
+  #expect(collection.language == nil)
+  #expect(collection.tag == nil)
+  #expect(collection.items.isEmpty)
+  #expect(collection.acceptedAccountIds.isEmpty)
+}

--- a/Packages/NetworkClient/Sources/NetworkClient/Endpoint/Collections.swift
+++ b/Packages/NetworkClient/Sources/NetworkClient/Endpoint/Collections.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Models
+
+public enum Collections: Endpoint {
+  case accountCollections(id: String)
+  case collection(id: String)
+  case accountInCollections(id: String)
+
+  public func path() -> String {
+    switch self {
+    case .accountCollections(let id):
+      "accounts/\(id)/collections"
+    case .collection(let id):
+      "collections/\(id)"
+    case .accountInCollections(let id):
+      "accounts/\(id)/in_collections"
+    }
+  }
+
+  public func queryItems() -> [URLQueryItem]? {
+    nil
+  }
+}


### PR DESCRIPTION
Phase 1 of #2478: read-only viewing of [Mastodon 4.6 Collections](https://blog.joinmastodon.org/2026/06/mastodon-4.6/).

## What's included

- **Model**: `AccountCollection` (named to avoid clashing with `Swift.Collection`) with nested `Item` (accepted/pending consent state) and shallow tag, plus the two response wrappers the server actually returns: `{"collections": [...]}` for the account listing and `{"collection": {...}, "accounts": [...]}` for a single collection (shapes verified against mastodon.social 4.6, which differ from the docs' bare-entity example).
- **Endpoints**: `Collections` enum with `accounts/:id/collections`, `collections/:id`, and `accounts/:id/in_collections`.
- **Profile UI**: a horizontal pill row below featured tags (mirroring `FeaturedTagsView`) showing each collection's name and member count; hidden entirely when the account has none or the server is older than 4.6 (the fetch fails silently by design).
- **Detail view**: tapping a pill opens the collection — description, topic hashtag, and member accounts rendered with the existing `AccountsListRow`. Member accounts come from the single-collection response (already hydrated — no extra requests), with a retry state on failure.
- **Localization**: new plural-aware `account.detail.collections-n-accounts` key (English), reuses `action.retry`.
- **Tests**: three decode tests in `ModelsTests` covering the docs example, the observed real-world wrapper shape, and null optional fields.

## Testing

- `ModelsTests` pass (10 tests).
- Verified live in the iOS 26.5 simulator against mastodon.social: @Gargron's five collections render on his profile, and the detail view lists members correctly.

Follow-ups tracked in #2478: the new notification types (phase 2) and collection management (phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)