### PR TITLE
 Fix fatal Swift 6.3.1 compiler crash in MediaUIZoomableContainer

### DIFF
--- a/Packages/MediaUI/Sources/MediaUI/MediaUIZoomableContainer.swift
+++ b/Packages/MediaUI/Sources/MediaUI/MediaUIZoomableContainer.swift
@@ -102,6 +102,9 @@ struct MediaUIZoomableContainer<Content: View>: View {
         _currentScale = scale
       }
 
+      deinit {
+      }
+
       func viewForZooming(in _: UIScrollView) -> UIView? {
         hostingController.view
       }


### PR DESCRIPTION
This fixes a fatal Swift compiler crash (Exit Code 65) that occurs when compiling the MediaUI package on newer Xcode versions.

The Swift 6.3.1 compiler was completely segfaulting during its SIL optimization pass because it was failing to properly synthesize the implicit deinit block for the Coordinator class.

Explicitly adding an empty deinit { } block cleanly bypasses the compiler bug and allowed the project to build successfully.