### PR TITLE
Accessibility: expose tappable rows, label icon-only controls, honour Reduce Motion

### DIFF
--- a/IceCubesApp/App/Tabs/NotificationTab.swift
+++ b/IceCubesApp/App/Tabs/NotificationTab.swift
@@ -40,6 +40,7 @@ struct NotificationsTab: View {
               Image(systemName: "bell")
             }
             .tint(.label)
+            .accessibilityLabel("settings.push.navigation-title")
           }
           if #available(iOS 26.0, *) {
             ToolbarSpacer(placement: .topBarTrailing)

--- a/IceCubesApp/App/Tabs/Settings/TagsGroupSettingView.swift
+++ b/IceCubesApp/App/Tabs/Settings/TagsGroupSettingView.swift
@@ -15,10 +15,12 @@ struct TagsGroupSettingView: View {
   var body: some View {
     Form {
       ForEach(tagGroups) { group in
-        Label(group.title, systemImage: group.symbolName)
-          .onTapGesture {
-            routerPath.presentedSheet = .editTagGroup(tagGroup: group, onSaved: nil)
-          }
+        Button {
+          routerPath.presentedSheet = .editTagGroup(tagGroup: group, onSaved: nil)
+        } label: {
+          Label(group.title, systemImage: group.symbolName)
+        }
+        .tint(.primary)
       }
       .onDelete { indexes in
         if let index = indexes.first {

--- a/IceCubesApp/Resources/Localization/Localizable.xcstrings
+++ b/IceCubesApp/Resources/Localization/Localizable.xcstrings
@@ -1327,6 +1327,17 @@
         }
       }
     },
+    "accessibility.conversations.send.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send message"
+          }
+        }
+      }
+    },
     "accessibility.editor.button.ai-prompt" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -9054,6 +9065,39 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "accessibility.timeline.pill.move-left" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move left"
+          }
+        }
+      }
+    },
+    "accessibility.timeline.pill.move-right" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move right"
+          }
+        }
+      }
+    },
+    "accessibility.timeline.streaming.label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stream new posts"
           }
         }
       }
@@ -19189,6 +19233,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        }
+      }
+    },
+    "action.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         }
       }

--- a/IceCubesAppWidgetsExtension/AccountWidget/AccountWidgetView.swift
+++ b/IceCubesAppWidgetsExtension/AccountWidget/AccountWidgetView.swift
@@ -18,6 +18,7 @@ struct AccountWidgetView: View {
           .resizable()
           .frame(width: 64, height: 64)
           .clipShape(Circle())
+          .accessibilityHidden(true)
         Text("\(entry.account.followersCount ?? 0)")
           .font(.title)
           .fontDesign(.rounded)
@@ -28,6 +29,7 @@ struct AccountWidgetView: View {
           .foregroundStyle(.secondary)
       }
     }
+    .accessibilityElement(children: .combine)
     .frame(maxWidth: .infinity)
   }
 }

