### PR TITLE
Fix custom server emojis displaying as raw shortcodes in headers

### DIFF
--- a/IceCubesApp/App/Tabs/Settings/AccountSettingView.swift
+++ b/IceCubesApp/App/Tabs/Settings/AccountSettingView.swift
@@ -1,6 +1,7 @@
 import Account
 import AppAccount
 import DesignSystem
+import EmojiText
 import Env
 import Models
 import NetworkClient
@@ -107,7 +108,7 @@ struct AccountSettingsView: View {
       ToolbarItem(placement: .principal) {
         HStack {
           AvatarView(account.avatar, config: .embed)
-          Text(account.safeDisplayName)
+          EmojiTextApp(.init(stringValue: account.safeDisplayName), emojis: account.emojis)
             .font(.headline)
         }
       }

--- a/Packages/Account/Sources/Account/Detail/Components/AccountDetailToolbar.swift
+++ b/Packages/Account/Sources/Account/Detail/Components/AccountDetailToolbar.swift
@@ -1,4 +1,5 @@
 import DesignSystem
+import EmojiText
 import Env
 import Models
 import NetworkClient
@@ -25,7 +26,8 @@ struct AccountDetailToolbar: ToolbarContent {
     ToolbarItem(placement: .principal) {
       if let account = account, displayTitle {
         VStack {
-          Text(account.displayName ?? "").font(.headline)
+          EmojiTextApp(.init(stringValue: account.safeDisplayName), emojis: account.emojis)
+            .font(.headline)
           Text("account.detail.featured-tags-n-posts \(account.statusesCount ?? 0)")
             .font(.footnote)
             .foregroundStyle(.secondary)

--- a/Packages/Account/Sources/Account/Detail/MediaGrid/AccountDetailMediaGridView.swift
+++ b/Packages/Account/Sources/Account/Detail/MediaGrid/AccountDetailMediaGridView.swift
@@ -1,4 +1,5 @@
 import DesignSystem
+import EmojiText
 import Env
 import MediaUI
 import Models
@@ -100,7 +101,13 @@ public struct AccountDetailMediaGridView: View {
         }
       }
     }
-    .navigationTitle(account.displayName ?? "")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .principal) {
+        EmojiTextApp(.init(stringValue: account.safeDisplayName), emojis: account.emojis)
+          .font(.headline)
+      }
+    }
     #if !os(visionOS)
       .scrollContentBackground(.hidden)
       .background(theme.primaryBackgroundColor)


### PR DESCRIPTION
This PR fixes a long-standing visual bug where custom server emojis embedded in an account's display name would render as raw shortcode strings (e.g., `:blobcat:`) in the navigation bar when viewing user profiles and within Settings. 
    
### Details
The standard SwiftUI `.navigationTitle(_:)` modifier only accepts plain `Text` or `String` primitives, which inherently lacks the ability to asynchronously download or parse custom remote emojis. 
    
To resolve this:
1. Removed `.navigationTitle` from `AccountDetailMediaGridView.swift`.
2. Replaced it with a `.toolbar` item injected directly into the `.principal` placement (the center of the navigation bar).
3. Swapped the raw strings out for the `EmojiTextApp` component, allowing the header to seamlessly fetch and render custom emojis exactly as they appear in the timeline.
    
We then applied this consistent `ToolbarItem(placement: .principal)` structure across `AccountDetailMediaGridView`, `AccountDetailToolbar`, and `AccountSettingView`.
    
### Testing
Tested on iOS 26.5.2. Profiles with custom server emojis in their display names now render correctly at the top of the screen instead of showing raw text.

<img width="585" height="1266" alt="IMG_1737" src="https://github.com/user-attachments/assets/924be6f9-b214-40c5-9688-51834e5dfc69" />