--- a/Packages/Account/Sources/Account/Detail/Tabs/MediaTab.swift
+++ b/Packages/Account/Sources/Account/Detail/Tabs/MediaTab.swift
@@ -88,12 +88,7 @@ private struct MediaTabView: View {
 
   var body: some View {
     Group {
-      HStack {
-        Label("Media Grid", systemImage: "square.grid.2x2")
-        Spacer()
-        Image(systemName: "chevron.right")
-      }
-      .onTapGesture {
+      Button {
         if let account {
           routerPath.navigate(
             to: .accountMediaGridView(
@@ -102,7 +97,15 @@ private struct MediaTabView: View {
             )
           )
         }
+      } label: {
+        HStack {
+          Label("Media Grid", systemImage: "square.grid.2x2")
+          Spacer()
+          Image(systemName: "chevron.right")
+            .accessibilityHidden(true)
+        }
       }
+      .buttonStyle(.plain)
       #if !os(visionOS)
         .listRowBackground(theme.primaryBackgroundColor)
       #endif

--- a/Packages/Account/Sources/Account/Metrics/AccountMetricsView.swift
+++ b/Packages/Account/Sources/Account/Metrics/AccountMetricsView.swift
@@ -76,6 +76,7 @@ public struct AccountMetricsView: View {
             Text("Top posts")
               .font(.headline)
               .foregroundStyle(theme.labelColor)
+              .accessibilityAddTraits(.isHeader)
             if isLoadingTopStatuses && topStatuses.isEmpty {
               VStack(spacing: 8) {
                 ForEach(0..<3, id: \.self) { _ in

--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationInputView.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationInputView.swift
@@ -12,6 +12,7 @@ struct ConversationInputView: View {
   var isSendingMessage: Bool
   var onSendMessage: () async -> Void
   @FocusState.Binding var isMessageFieldFocused: Bool
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   var body: some View {
     inputTextView
@@ -58,6 +59,7 @@ struct ConversationInputView: View {
           Image(systemName: "plus")
         }
       }
+      .accessibilityLabel("status.action.reply")
       .padding(.bottom, 7)
     }
   }
@@ -119,9 +121,10 @@ struct ConversationInputView: View {
             }
           }
         }
+        .accessibilityLabel("accessibility.conversations.send.label")
         .keyboardShortcut(.return, modifiers: .command)
         .padding(.bottom, 6)
-        .animation(.bouncy, value: isSendingMessage)
+        .animation(reduceMotion ? .easeInOut(duration: 0.15) : .bouncy, value: isSendingMessage)
         .transition(.move(edge: .trailing))
       }
     }

--- a/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
+++ b/Packages/Conversations/Sources/Conversations/Detail/ConversationMessageView.swift
@@ -29,10 +29,13 @@ struct ConversationMessageView: View {
         if isOwnMessage {
           Spacer()
         } else {
-          AvatarView(message.account.avatar)
-            .onTapGesture {
-              routerPath.navigate(to: .accountDetailWithAccount(account: message.account))
-            }
+          Button {
+            routerPath.navigate(to: .accountDetailWithAccount(account: message.account))
+          } label: {
+            AvatarView(message.account.avatar)
+          }
+          .buttonStyle(.plain)
+          .accessibilityLabel(message.account.safeDisplayName)
         }
         if #available(iOS 26.0, *) {
           textView

--- a/Packages/Conversations/Sources/Conversations/List/ConversationsListRow.swift
+++ b/Packages/Conversations/Sources/Conversations/List/ConversationsListRow.swift
@@ -109,7 +109,7 @@ struct ConversationsListRow: View {
           #endif
         }
       } label: {
-        Label("Reply", systemImage: "arrowshape.turn.up.left.fill")
+        Label("status.action.reply", systemImage: "arrowshape.turn.up.left.fill")
       }
     }
     .swipeActions(edge: .trailing, allowsFullSwipe: false) {

--- a/Packages/DesignSystem/Sources/DesignSystem/Views/TagChartView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/TagChartView.swift
@@ -25,5 +25,6 @@ public struct TagChartView: View {
     .chartYAxis(.hidden)
     .frame(width: 70, height: 40)
     .clipShape(RoundedRectangle(cornerRadius: 4))
+    .accessibilityHidden(true)
   }
 }

--- a/Packages/DesignSystem/Sources/DesignSystem/Views/ThemePreviewView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/ThemePreviewView.swift
@@ -32,6 +32,28 @@ struct ThemeBoxView: View {
   var color: ColorSet
 
   var body: some View {
+    Button {
+      let currentScheme = theme.selectedScheme
+      if color.scheme != currentScheme {
+        theme.followSystemColorScheme = false
+      }
+      theme.applySet(set: color.name)
+    } label: {
+      boxContent
+    }
+    .buttonStyle(.plain)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(color.name.rawValue)
+    .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    .onAppear {
+      isSelected = theme.selectedSet.rawValue == color.name.rawValue
+    }
+    .onChange(of: theme.selectedSet) { _, newValue in
+      isSelected = newValue.rawValue == color.name.rawValue
+    }
+  }
+
+  private var boxContent: some View {
     ZStack(alignment: .topTrailing) {
       Rectangle()
         .foregroundColor(.white)
@@ -77,19 +99,6 @@ struct ThemeBoxView: View {
       .background(color.secondaryBackgroundColor)
       .font(.system(size: 15))
       .cornerRadius(4)
-    }
-    .onAppear {
-      isSelected = theme.selectedSet.rawValue == color.name.rawValue
-    }
-    .onChange(of: theme.selectedSet) { _, newValue in
-      isSelected = newValue.rawValue == color.name.rawValue
-    }
-    .onTapGesture {
-      let currentScheme = theme.selectedScheme
-      if color.scheme != currentScheme {
-        theme.followSystemColorScheme = false
-      }
-      theme.applySet(set: color.name)
     }
   }
 }

--- a/Packages/DesignSystem/Sources/DesignSystem/Views/ToastOverlayView.swift
+++ b/Packages/DesignSystem/Sources/DesignSystem/Views/ToastOverlayView.swift
@@ -3,28 +3,45 @@ import SwiftUI
 
 public struct ToastOverlayView: View {
   @Environment(ToastCenter.self) private var toastCenter
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   public init() {}
 
   public var body: some View {
     ZStack(alignment: .top) {
       if let toast = toastCenter.toast {
-        ToastView(toast: toast)
-          .padding(.horizontal, .layoutPadding)
-          .padding(.top, 12)
-          .contentShape(Rectangle())
+        toastContent(toast)
           .transition(.move(edge: .top).combined(with: .opacity))
-          .onTapGesture {
-            if let action = toast.action {
-              action.handler()
-            }
-            toastCenter.dismiss(id: toast.id)
-          }
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-    .animation(.bouncy(duration: 0.4), value: toastCenter.toast)
+    .animation(
+      reduceMotion ? .easeInOut(duration: 0.2) : .bouncy(duration: 0.4),
+      value: toastCenter.toast)
     .allowsHitTesting(toastCenter.toast != nil)
+  }
+
+  @ViewBuilder
+  private func toastContent(_ toast: ToastCenter.Toast) -> some View {
+    if toast.action != nil {
+      Button {
+        toast.action?.handler()
+        toastCenter.dismiss(id: toast.id)
+      } label: {
+        ToastView(toast: toast)
+          .padding(.horizontal, .layoutPadding)
+          .padding(.top, 12)
+      }
+      .buttonStyle(.plain)
+    } else {
+      ToastView(toast: toast)
+        .padding(.horizontal, .layoutPadding)
+        .padding(.top, 12)
+        .contentShape(Rectangle())
+        .onTapGesture {
+          toastCenter.dismiss(id: toast.id)
+        }
+    }
   }
 }
 

--- a/Packages/MediaUI/Sources/MediaUI/MediaUIAttachmentImageView.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIAttachmentImageView.swift
@@ -4,8 +4,21 @@ import SwiftUI
 
 public struct MediaUIAttachmentImageView: View {
   public let url: URL
+  public let description: String?
 
   @GestureState private var zoom = 1.0
+
+  private var accessibilityLabel: Text {
+    if let description, !description.isEmpty {
+      return Text(description)
+    }
+    return Text("accessibility.media.supported-type.image.label")
+  }
+
+  public init(url: URL, description: String? = nil) {
+    self.url = url
+    self.description = description
+  }
 
   public var body: some View {
     MediaUIZoomableContainer {
@@ -19,6 +32,7 @@ public struct MediaUIAttachmentImageView: View {
             .padding(.top, 44)
             .padding(.bottom, 32)
             .scaleEffect(zoom)
+            .accessibilityLabel(accessibilityLabel)
         } else if state.isLoading {
           ProgressView()
             .progressViewStyle(.circular)

--- a/Packages/MediaUI/Sources/MediaUI/MediaUIView.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIView.swift
@@ -102,6 +102,7 @@ private struct DismissToolbarItem: ToolbarContent {
       } label: {
         Image(systemName: "xmark")
       }
+      .accessibilityLabel("action.close")
       .keyboardShortcut(.cancelAction)
     }
   }
@@ -231,7 +232,7 @@ private struct DisplayView: View {
   var body: some View {
     switch data.type {
     case .image:
-      MediaUIAttachmentImageView(url: data.url)
+      MediaUIAttachmentImageView(url: data.url, description: data.description)
     case .av:
       MediaUIAttachmentVideoView(viewModel: .init(url: data.url, forceAutoPlay: true))
         .ignoresSafeArea()

--- a/Packages/Notifications/Sources/Notifications/List/NotificationsHeaderFilteredView.swift
+++ b/Packages/Notifications/Sources/Notifications/List/NotificationsHeaderFilteredView.swift
@@ -11,24 +11,27 @@ struct NotificationsHeaderFilteredView: View {
 
   var body: some View {
     if filteredNotifications.pendingNotificationsCount > 0 {
-      HStack {
-        Label("notifications.content-filter.requests.title", systemImage: "archivebox")
-          .foregroundStyle(.secondary)
-        Spacer()
-        Text("\(filteredNotifications.pendingNotificationsCount)")
-          .font(.footnote)
-          .fontWeight(.semibold)
-          .monospacedDigit()
-          .foregroundStyle(theme.primaryBackgroundColor)
-          .padding(8)
-          .background(.secondary)
-          .clipShape(Circle())
-        Image(systemName: "chevron.right")
-          .foregroundStyle(.secondary)
-      }
-      .onTapGesture {
+      Button {
         routerPath.navigate(to: .notificationsRequests)
+      } label: {
+        HStack {
+          Label("notifications.content-filter.requests.title", systemImage: "archivebox")
+            .foregroundStyle(.secondary)
+          Spacer()
+          Text("\(filteredNotifications.pendingNotificationsCount)")
+            .font(.footnote)
+            .fontWeight(.semibold)
+            .monospacedDigit()
+            .foregroundStyle(theme.primaryBackgroundColor)
+            .padding(8)
+            .background(.secondary)
+            .clipShape(Circle())
+          Image(systemName: "chevron.right")
+            .foregroundStyle(.secondary)
+            .accessibilityHidden(true)
+        }
       }
+      .buttonStyle(.plain)
       .listRowBackground(theme.secondaryBackgroundColor)
       .listRowInsets(
         .init(

--- a/Packages/Notifications/Sources/Notifications/List/NotificationsListView.swift
+++ b/Packages/Notifications/Sources/Notifications/List/NotificationsListView.swift
@@ -101,7 +101,7 @@ public struct NotificationsListView: View {
           Button {
             routerPath.navigate(to: .conversations)
           } label: {
-            Label("Direct Messages", systemImage: "message")
+            Label("conversations.navigation-title", systemImage: "message")
           }
           .tint(theme.labelColor)
         }

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusActionButton.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusActionButton.swift
@@ -101,7 +101,7 @@ struct StatusActionButton: View {
         .font(.scaledBody)
       #else
         .font(.body)
-        .dynamicTypeSize(.large)
+        .dynamicTypeSize(...DynamicTypeSize.accessibility3)
       #endif
   }
 
@@ -123,7 +123,7 @@ struct StatusActionButton: View {
         .font(.scaledFootnote)
       #else
         .font(.footnote)
-        .dynamicTypeSize(.medium)
+        .dynamicTypeSize(...DynamicTypeSize.accessibility2)
       #endif
       .monospacedDigit()
       .opacity(count > 0 ? 1 : 0)

--- a/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowMediaPreviewView.swift
+++ b/Packages/StatusKit/Sources/StatusKit/Row/Subviews/StatusRowMediaPreviewView.swift
@@ -186,6 +186,7 @@ struct BlurOverLay: View {
   @Environment(\.isInCaptureMode) private var isInCaptureMode: Bool
   @Environment(UserPreferences.self) private var preferences
   @Environment(\.isMediaCompact) private var isCompact: Bool
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   @Namespace var buttonSpace
 
@@ -201,7 +202,7 @@ struct BlurOverLay: View {
           )
         if !isCompact {
           Button {
-            withAnimation(.spring) {
+            withAnimation(reduceMotion ? nil : .spring) {
               isFrameExpanded.toggle()
             }
           } label: {

--- a/Packages/Timeline/Sources/Timeline/View/TimelineQuickAccessPills.swift
+++ b/Packages/Timeline/Sources/Timeline/View/TimelineQuickAccessPills.swift
@@ -14,6 +14,7 @@ public struct TimelineQuickAccessPills: View {
   @Binding var timeline: TimelineFilter
 
   @State private var draggedFilter: TimelineFilter?
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   public init(pinnedFilters: Binding<[TimelineFilter]>, timeline: Binding<TimelineFilter>) {
     _pinnedFilters = pinnedFilters
@@ -101,11 +102,44 @@ public struct TimelineQuickAccessPills: View {
       delegate: PillDropDelegate(
         destinationItem: filter,
         items: $pinnedFilters,
-        draggedItem: $draggedFilter)
+        draggedItem: $draggedFilter,
+        reduceMotion: reduceMotion)
     )
     .buttonBorderShape(.capsule)
     .controlSize(.mini)
+    .accessibilityActions {
+      let visible = pinnedFilters.filter(isFilterSupported)
+      if let index = visible.firstIndex(of: filter) {
+        if index > 0 {
+          Button("accessibility.timeline.pill.move-left") { movePill(filter, by: -1) }
+        }
+        if index < visible.count - 1 {
+          Button("accessibility.timeline.pill.move-right") { movePill(filter, by: 1) }
+        }
+      }
+    }
+  }
 
+  private func movePill(_ filter: TimelineFilter, by offset: Int) {
+    guard let from = pinnedFilters.firstIndex(of: filter) else { return }
+    // Hidden pills (unsupported list filters) still occupy slots in
+    // pinnedFilters, so step past them to the next visible neighbour.
+    let stride = offset < 0 ? -1 : 1
+    var to = from + stride
+    while pinnedFilters.indices.contains(to), !isFilterSupported(pinnedFilters[to]) {
+      to += stride
+    }
+    guard pinnedFilters.indices.contains(to) else { return }
+    let perform = {
+      pinnedFilters.move(
+        fromOffsets: IndexSet(integer: from),
+        toOffset: to > from ? to + 1 : to)
+    }
+    if reduceMotion {
+      perform()
+    } else {
+      withAnimation { perform() }
+    }
   }
 
   private func isFilterSupported(_ filter: TimelineFilter) -> Bool {
@@ -122,6 +156,7 @@ struct PillDropDelegate: DropDelegate {
   let destinationItem: TimelineFilter
   @Binding var items: [TimelineFilter]
   @Binding var draggedItem: TimelineFilter?
+  let reduceMotion: Bool
 
   func dropUpdated(info _: DropInfo) -> DropProposal? {
     return DropProposal(operation: .move)
@@ -138,10 +173,15 @@ struct PillDropDelegate: DropDelegate {
       if let fromIndex {
         let toIndex = items.firstIndex(of: destinationItem)
         if let toIndex, fromIndex != toIndex {
-          withAnimation {
+          let move = {
             self.items.move(
               fromOffsets: IndexSet(integer: fromIndex),
               toOffset: toIndex > fromIndex ? (toIndex + 1) : toIndex)
+          }
+          if reduceMotion {
+            move()
+          } else {
+            withAnimation { move() }
           }
         }
       }

--- a/Packages/Timeline/Sources/Timeline/View/TimelineToolbarTagGroupButton.swift
+++ b/Packages/Timeline/Sources/Timeline/View/TimelineToolbarTagGroupButton.swift
@@ -34,6 +34,7 @@ struct TimelineToolbarTagGroupButton: ToolbarContent {
           } label: {
             Image(systemName: "ellipsis")
               .foregroundStyle(theme.labelColor)
+              .accessibilityLabel("tag-groups.edit.section.title")
           }
         }
       default:

--- a/Packages/Timeline/Sources/Timeline/View/TimelineView.swift
+++ b/Packages/Timeline/Sources/Timeline/View/TimelineView.swift
@@ -106,6 +106,10 @@ public struct TimelineView: View {
                 ? "antenna.radiowaves.left.and.right" : "antenna.radiowaves.left.and.right.slash")
           }
           .tint(theme.labelColor)
+          .accessibilityLabel("accessibility.timeline.streaming.label")
+          .accessibilityValue(
+            viewModel.isStreamingTimeline
+              ? "accessibility.general.toggle.on" : "accessibility.general.toggle.off")
         }
       }
       TimelineToolbarTagGroupButton(timeline: $timeline)


### PR DESCRIPTION
Closes #2486.

Improves VoiceOver, Dynamic Type, and Reduce Motion support across Timeline, Notifications, Conversations, MediaUI, DesignSystem, StatusKit, and Account. Commits are split by package for review.

## VoiceOver

- Convert `onTapGesture` handlers on non-interactive containers to `Button`, so the rows are exposed as actionable and reachable via Switch Control / Full Keyboard Access: theme picker swatches, account media tab, notification requests header, conversation avatars, tag group settings rows.
- Add rotor actions to reorder timeline quick-access pills, which were previously drag-only. Actions are computed over the visible pills, so hidden entries (list filters whose list hasn't loaded) are stepped over rather than swapped into.
- Plumb attachment alt text into the fullscreen media viewer, falling back to the existing `accessibility.media.supported-type.image.label` when an attachment has no description.
- Label the streaming toggle, media viewer dismiss button, message send button, push-notification settings button, and tag group toolbar button.
- Mark the "Top posts" metrics heading with `.isHeader`.
- Hide decorative chevrons and the tag sparkline from the accessibility tree.

## Dynamic Type

- `StatusActionButton` previously pinned its icon and count to fixed `.large` / `.medium` sizes, ignoring Dynamic Type entirely. They now scale up to `accessibility3` / `accessibility2`, preserving the existing icon-larger-than-count relationship.

## Reduce Motion

- Honour `accessibilityReduceMotion` in the toast overlay, message send transition, media blur overlay, and pill reordering (including the drag path, via the environment value rather than a UIKit global).

## Localization

- Adds five keys (`accessibility.conversations.send.label`, the two timeline pill rotor actions, `accessibility.timeline.streaming.label`, `action.close`). Additions only — no existing entries modified, reordered, or reformatted.
- Replaces two hardcoded English labels with existing localized keys (`status.action.reply`, `conversations.navigation-title`).

## Notes for review

- `MediaUIAttachmentImageView` gains a `description` parameter. It defaults to `nil`, so existing callers are source-compatible, but it is a public initializer in a package.
- Builds clean on iOS 27 / Xcode 27.0 with no new warnings.
- SwiftFormat: this branch adds no violations beyond the existing baseline for the files it touches, under the repo's `.swiftformat`.
- Verified with VoiceOver on device.

---

This work is part of [Access100](https://access100.day/en), a volunteer initiative to make 100 apps accessible by 3 December 2026. Disclosure: I'm involved with Binclusive, who started the initiative. Happy to drop this note if you'd rather the PR stayed purely technical.
